### PR TITLE
feat: Handle network loading and error states in ResultList

### DIFF
--- a/webapp/src/components/SearchLayout/ResultList.test.tsx
+++ b/webapp/src/components/SearchLayout/ResultList.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import ResultList from './ResultList';
+import searchReducer, { setResultListState } from '@/store/searchSlice';
+import settingsReducer from '@/store/settingsSlice';
+
+function renderResultList(initialSearchState: any = {}) {
+  const store = configureStore({
+    reducer: {
+      search: searchReducer,
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      search: {
+        input: { mode: 'term', extendedSettingsVisible: false, inputLang: 'tib' },
+        resultList: {
+          sidebarVisible: true,
+          query: 'test',
+          lang: 'tib',
+          offset: 0,
+          results: [],
+          isSearching: false,
+          error: null,
+          ...initialSearchState
+        },
+        ftsResultList: { query: '', lang: 'tib', offset: 0, results: [], isSearching: false, error: null },
+        definition: { term: '', html: '', inlineSections: {}, isLoading: false, isDefinitionOnly: false, error: null }
+      },
+      settings: {
+        unicode: false,
+        lowercase: true,
+        listSize: 10,
+        layout: 'layout_white',
+        activeDictionaries: [],
+        inactiveDictionaries: [],
+      }
+    }
+  });
+
+  return render(
+    <Provider store={store}>
+      <ResultList
+        onTermSelected={vi.fn()}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        selectedTerm={null}
+      />
+    </Provider>
+  );
+}
+
+describe('ResultList Component', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders "Searching..." when isSearching is true', () => {
+    renderResultList({ isSearching: true, results: [] });
+    expect(screen.getByText('Searching...')).toBeInTheDocument();
+  });
+
+  it('renders network error message when error is present', () => {
+    renderResultList({ error: 'Failed to fetch', isSearching: false });
+    expect(screen.getByText('Network error: Failed to fetch')).toBeInTheDocument();
+  });
+
+  it('renders "No results found." when not loading, no error, and results are empty', () => {
+    renderResultList({ isSearching: false, error: null, results: [] });
+    expect(screen.getByText('No results found.')).toBeInTheDocument();
+  });
+
+  it('renders results correctly when results are present', () => {
+    renderResultList({
+      isSearching: false,
+      error: null,
+      results: [{ term: 'sangs rgyas' }, { term: 'chos' }]
+    });
+    
+    // ResultItem components render their content
+    expect(screen.getByText('sangs rgyas')).toBeInTheDocument();
+    expect(screen.getByText('chos')).toBeInTheDocument();
+    
+    // "No results found." should not be in document
+    expect(screen.queryByText('No results found.')).not.toBeInTheDocument();
+  });
+});

--- a/webapp/src/components/SearchLayout/ResultList.tsx
+++ b/webapp/src/components/SearchLayout/ResultList.tsx
@@ -44,13 +44,11 @@ export default function ResultList({ onTermSelected, onPrev, onNext, selectedTer
     return (
       <div className="leftSideBar">
         <div className="sideBarInnerWrap">
-          <div className="paginate_info text-red-600 font-bold p-4">Network error: {error}</div>
+          <div className="paginate_info !text-red-600 font-bold p-4">Network error: {error}</div>
         </div>
       </div>
     );
-  }
-
-  if (isSearching) {
+  } else if (isSearching) {
     return (
       <div className="leftSideBar">
         <div className="sideBarInnerWrap">
@@ -58,9 +56,7 @@ export default function ResultList({ onTermSelected, onPrev, onNext, selectedTer
         </div>
       </div>
     );
-  }
-
-  if (!hasResults) {
+  } else if (!hasResults) {
     return (
       <div className="leftSideBar">
         <div className="sideBarInnerWrap">

--- a/webapp/src/components/SearchLayout/ResultList.tsx
+++ b/webapp/src/components/SearchLayout/ResultList.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export default function ResultList({ onTermSelected, onPrev, onNext, selectedTerm }: Props) {
-  const { results, offset, lang: resultsLang, query } = useSelector((s: RootState) => s.search.resultList);
+  const { results, offset, lang: resultsLang, query, isSearching, error } = useSelector((s: RootState) => s.search.resultList);
   const { unicode, listSize } = useSelector((s: RootState) => s.settings);
   const { term: activeTerm } = useSelector((s: RootState) => s.search.definition);
   const useUnicodeTibetan = (unicode !== false);
@@ -40,11 +40,31 @@ export default function ResultList({ onTermSelected, onPrev, onNext, selectedTer
   const visibleResults = results.slice(0, listSize);
   const hasResults = results.length > 0;
 
+  if (error) {
+    return (
+      <div className="leftSideBar">
+        <div className="sideBarInnerWrap">
+          <div className="paginate_info text-red-600 font-bold p-4">Network error: {error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isSearching) {
+    return (
+      <div className="leftSideBar">
+        <div className="sideBarInnerWrap">
+          <div className="paginate_info p-4">Searching...</div>
+        </div>
+      </div>
+    );
+  }
+
   if (!hasResults) {
     return (
       <div className="leftSideBar">
         <div className="sideBarInnerWrap">
-          <div className="paginate_info">No results found.</div>
+          <div className="paginate_info p-4">No results found.</div>
         </div>
       </div>
     );


### PR DESCRIPTION
**Problem** Previously, when a user had a slow or failed network connection, the dictionary sidebar would incorrectly default to displaying "No results found." This made it impossible to distinguish between a genuinely missing word and a request that was still loading or had failed, which severely degraded the UX in low-connectivity areas.

**Solution** This PR fixes the issue by introducing proper UI states in the dictionary sidebar that accurately reflect the current state of the network request.

- Updated ResultList.tsx to consume the isSearching and error states from the Redux searchSlice.
- When a request is pending, the sidebar now explicitly displays "Searching..."
- When a request fails (e.g. PHP backend throws an error or the network drops), it now explicitly displays "Network error: [error details]"
- "No results found." is now strictly reserved for queries that definitively succeed but return an empty array.

## Testing

- Added a comprehensive component test suite (ResultList.test.tsx) utilizing Vitest and React Testing Library.
- Tests verify the component appropriately transitions between loading, error, empty, and populated states using a mock Redux store.
- All tests pass successfully locally.