### PR TITLE
[fix] handling of tibetan unicode characters in activeTerm URL

### DIFF
--- a/webapp/code/js/dict/main.js
+++ b/webapp/code/js/dict/main.js
@@ -368,8 +368,9 @@ var DICT={
   },
 
   uniToWylie:function(text) {
-    if(this.useUnicodeTibetan) {
-      result = "";
+    if(!text) return text;
+    if(this.useUnicodeTibetan || /[\u0F00-\u0FFF]/.test(text)) {
+      var result = "";
       var tokenizer = new jQuery.tokenizer( this.UNICODE_SEPARATORLIST,
         function( syllable, isSeparator ) {
           result += DICT.uniSyllableToWylieSyllable(syllable);
@@ -1153,6 +1154,13 @@ var DICT={
           return;
         
         var stateInfo = JSON.parse(state);
+
+        if (stateInfo.activeTerm && /[\u0F00-\u0FFF]/.test(stateInfo.activeTerm)) {
+          stateInfo.activeTerm = DICT.uniToWylie(stateInfo.activeTerm);
+        }
+        if (stateInfo.currentListTerm && /[\u0F00-\u0FFF]/.test(stateInfo.currentListTerm)) {
+          stateInfo.currentListTerm = DICT.uniToWylie(stateInfo.currentListTerm);
+        }
 
         if(stateInfo.lang)
             DICT.lang = stateInfo.lang;


### PR DESCRIPTION
This PR fixes a bug in the application's URL state handling where dictionary links containing Tibetan Unicode fail to load the requested definitions. Because the local database queries rely exclusively on Wylie transliteration indices, passing raw Unicode directly through the URL router doesn't work properly. This fix patches the application's deserialization logic (setState) to automatically map activeTerm and currentListTerm values through the internal Unicode-to-Wylie converter if Tibetan characters (/[\u0F00-\u0FFF]/) are detected, ensuring direct dictionary links load successfully regardless of the input script.

The goal of this PR is to allow easier integration into third party software without them having to "know" wylie.

Testing URLs
1. Currently behaving as expected (Wylie): URL with Wylie transliteration (will load the term definitions normally on the live site): [https://dictionary.christian-steinert.de/#{"activeTerm":"'di skad bdag gis thos pa dus gcig na"}]

2. Should behave as expected after PR (Tibetan Unicode): URL with Tibetan Unicode (currently fails on the live site, but will correctly convert and load the Wylie result after this PR): https://dictionary.christian-steinert.de/#{"activeTerm":"འདི་སྐད་བདག་གིས་ཐོས་པ་དུས་གཅིག་ན"}