### PR TITLE
49-LokeshChandraSkt: fix "rgu ba"

### DIFF
--- a/_input/dictionaries/public/49-LokeshChandraSkt
+++ b/_input/dictionaries/public/49-LokeshChandraSkt
@@ -7446,7 +7446,7 @@ rgas byed|jarāhita
 rgas byed ma|jarāhiṇī
 rgas med|nirjara
 rgas shi|jarāmaraṇa
-rgu ba|prābhāra
+rgu ba|prāgbhāra
 rgu bo|śūrpaka
 rgud|alakṣmī 2) vipatti
 rgud pa|1) āpadā 2) vipārtta 3) viplava 4) vivartate 5) vyasana 6) vyāpat


### PR DESCRIPTION
Should be "prāgbhāra" and the "g" is missing.  Compare with Negi.  The scan at the archive.org has rather bad print quality in this particular place, but I think you can see that ga in the sandhi if you squint just right.

https://archive.org/details/dictionarytibetansanskritdictionarylokeshchandra_78_F/page/n511/mode/2up

Probably needs fixing in the source file too, but I'm not sure how to do that properly.