### PR TITLE
Ives Waldo: "la med la" is a "pass" ("la zhig")

### DIFF
--- a/_input/dictionaries/public/08-IvesWaldo
+++ b/_input/dictionaries/public/08-IvesWaldo
@@ -53910,7 +53910,7 @@ la rdzas rdo phung|rock cairn below/ at summit of a high pass
 la stod byang|N Loto
 la stod lho|S Loto
 la stod tsho bzhir|in the four parts of Loto
-la med la|{la med pass}
+la med la|{la med} pass
 la li ta|Lalita
 la la na|[Skt] rkyang ma nadi
 la la phud|med. herb {la la phud}


### PR DESCRIPTION
Fix misplaced curly.  See this entry in tib.-tib. dictionaries.