### PR TITLE
tshig mdzod chen mo: fix ga-bzhag and split entries

### DIFF
--- a/_input/dictionaries/public/25-tshig-mdzod-chen-mo-Tib
+++ b/_input/dictionaries/public/25-tshig-mdzod-chen-mo-Tib
@@ -38,7 +38,7 @@ ka dag|1) {stong pa nyid/} 2) {ka nas dag pa ste thog ma nyid nas dri ma med pa/
 ka dag khregs chod|{gsang sngags rdzogs pa chen po'i nyams len gyi gnad/ le lo can 'bad med du grol ba'i gdams pa ste/ gzhi gnas rang byung gi ye shes de grol lugs chen po bzhi'i ngang du gnas pa nyid ngo rang thog tu 'phrod/ thag chig thog tu chod/ gding grol thog tu bca' ba bcas kyis chos nyid ka dag ma bcos gnyug ma'i don la ye bab sor bzhag gi ngang skyong ba'o/}
 ka dam pa|{(legs)} 1) {shing tshogs can/} 2) {chu bya mthing ril lam chu skyar/}
 ka dam pa can|{(mngon) sprin pa/}
-ka dam pa bde gshegs|{mtshan dngos shes rab seng ge'am/ spobs pa mtha' yas kyang zer/ rab byung gnyis pa'i chu stag la mdo khams su 'khrungs/ rab byung gsum pa'i sa yos la khams dpal yul du ka: thog dgon pa btab/ chu byi la 'das pa'i sngags rnying ma'i slob dpon zhig}
+ka dam pa bde gshegs|{mtshan dngos shes rab seng ge'am/ spobs pa mtha' yas kyang zer/ rab byung gnyis pa'i chu stag la mdo khams su 'khrungs/ rab byung gsum pa'i sa yos la khams dpal yul du kaHthog dgon pa btab/ chu byi la 'das pa'i sngags rnying ma'i slob dpon zhig}
 ka dam bha ra|{(legs) sngo sman rigs shig}
 ka dar|{rten 'brel byed skabs ka ba la sgrog pa'i kha btags/}
 ka sde|1) {bod yig gsal byed kyi sde pa dang po ste/ ka kha ga nga/ ka kha ga nga ?} 2) {legs sbyar gsal byed kyi sde pa dang po ste/ ka kha ga gha nga/ ka kha ga gha nga ?}
@@ -68,7 +68,7 @@ ka ma la shI la|{padma'i ngang tshul te dus rabs brgyad par rgya gar shar phyogs
 ka mang ma|{ka ba mang po yod pa'i khang pa/}
 ka mad|{bod yig gsal byed ka la sogs pa/ ka mad sum cu/}
 ka mi yam|{(legs) mtsher pa/}
-ka mig bod lugs khang pa che chung brtsi stangs ka ba gcig gi sa'i rgya khyon|{khang pa ka mig gsum gyi sa yod/}
+ka mig|{bod lugs khang pa che chung brtsi stangs ka ba gcig gi sa'i rgya khyon/ khang pa ka mig gsum gyi sa yod/}
 ka med|{thabs shes med pa/ mi byed ka med red snyan gtser phran bu mi zhu ka med byung/}
 ka rtsom|{tshig rkang re re'i thog mtha' bar gsum gang rung du ka sogs gsal byed rim par bsgrigs pa'i rtsom tshig}
 ka gzhu|{ka ba dang gzhu/}
@@ -94,7 +94,7 @@ ka sha|1) {sha mo'i bye brag cig} 2) {(legs) gsal byed zer ba'i 'dam rtswa zhig}
 ka shu ka|{(legs) gser spus legs nyes rtog byed rdo nag po zhig}
 ka shubs|{gos chen sogs las bzos pa'i ka ba'i shubs/}
 ka bshad|{tshig rkang re re'i thog mtha' bar gsum gang rung du ka sogs gsal byed rim par bkod pa'i rtsom yig}
-ka thog dgon|{si khron zhing chen gyi dkar mdzes bod rigs rang skyong khul dpal yul rdzong khongs kyi dgon pa zhig ste dus rabs bcu gnyis par phag mo gru pa'i gcung po ka dam pa bde gshegs kyis btab pa/}
+kaHthog dgon|{si khron zhing chen gyi dkar mdzes bod rigs rang skyong khul dpal yul rdzong khongs kyi dgon pa zhig ste dus rabs bcu gnyis par phag mo gru pa'i gcung po ka dam pa bde gshegs kyis btab pa/}
 kA ka ru|{(legs) sdig srin/}
 kA ko la|{(legs)} 1) {bya rog chen po/} 2) {dug kA ko la ste btsan dug}
 kA tyA ya na|{ka tya'i bu dang 'dra/}
@@ -106,15 +106,15 @@ kag|1) {dus nges can gyi bar chad kyi don du go ba'i skag dang 'dra/}2) {(rnying
 kang ka|{(legs) mgo nag la rgyab dkar ba'i dur bya zhig}
 kang ka'i mchu|{(legs) sha rngams mthug po'i gting du yod pa'i rus pa chag pa rnams 'don byed kyi skam pa zhig}
 kat+pU ra|{(legs) lus rgyas sam rab bsil te ga bur gyi ming gzhan zhig}
-tarti ka|{(legs) hor zla bcu pa/}
+kar+ti ka|{(legs) hor zla bcu pa/}
 kan|1) {(rgya) lag rtsa 'phar stangs lta skabs sman pa'i gung mdzub kyis nad pa'i mkhrig ma gnon sa'i rtsa ming/} 2) {lag pa'i gung mo'am gung mdzub/} 3) {(yul) pha rol ston pa'i spyi sgra zhig ri 'go kan la dar dmar tshugs/}
 kan khrang|{(rgya) rgya thug dang/ bod thug man chi'i sogs sgril byed kyi rgyug hril/}
 kan tur|{(rgya) gzugs po gan bub bam mgo rting slog pa'i lus rtsal/ kan tur slog pa/}
 kan rtsa|{(rgya) gung mdzub 'og gi rtsa/}
 kan tshal|{(rgya) sngo tshal skam po dang/ mtsho nas thon pa'i sha tshal skam po'i spyi ming/}
 kan 'og|{(rgya) gung mdzub 'og gi rtsa/}
-kan g.yas 'og nad pa'i lag pa|{g.yas pa'i kan rtsar don lnga'i nang gi mtsher pa/snod drug nang gi pho ba'i rtsa yod/}
-kan g.yon 'og nad pa'i lag pa|{g.yon pa'i kan rtsar don lnga'i mchin pa dang/snod drug gi mkhris pa'i rtsa gnyis yod/}
+kan g.yas 'og|{nad pa'i lag pa g.yas pa'i kan rtsar don lnga'i nang gi mtsher pa/snod drug nang gi pho ba'i rtsa yod/}
+kan g.yon 'og|{nad pa'i lag pa g.yon pa'i kan rtsar don lnga'i mchin pa dang/snod drug gi mkhris pa'i rtsa gnyis yod/}
 kan lho bod rigs rang skyong khul|{kan su'u zhing chen gyi lho phyogs su yod pa'i bod rigs rang skyong khul zhig ste/ 1953 lor btsugs/ de'i khongs su zha ho rdzong/ rma chu rdzong/ klu chu rdzong/ co ni rdzong/ the bo rdzong/ 'brug chu rdzong/ len than rdzong ste rdzong khag bdun yod cing/ bod/ rgya/ hus/ sa lar/ sogs po sogs mi rigs kha shas yod/ rang skyong khul gyi mi dmangs srid gzhung gnas sa de zha ho'i gtsos yin/}
 kanda ka ri|{(legs) tsher ma can te shing sman gyi rigs shig ro mngar la kha zhing tsha ba/ zhu rjes snyoms/ nus pas rlung tshad dang bad kan skya bo/ glo nad bcas la phan/}
 kab kob|{ka be ko be'i bsdus tshig}
@@ -233,7 +233,7 @@ kun 'gebs|{(mngon) nam mkha'/}
 kun 'gyed|{(mngon) lha tshangs pa/}
 kun 'gro|1) {(mngon) 1/ nam mkha'/ 2/ sbrul/} 2) {kun tu 'gro ba ste sems thams cad kyi 'khor du 'gro ba'am rjes su 'gro ba/}
 kun 'gro lnga|{sems thams cad kyi rjes su 'gro ba'i sems byung lnga ste tshor ba dang/ 'du shes/ sems pa/ reg pa/ yid byed bcas so/}
-kun tu 'jug byed|{kun 'byung bden pa/ kun tu 'jug bral/ thams cad du 'gro zhing rnam grol thob pa la gegs byed pa'i nyon mongs can gyi chos rnams skyed par byed pa phra rgyas kyi dngos po rnams so/}
+kun 'gro'i rgyu|{rgyu drug gi nang gses shig ste/ khams gsum thams cad du 'gro zhing rnam grol thob pa la gegs byed pa'i nyon mongs can gyi chos rnams skyed par byed pa phra rgyas kyi dngos po rnams so/}
 kun 'joms|1) {tshang ma 'gems par byed pa/} 2) {sbyor ba nyer bdun gyi nang gses shig} 3) {(mngon) chu srin chen po/}
 kun nyon gyi dbang po lnga|{so skyes rgyud kyis bsdus pa'i tshor ba lnga'o/}
 kun tu 'khor ba'i rgyan|{snyan ngag gi sgra rgyan yi ge'i sgra 'dra bas tshig rkang brtsegs pa'i tshid bcad sgor mo'am/ gru bzhi'i dbyibs can gyi phyogs kun tu 'khor bar bkod pa'[i rgyan zhig}
@@ -268,7 +268,8 @@ kun brtags pa'i stobs|{ting nge 'dzin dang 'grogs pa'i shes rab kyis phyi nang g
 kun mthong|{(mngon) me long/}
 kun da|1) {kun mud kyi zur chag} 2) {(mngon) khu ba/}
 kun dong|{btsong/}
-kun bdag 'jig rten yongs kyi bdag po|{kun bde gling/ lha sa'i rtse po ta la'i lho nub phyogs su rab byung bcu gsum pa'i shing stag lor phyag btab pa'i dgon pa zhig ste/ de'i bdag po rta tshag no mi han nam/ rje drung ho thog thu zhes pa'i go ming 'dzin pa'i skye phreng snga phyi gnyis kyis gong ma chan lung dang/ kwang zhu'i skabs su bod kyi srid skyong thengs gnyis byas yod/}
+kun bdag|{'jig rten yongs kyi bdag po/}
+kun bde gling|{lha sa'i rtse po ta la'i lho nub phyogs su rab byung bcu gsum pa'i shing stag lor phyag btab pa'i dgon pa zhig ste/ de'i bdag po rta tshag no mi han nam/ rje drung ho thog thu zhes pa'i go ming 'dzin pa'i skye phreng snga phyi gnyis kyis gong ma chan lung dang/ kwang zhu'i skabs su bod kyi srid skyong thengs gnyis byas yod/}
 kun bden|{kun 'byung bden pa'i bsdus ming/}
 kun bden gyi spang bya bdun|{'dod pa'i khams 'dir kun bden mthong bas spang bar bya ba ma rig pa dang/ 'dod chags/ khong khro/ nga rgyal/ the tshom/ log lta/ lta ba mchog 'dzin te bdun/}
 kun 'dar ma|{rtsa dbu ma ste/ 'di la brten nas thig le dang/ rtsa'i bde ba dang/ rlung gi bde ba kun skye bas kun zhes bya la/ de spyi la khyab pas 'dar ma zhes bya'o/}
@@ -378,7 +379,7 @@ ke la sha'i rgyal po|{(mngon) gangs ti si/}
 ke sha can|{(legs) 'greng bu dang na ro nyis brtsegs yod pa'i yi ge 'greng bu ``ee'' na ro ``oo''}
 ke sa ra|{(legs)} 1) {me tog gi ge sar ram/ ze'u 'bru/} 2) {(mngon) skra/}
 kee la sha|{ke la sha dang 'dra/}
-#keg dus nges can gyi bar chad kyi don du go ba'i skag dang 'dra|
+keg|{dus nges can gyi bar chad kyi don du go ba'i skag dang 'dra/}
 keg 'phrang|{tshe'i bar chad dam gegs kyi 'gag dog po/}
 keng rus|{sha med rus khog khyi keng rus la chags pa/}
 keng rus kyi 'du shes|{mi sdug pa sgom skabs chags yul keng rus kyi rnam par 'du shes pa'am sems pa/}
@@ -390,7 +391,8 @@ ke'u tse|{(rgya) g.yu byur sngo ne sogs brgyus pa'i bud med kyi brang rgyan phre
 ke'u rtse|{ke'u tse dang 'dra/}
 ke'u tshang|{brag phug}
 ker ker|{lus sogs drang por gyen du 'greng tshul/ ker ker du langs nas phyogs su lta/ mdzub mo ker ker byas nas bsam blo gtong/}
-ker thig ker du bris pa'i drang thig ker ba|{(tha mi dad pa) gyen du lang ba'am/ 'greng ba/ gzugs po gyen du ker ba/ mdzub mo gyen du ker ba/ ker langs/}
+ker thig|{ker du bris pa'i drang thig}
+ker ba|{(tha mi dad pa) gyen du lang ba'am/ 'greng ba/ gzugs po gyen du ker ba/ mdzub mo gyen du ker ba/ ker langs/}
 ker mo|1. {lus gcer bu/ }2. {gcig pu/}
 ker re|{ya yo med par langs pa'i tshul/ lus po ker re langs/ dar shing ker rer btsugs/}
 ker leb sgur gsum|{ker ker mi dang/ leb leb sa/ sgur sgur phyugs te spyi tshogs rnying pa'i skabs khral 'u lag 'gel sa'i yul gsum/ ker leb sgur gsum gyi khral rigs/}
@@ -401,7 +403,7 @@ ko rkyal|{ko ba'i rkyal snod/}
 ko skud|1) {ko ba las dras pa'i rgyun bu/} 2) {ko ba mnyed dus ko bar byug pa'i zhag dang klad zho sogs/}
 ko sko|{kos ko dang 'dra/}
 ko skyi|{ko ba'i phyi shun gyi skyi'am/ pags pa srab po/}
-#ko khug ko ba'i khug ma chung ngu|
+ko khug|{ko ba'i khug ma chung ngu/}
 ko khrol|{ko rgyun las bzos pa'i khrol tshags/}
 ko mkhan|1) {ko ba'i ca lag bzo mkhan/} 2) {ko gru gtong mkhan/}
 ko gru|1) {ko ba dang gru'i bsdus ming/} 2) {ko bas bzos pa'i gru/ ko gru gtong ba/ ko gru'i sgrol 'don/}
@@ -409,7 +411,8 @@ ko gla|{ko gru'i gla/ ko gla med pa'i 'grul pa min/}
 ko rgyun|{ko ba dras pa'i skud pa/}
 ko sgrog|1) {rgyun bu las bzos pa'i kha sgrog} 2) {ko ba las bzos pa'i rta sgrog ko sgrom/ko bas bzos pa'i snod cig}
 ko ci|{(rnying) lhag bcas ste sogs kyi sgra'i 'jug tshul dang 'dra ba'i phrad cig ste}
-ko lcag sngar 'gram par gzhu byed kyi khrims chas shig ko chu|{ko mog gi chu'am/ sa kong dong du 'khyil ba'i chu/}
+ko lcag|{sngar 'gram par gzhu byed kyi khrims chas shig}
+ko chu|{ko mog gi chu'am/ sa kong dong du 'khyil ba'i chu/}
 ko ches pa|{(rnying) go ba thal drags pa/}
 ko nye|{klu bdud rdo rje rigs gnyis kyi nang tshan me tog dkar po 'char ba zhig}
 ko ta|{'bru rigs tha ma'i tha ma bra bo lta bu/ zas mchog ko ta rgyan mchog mtshon la byed/}
@@ -427,15 +430,16 @@ ko phub|{ko bas bzos pa'i mtshon cha 'gog byed/}
 ko phyar|{sa la gding bya'i ko ba mnyes ma'i phyar ba/}
 ko 'phyags|{(yul) ko lpags yod tshad sdud len gyi khral/}
 ko ba|1) {rta g.yag sogs kyi pags pa mnyes ma dang ma mnyes pa spyi'i ming/ ko bubs bzhi/ ko ba sreg pa/ ko ba mnyes pa/ ko ba skyi bcad/ ko lham yu ring/ ko ba gcig nas dras pa'i rgyun bu/} 2) {(yul) chu bo las sgrol byed kyi yo byad cig}
-#ko ba'i 'u lag sngar gzhung sar chu thog nas shing cha skyel 'dren byed pa'i khral|
+ko ba'i 'u lag|{sngar gzhung sar chu thog nas shing cha skyel 'dren byed pa'i khral/}
 ko byi la|{thang sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas khrag rlung stod 'tshang 'joms/ glang thabs sel/ dug tshad zhi bar byed/ ming gi rnam grangs la sngo leb spu can dang/ ldum stag phur leb/ bya 'phur leb bcas so/}
 ko byil|{ko byi la dang 'dra/}
 ko 'bigs|{ko ba la khung bu 'bigs byed kyi lag cha snyung bu/}
 ko 'bugs|{ko ba 'bigs byed kyi snyung bu/}
 ko 'be|{ko ba las bzos pa'i dkar brtsegs kyi khebs te dre'u dang/ khal bong sogs kyi sga 'og tu brgyag bya zhig}
 ko 'bo|{ko bas bzos pa'i 'bo/}
-ko 'bog ko bas bzos pa'i khom 'bog gam gyon 'bog ko 'bol|{ko bas bzos pa'i 'bol gdan/}
-#ko mog chu 'khyil ba'i sa kong dong|
+ko 'bog|{ko bas bzos pa'i khom 'bog gam gyon 'bog}
+ko 'bol|{ko bas bzos pa'i 'bol gdan/}
+ko mog|{chu 'khyil ba'i sa kong dong/}
 ko tse|{sko tse dang 'dra/}
 ko brtsegs|{(yul) lham zom pa'i ko mthil brtsegs ma/}
 ko tshags|{ko bas bzos pa'i tshags ma/}
@@ -451,17 +455,17 @@ ko la'i 'dab|{(mngon) na gi/}
 ko le|{(rnying) tshang ma/ ko ler gzer ba/}
 ko long|{rkyen chung ngu tsam la'ang khong khro lang skyen pa/ ko long chen po/ ko long tsha po/ tshig mtho dman cung zad tsam la ko long chen po langs pa/}
 ko sha|{lus stobs skye ba dang/ snying mkhal gyi nad gso bar byed pa'i sman zhig}
-ko sha|{(legs) mdzod/}
+ko Sha|{(legs) mdzod/}
 ko sham pa|{bka' gdams pa spyan snga bas sham thabs la ko ba'i lhan pa mang po btab pas khong la mtshan de ltar btags/}
 ko shel|{shes mnyen po/}
-#ko sag ko seg dang 'dra|
-#ko seg phor pa sogs 'jam po bzo byed|
+ko sag|{ko seg dang 'dra/}
+ko seg|{phor pa sogs 'jam po bzo byed/}
 ko bse|{ko ba mnyes ma'i skyi la rtsi gang rung btang yod pa'i rigs/}
 koo shambhi|{(legs) sngar rgya gar dbus phyogs su yod pa'i rgyal khab mdzod ldan/}
 koo shambhi'i gzhi|{'dul ba gzhi bcu bdun gyi nang gses las bye ba'am las kyi rtsod pa'i gzhi ste/ koo shambhi'i dge slong gis yangs pa can pa'i dge slong gnas dbyung byas pas rtsod pa chen por gyur te/ las bye ba la yul gyi ming gis btags pa/}
 koo shi ka|{(legs)} 1) {mkhas pa/} 2) {sman gu gul/} 3) {brgya byin/}
 koo shi han|{gu shi han dang 'dra/}
-kog phyi shun gyong po|{mar gyi grod kog shun kog}
+kog|{phyi shun gyong po/ mar gyi grod kog  shun kog}
 kog gis|{(rnying) myur du'am glo bur du/}
 kog man|{(rgya) rgya thug skam po/}
 kog tse|{rgya dang rnyi'i spyi ming/}
@@ -472,20 +476,20 @@ kong chas|{yul kong po'i chas/}
 kong jo|{(rgya) gong ma'am rgyal po'i sras mo/}
 kong dong|{sa brus pa'i khung bu/}
 kong rna|{kong yul nas dar ba'i rna rgyan/}
-kong rna pan tog rgya lu chas kyi rna rgyan g.yas kong rna dang|{g.yon pan tog}
+kong rna pan tog|{rgya lu chas kyi rna rgyan g.yas kong rna dang/ g.yon pan tog}
 kong po|{bod rang skyong ljongs kyi shar ngos nyang chu'i stod rgyud du yod pa'i yul lung gi ming/}
 kong po rgya mda'|1) {rdzong zhig bod rang skyong ljongs kyi kong yul nyang chu'i stod rgyud du yod/ deng skabs rdzong mi dmangs srid gzhung de nga phod zam khar yod/} 2) {grong zhig bod rang skyong ljongs kyi kong yul nyang chu dang spyi mda' phyogs nas 'bab pa'i chu gnyis 'dzoms sa'i lung pa sum mdor yod/}
 kong po bar la|{bod rang skyong ljongs kyi mal gro gung dkar rdzong dang kong po rgya mda'i bar du yod pa'i la zhig yin zhing/ dbus dang kong po'i mtshams ri'ang yin/}
 kong po bu chu|{lha khang zhig bod kyi sa gzhi srin mo gan rkyal du 'gyel ba 'dra ba'i kha gnon du srong btsan skabs su bzhengs pa'i gtsug lag khang yang 'dul bzhi'i gras shig}
 kong po lo gsar|{kong po'i yul srol zhig ste bod zla bcu pa'i nang kong yul du gtong ba'i lo gsar}
-kong sprul zin tig karma ngag dbang yon tan rgya mtshos rab byung bcu bzhi pa'i nang mdzad pa'i nang sman sprad pa'i nyams yig cig ste|{de'i nang gtso che ba ni nad re re bzhin rtags dang bcos thabs sogs gnad du dril nas kha gsal zhing don tshang ba bstan yod pa dang/ de bzhin sman dug 'don byed thabs sogs nyer mkho'i don rnams ma 'dres par bkod pa'i sman gzhung zhig}
+kong sprul zin tig|{karma ngag dbang yon tan rgya mtshos rab byung bcu bzhi pa'i nang mdzad pa'i nang sman sprad pa'i nyams yig cig ste/ de'i nang gtso che ba ni nad re re bzhin rtags dang bcos thabs sogs gnad du dril nas kha gsal zhing don tshang ba bstan yod pa dang/ de bzhin sman dug 'don byed thabs sogs nyer mkho'i don rnams ma 'dres par bkod pa'i sman gzhung zhig}
 kong sprul yon tan rgya mtsho|{mtshan gzhan gar dbang blo gros mtha' yas ni rab byung bcu bzhi pa'i chu byar mdo khams 'bri zla zal mo sgang gi pad ma lha rtse'i mdun rol rong rgyab sbas pa'i yul du sku 'khrungs/ khong gis rin chen gter mdzod dang/ gdams ngag mdzod/ bka' brgyud sngags mdzod rnams bsgrigs par mdzad cing/ shes bya mdzod dang/ thun min gsang ba'i mdzod brtsams pa dang gter nas bton pa bcas mdzod chen lnga dang/ de 'brel sman dang gtam tshogs sogs gsung thor bu sna tshogs bcas po ti brgya la nye ba zhig rtsom sgrig mdzad/ rab byung bco lnga pa'i sa phag lor 'das/}
 kong sprel|{kong po nas thon pa'i spre'u/}
 kong bu|{dpangs mtho zhing gting ring ba'i snod chung ngu zhig ste mar me 'bul snod/ mchod kong/ gser kong/}
 kong mo|1. {yul kong po'i bud med/ }2. {phug zab pa/ mig kong mo/ sa kong mo/}
 kong btsun de mo|{bstan ma bcu gnyis kyi gras kong yul gyi gnas bdag cig yul yar klung la bsdad na lha yar lha sham po dang/ yul kong por bsdad na lha kong btsun de mo bsten dgos/}
 kong 'dzin 'ul mi|{sngar lha ldan sa khul du lnga mchod dang/ bzhi mchod skabs mchod me 'gengs rgyu dang/ dgram rgyu/ mchod kong bsdu rgyu sogs kyi las ka byed mkhan 'ul mi/}
-#kong zhag nyi skar bcu dang chu tshod drug spyi zla dgu pa'i tshes bcu gsum skor nas 'ol pa log pa'i kong zhag bco lnga 'dren|
+kong zhag|{nyi skar bcu dang chu tshod drug spyi zla dgu pa'i tshes bcu gsum skor nas 'ol pa log pa'i kong zhag bco lnga 'dren/}
 kong zhwa|{kong po'i pho mo'i zhwa mo/}
 kong yul|{kong po dang don gcig}
 kong lham|{kong po ba pho mo spyi'i lham/}
@@ -543,7 +547,7 @@ kyu|{ming 'ga'i mthar sbyar na bzo dbyibs gug gug ston pa'i sgra/ lcags kyu/ nya
 kyu ma|{g.yu/}
 kyu ru ra|{skyu ru ra dang 'dra/}
 kyu ru ru|{'bu dang byi'u sogs kyis skad 'byin tshul lam sgrog stangs shig}
-kyug kyug 'jam zhing 'od 'tsher ba|{skra nag kyug kyug byed/}
+kyug kyug|{'jam zhing 'od 'tsher ba/ skra nag kyug kyug byed/}
 kyung bu|{(rnying) tho ba/}
 kyur kyur|{'bu dang bya sogs kyis skad phra mo 'don tshul/}
 kye|{rang las mtho ba zhig la 'bod pa'i sgra/ kye rgyal po chen po/}
@@ -551,7 +555,7 @@ kye kye|{'bod brda nyis brtsegs sam/ nan tan gyis 'bod pa'i tshig}
 kye rdo rje|{dgyes pa rdo rje ste sngags bla med kyi yi dam zhig ming gi rnam grangs la dgyes pa rdo rje dang/ rdo rje gri gug dpal ldan khrag 'thung/ rol pa'i rdo rje/ he badzra/ he ru ka bcas so/}
 kye rdo rje zhes bya ba'i rgyud kyi rgyal po|{rgyud sde'i bye brag cig rnal 'byor bla na med pa'i rgyud sde brtag pa gnyis pa ste/ dgyes pa rdo rje'i rtsa ba'i rgyud rgyas pa 'bum phrag bdun yod pa las cung zad bsdus pa 'bum phrag lnga pa dang/ de las kyang btus pa'i dgyes pa rdo rje zhes bya ba'i rgyud kyi rgyal po bcas rgya gar gyi mkhan po ga ya dha ra dang/ 'brog mi'i 'gyur la slar yang lo tsA ba gzhon nu dpal gyis 'gyur chad bsabs pa/}
 kye rdor|{kye rdo rje'i bsdus tshig}
-#kye rdor gyi sgrub thabs kyi yan lag drug gzhal yas khang bskyed pa rnam snang gi yan lag dbang bskur ba mi bskyod pa'i yan lag bdud rtsi myang ba 'od dpag med kyi yan lag bstod pa rin 'byung gi yan lag mchod pa don grub kyi yan lag rjes chags rdor sems kyi yan lag rnams so|
+kye rdor gyi sgrub thabs kyi yan lag drug|{gzhal yas khang bskyed pa rnam snang gi yan lag  dbang bskur ba mi bskyod pa'i yan lag  bdud rtsi myang ba 'od dpag med kyi yan lag  bstod pa rin 'byung gi yan lag  mchod pa don grub kyi yan lag  rjes chags rdor sems kyi yan lag rnams so/}
 kye ma|{smad pa dang/ smon pa/ zhum pa/ ngo mtshar ba/ mya ngan/ nges pa sogs kyi don la 'jug pa'i 'bod tshig cig kye ma 'di 'dra ma shod/ kye ma lo legs pa la/ kye ma phangs pa la/ kye ma mtshar/ kye ma yid sems skyo ba la kye ma khyod kyis ltos dang/}
 kye ma kyi hud|{mya ngan gyi tshig gam/ smre sngags 'don pa'i tshig}
 kye ma kye hud|{kye ma kyi hud dang 'dra/}
@@ -571,7 +575,7 @@ kyo ba|{(rnying) lcags kyu/}
 kyo ba tang|{(rnying) lcags kyu/}
 kyog kyog 'khyog po|{mgo bo kyog kyog lam kyog kyog}
 kyog ge ba|{drang min 'khyog po'i rnam pa/ the tshom gyi blo kyog ge ba/ rgad po gzugs po kyog ge ba/}
-#kyog thig thig 'khyog po|
+kyog thig|{thig 'khyog po/}
 kyog pa|{kyog po dang 'dra/}
 kyog po|{drang min 'khyog po'am yon po/ 'gro lam kyog po/ gtam kyog po/ rkang lag kyog po/ khug kyog}
 kyog lam|{'gro lam 'khyog po/}
@@ -616,11 +620,12 @@ krung dban|{(rgya) dkar yol 'bring ba/}
 krung hwa mi rigs|{dus yun ring ba'i lo rgyus dang/ 'od stong 'bar ba'i rig gnas rjes 'bras/ gzi brjid che ba'i gsar brje'i srol rgyun dang ldan pa'i rang re'i krung hwa mi dmangs spyi mthun rgyal khab kyi khongs gtogs mi rigs lnga bcu lhag tsam gyi spyi ming/}
 krub zan|{(yul) srubs zan te/ tshem bu'i bar srub tu 'jug pa'i rgyan/}
 krum|{sha'i zhe sa/ krum khu/ gsol krum bzhes/}
-krum khog sha khog krum dod|{sha'i dod dngul/}
+krum khog|{sha khog}
+krum dod|{sha'i dod dngul/}
 krum mda'|{me mda' 'phrul mda' thung thung/}
 krums|{krum dang 'dra/}
 kru'u zhi|{(rgya) rgyal khab dang/ srid tang/ tshod pa/ tshogs 'du sogs 'ga' zhig gi 'go khrid mtho shos kyi go ming/}
-#kre nag thab zangs dang khog ma sogs du bas bdug pa'i dreg pa nag po|
+kre nag|{thab zangs dang khog ma sogs du bas bdug pa'i dreg pa nag po/}
 krog krog|1) {sgra'i khyad par/ sgo la krog krog gtong ba/} 2) {dregs pa'am nga rgyal ba'i rnam 'gyur/ byed stangs krog krog tsha ba/}
 krong krong|{srong por langs tshul/ rna ba krong krong byas nas nyan pa/}
 krong nge ba|{srong nge ba/ shing sdong krong nge ba/ krong nge bar 'greng ba/}
@@ -656,8 +661,7 @@ klad spri|{klad pa'i skyi dkar/}
 klad phor|{ka li/}
 klad byi|{mgo dmar ba'am zangs khog lta bu ste mgo bo'i skra rnams rang bzhin gyis bud pa/}
 klad ma|{thog ma'am/ steng ma'am/ gong ma/ dus kyi klad ma/}
-klad med|{byab chung ngam col chung/}
-#klad med kyi gtam|
+klad med|{byab chung ngam col chung/ klad med kyi gtam/}
 klad rtsa|{lus kyi klad pa 'phel rgyas 'byung ba'i rtsa/}
 klad rtsal|{bsam blo'i nus rtsal/}
 klad zho|{ka li'i nang gi klad pa zho dang 'dra ba/}
@@ -680,7 +684,8 @@ klu glang nag po rwa can|1) {mtsho glang zhig} 2) {sdig srin/}
 klu rgyal|{klu'i rgyal po ste/ sde brgyad nang tshan gyi klu rigs kyi gtso bo/}
 klu rgyal rgya mtshos zhus pa|{'phags pa klu'i rgyal po rgya mtshos zhus pa'i mdo rgyas pa bam po bdun dang le'u bcu pa/ rgya gar gyi mkhan po dzi na mi tra dang/ pradznyA warma dang/ lo tsA ba bande ye shes sde la sogs pas bsgyur ba/}
 klu rgyal ma dros pas zhus pa|{'phags pa klu'i rgyal po ma dros pas zhus pa'i mdo bam po bzhi pa/ rgya gar gyi mkhan po dzi na mi tra dang/ dA na shI la dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
-klu sgug sgar sgrig sngar hor zla dang po'i tshes nyer gnyis nyin lha sa'i brag ra klu sgug gi thang chen du gzim chung ba rnams sdeb tshogs kyis smon lam gtor rgyag pa'i rgyab snon du 'gro rgyu'i sgar sgrig byed pa klu sgrub|{'dzam gling mdzes pa'i rgyan drug gi ya gyal te/ ston pa thub pa'i dbang po mya ngan las 'das nas lo bzhi brgya'i thog rgya gar lho phyogs be darbha'i yul du bram ze zhig gi khyim du sku 'khrungs/ dgung lo chung ngu'i dus nas gsang ba sngags kyi rgyud sde bzhi dang/ sde snod gsum sogs thun mong dang thun min gyi rig pa'i gnas mtha' dag la mkhas par sbyangs/ dpal na lenta'i gtsug lag khang du grub chen sa ra ha pa'i sku mdun du rab tu byung/ mtshan dge slong dpal ldan du grags/ mtha' bral dbu ma rigs tshogs drug dang/ rgyud kun las btus pa sogs stobs bcu mnga' ba'i dgongs don gsal bar byed pa'i bstan bcos kyi rgyal po mang du bskrun/ khyad par du gso ba rig pa'i skor la 'tsho ba'i mdo tshigs su bcad pa/ rtswa a wa'i cho ga/ sman rin po che'i rim pa/ dngul chu'i sbyor ba rin chen phreng ba/ lhog pa spun bzhi'i gnyan bcos sogs bstan bcos shin tu mang/ 'phags pa lha sogs slob ma nyi rdul ltar bskyangs/ mchod rten dang lha khang mang po btab/ rdo rje gdan la dra mig gi ra bas bskor/ lho phyogs dpal ldan 'bras spungs kyi bkod pa bzhengs/ spyi'i lugs la dgung lo drug brgya dang/ snga 'gyur ltar na dgung lo chig stong bar bzhugs nas 'gro don mdzad par grags/}
+klu sgug sgar sgrig|{sngar hor zla dang po'i tshes nyer gnyis nyin lha sa'i brag ra klu sgug gi thang chen du gzim chung ba rnams sdeb tshogs kyis smon lam gtor rgyag pa'i rgyab snon du 'gro rgyu'i sgar sgrig byed pa/}
+klu sgrub|{'dzam gling mdzes pa'i rgyan drug gi ya gyal te/ ston pa thub pa'i dbang po mya ngan las 'das nas lo bzhi brgya'i thog rgya gar lho phyogs be darbha'i yul du bram ze zhig gi khyim du sku 'khrungs/ dgung lo chung ngu'i dus nas gsang ba sngags kyi rgyud sde bzhi dang/ sde snod gsum sogs thun mong dang thun min gyi rig pa'i gnas mtha' dag la mkhas par sbyangs/ dpal na lenta'i gtsug lag khang du grub chen sa ra ha pa'i sku mdun du rab tu byung/ mtshan dge slong dpal ldan du grags/ mtha' bral dbu ma rigs tshogs drug dang/ rgyud kun las btus pa sogs stobs bcu mnga' ba'i dgongs don gsal bar byed pa'i bstan bcos kyi rgyal po mang du bskrun/ khyad par du gso ba rig pa'i skor la 'tsho ba'i mdo tshigs su bcad pa/ rtswa a wa'i cho ga/ sman rin po che'i rim pa/ dngul chu'i sbyor ba rin chen phreng ba/ lhog pa spun bzhi'i gnyan bcos sogs bstan bcos shin tu mang/ 'phags pa lha sogs slob ma nyi rdul ltar bskyangs/ mchod rten dang lha khang mang po btab/ rdo rje gdan la dra mig gi ra bas bskor/ lho phyogs dpal ldan 'bras spungs kyi bkod pa bzhengs/ spyi'i lugs la dgung lo drug brgya dang/ snga 'gyur ltar na dgung lo chig stong bar bzhugs nas 'gro don mdzad par grags/}
 klu sgrub snying po|{'phags pa klu sgrub kyi mtshan gzhan zhig}
 klu chu|1) {rdzong zhig kan su'u zhing chen khongs kan lho bod rigs rang skyong khul gyi nub dang klu chu'i stod rgyud du yod/} 2) {rma chu'i stod rgyud kyi yan lag cig kan su'u zhing chen gyi lho nub phyogs na yod}
 klu chen|{klu rgyal dang don gcig}
@@ -690,19 +695,20 @@ klu gtor|{klu la bsngo ba'i gtor ma/}
 klu thebs|{klu sa'i steng du 'ong ba'i dus te zla ba so sor klu thebs tshes grangs nges can re yod cing/ de la yang thebs chen dang/ thebs chung gnyis yod/}
 klu thor|{thor nad cig}
 klu mthar byed|{(mngon) nam mkha' lding ngam/ bya khyung/}
-klu dug klu las byung ba'i gnod pa ste|{nang gses kha rlangs kyi dug dang/ mthong dug tshor ba'i dug reg pa'i dug sogs yod/}
+klu dug|{klu las byung ba'i gnod pa ste/ nang gses kha rlangs kyi dug dang/ mthong dug tshor ba'i dug reg pa'i dug sogs yod/}
 klu gdon nad|{lha srin sde brgyad kyi nang tshan gdug pa can klus gtong bar grags pa'i mdze nad sogs/}
-klu bdag klu rgyal dang don gcig klu bdud|1) {mdze nad sogs gtong mkhan klu gdug rtsub can/} 2) {mdze nad dang/ gza' nad/ chu ser/ skrangs pa sogs la phan pa'i sngo sman zhig}
+klu bdag|{klu rgyal dang don gcig}
+klu bdud|1) {mdze nad sogs gtong mkhan klu gdug rtsub can/} 2) {mdze nad dang/ gza' nad/ chu ser/ skrangs pa sogs la phan pa'i sngo sman zhig}
 klu bdud rdo rje|{sngo sman gyi rigs shig ste/ me tog dkar nag gnyis mchis pa/ ro mngar la bska/ zhu rjes bsil/ nus pas gza' nad dang/ mdze nad/ 'bam grum bu/ chu ser bcas la phan/}
 klu bdud rdo rje dkar po|{dma' sar nyin ngos las skye ba/ lo ma spu chung can/ me tog dkar po bon shang 'dra ba'i sngo sman zhig 'dis gza' klu 'bam gdon 'joms/}
 klu bdud rdo rje nag po|{srib kyi shing phran gseb las skye ba/ lo ma dngul gyi mdel zhib 'dra ba/ me tog thal dkar glang chen mdog dril bu 'dra ba thur du bub pa zhig 'dis gza' klu 'bam gdon rnams 'joms/}
 klu bdud rdo rje dman pa|{sngo sman zhig 'dis chu khams gso ba dang glo ba'i tsha ba sel/}
-#klu ldog klu sa yi rgyu bar sa 'og tu 'gro ba|
+klu ldog|{klu sa yi rgyu bar sa 'og tu 'gro ba/}
 klu nad|{lha srin sde brgyad kyi nang tshan klus btang bar grags pa'i nad mdze dang/ shu ba/ phol mig za rkong lta bu/}
 klu gnod|{klu las byung ba'i gnod 'tshe/}
 klu dbang|{klu chen/}
 klu 'bum|{klu la phan pa'i bon gzhung zhig}
-#klu 'bum dkar nag bon gzhung klu chog khag gnyis kyi bsdus ming|
+klu 'bum dkar nag|{bon gzhung klu chog khag gnyis kyi bsdus ming/}
 klu 'bum dkar po|{bon gzhun klu 'bum sde tshan dang po/}
 klu 'bum khra bo|{bon gzhung klu 'bum sde tshan gnyis pa/}
 klu 'bum nag po|{bon gzhung klu 'bum sde tshan gsum pa/}
@@ -720,7 +726,8 @@ klung skyes lo tshan|{sngo sman zhig sman 'di la skye gnas dbang gis ming mi 'dr
 klung khang|{sa bab dma' sar chags pa'i khang pa/}
 klung rgya|{lung gzhung skam gsher la gnas pa'i srog chags bsad mi chog pa'i khrims/ skam gsher la gnas pa'i srog chags che phrar 'tshe ba mi chog pa'i klung rgya sdom pa/}
 klung rgyun|{chu 'bab pa'i rgyun/}
-klung sgog ke dzi zhes lung gzhung du skyes pa'i sgog pa'i bye brag cig klung chu|{gtsang chu'am/ klung la rgyug pa'i chu/}
+klung sgog|{ke dzi zhes lung gzhung du skyes pa'i sgog pa'i bye brag cig}
+klung chu|{gtsang chu'am/ klung la rgyug pa'i chu/}
 klung rta|{rlung rta dang 'dra/}
 klung thang|{klung la yod pa'i thang/}
 klung ldan|{'bab chu/ bka' mchid klung ldan rgyun mi 'chad pa ltar stsol/}
@@ -748,8 +755,9 @@ klu'i yi ge|{nAgara'i yi ge ste sngar rgya gar gyi yi ge zhig}
 klu'i bshes gnyen|{spyi lo'i dus rabs bzhi pa'am lnga pa tsam la byung ba'i rgya gar gyi slob dpon zhig yin pa 'di klu sgrub kyi dbu ma'i rigs lam spel mkhan dang/ sangs rgyas bskyangs ni de'i yang slob yin/}
 klo pa|{bod rang skyong ljongs kyi klo yul la gzhis chags pa'i mi/}
 klo yul|{bod rang skyong ljongs kyi shar lho'i rgyud kyi sa gnas shig}
-klo shog stod klo zhes pa'i lung pa nas thon pa'i shog bu|{klo sug klo yul nas thon pa'i sug smel gyi ming/}
-klog klag klog pa'i ming tsam|{dpe deb klog klag byed pa/}
+klo shog|{stod klo zhes pa'i lung pa nas thon pa'i shog bu/}
+klo sug|{klo yul nas thon pa'i sug smel gyi ming/}
+klog klag|{klog pa'i ming tsam/ dpe deb klog klag byed pa/}
 klog skya|{sa skya'i lo tsA ba shes rab brtsegs kyi 'khrungs yul gtsang phyogs kyi sa cha zhig}
 klog gi slob dpon|{thog mar yi ge slob mkhan dge rgan/ klog gi slob dpon bsten nas yi ge sgra dag po slobs shig}
 klog grwa|{yi ge klog mkhan gyi tshogs pa/}
@@ -770,7 +778,7 @@ klong 'khor|{'khor bzhin nub 'gro ba'i chu rba rlabs gting zab po zhig}
 klong 'khyil|1) {'od kor/} 2) {mtsho 'khor/}
 klong gyur|{klong du gyur pa ste/ dbang du gyur pa'am/ don yongs su rtogs pa/ rig gnas mang po klong du gyur pa/}
 klong chen|{zab cing yangs pa'i blo khog gam shes rab/}
-#klong chen snying thig gsang sngags rnying ma'i gter chos shig ste rig 'dzin 'jigs med gling pa'i dgongs gter|
+klong chen snying thig|{gsang sngags rnying ma'i gter chos shig ste rig 'dzin 'jigs med gling pa'i dgongs gter/}
 klong chen mdzod bdun|{dus rabs bcu bzhi par rnying ma'i slob dpon klong chen rab 'byams kyis mdzad pa'i bstan bcos bdun te/ grub mtha' mdzod/ theg mchog mdzod/ yid bzhin mdzod/ man ngag mdzod/ chos dbyings mdzod/ gnas lugs mdzod/ tshig don mdzod rnams so/}
 klong chen rab 'byams|{rtogs pa rgya chen po thob pa/}
 klong chen rab 'byams pa|{rnying ma'i slob dpon klong chen pa dri med 'od zer zhes pa dbus lho g.yo ru gra'i cha stod grong du rab byung lnga pa'i sa sprel lor 'khrungs/ rab byung drug pa'i chu yos lor 'das/ ta'i si tu byang chub rgyal mtshan dang dus mnyam yin/ khong gis mdzad pa'i mdzod chen bdun dang/ snying thig ya bzhi/ ngal gso skor gsum/ rang grol skor gsum sogs chos tshan brgya phrag gnyis lhag tsam yod/}
@@ -787,7 +795,7 @@ kshetra pa la|{(legs) rgyal skyong ste/ mgon po phyag drug pa'i 'khor shar phyog
 dkag pa|{(yul) bzhus pa'i gsher khu 'khyags nas sra 'thas su 'gyur ba/ mar khu dkag zhag dkag dkan} 1) {gyen/ brag dkan gzar po/ ri bo dkan gzar 'dzeg dus dbugs kyang sngangs/} 2) {rkan dang 'dra/}
 dkan gnyer|{kha'i ya rkan kyong 'bur ri mo/}
 dka' dka'|{khag po khag po'i don/ las ka dka' dka' ltar yod kyang 'bad na 'grub yong/}
-dka' 'gag dka' las khag sa'i 'gag rtsa|{dka' 'gag rim gyis bsal/}
+dka' 'gag|{dka' las khag sa'i 'gag rtsa/ dka' 'gag rim gyis bsal/}
 dka' 'grel|{gzhung gi tshig don rnams mthar chags su ma bshad par dka' ba'i gnas rnams rtsal du bton nas bshad pa'i gzhung/}
 dka' 'grel dgos 'dod 'byung ba|{rab byung bdun pa'i nang byang pa rnam rgyal grags bzang gis mdzad pa'i phyi ma rgyud kyi dka' gnad rnams gsal bar 'grel ba'i sman gyi bstan bcos shig}
 dka' 'grel legs bshad gser rgyan|{rab byung bcu gcig pa'i nang dar mo sman rams pa blo bzang chos grags kyis mes po'i zhal lung gi kha skong tshul du mdzad pa'i man ngag rgyud kyi dka' gnad rnams gsal bar 'grel ba zhig}
@@ -835,7 +843,7 @@ dkar rkyang|{tshos mdog gzhan ma 'dres pa'i dkar po/ dkar po dkar rkyang/}
 dkar skya|{kha dog dkar tsam zhig}
 dkar skyong|{sha rus tshil khrag sogs dmar rigs ma 'dres shing/ mar phyur 'o zho 'bras rtsam sogs dkar rtsi dang/ dkar sdor kho nar brten pa'i bza' btung longs spyod/}
 dkar khung|1) {thog khung ngam/ mthongs khung/} 2) {sge'u khung/}
-dkar khyug khyug 'od dkar po'i rgyu stangs|{bar snang du skar mda' zhig dkar khyug khyug rgyug gin 'dug}
+dkar khyug khyug|{'od dkar po'i rgyu stangs/ bar snang du skar mda' zhig dkar khyug khyug rgyug gin 'dug}
 dkar khra|{gzhi dkar po la sngo dmar sogs kyi ri mo sna tshogs yod pa/ ras dkar khra/ shog bu dkar khra/}
 dkar khra man|{gzi yi rigs ri mo sngo dkar dmar sogs ma nges pa 'byung ba zhig ste/ nus pas gza' nad dang 'byung po'i gdon srung/}
 dkar khra men|{rin chen rigs kyi rdo gnam sa kha sprod zer ba/}
@@ -901,7 +909,8 @@ dkar me|{mchod me/}
 dkar me bsngo zhu|{phung po 'don pa'i snga nyin mchod sprin dang bsngo rten 'bul srol/}
 dkar mo|{mdog dkar po dang 'dra/}
 dkar mo gos gcig ma|{lha dbang phyug gi btsun mo zhig}
-dkar mo gre 'gag lug gi mid pa 'gag nas myur du 'chi ba'i 'gos nad cig dkar dmar|{kha dog dkar po dang dmar po/}
+dkar mo gre 'gag|{lug gi mid pa 'gag nas myur du 'chi ba'i 'gos nad cig}
+dkar dmar|{kha dog dkar po dang dmar po/}
 dkar gtsang|{mdog dkar po dri ma med pa/ kha btags dkar gtsang/ gyon pa dkar gtsang/}
 dkar rtsi|1) {tshon rtsi dkar po/} 2) {khang pa sogs la rtsi byug rgyu'i sa dkar te/ ro mngar bska/ nus pas sha rus la zhen pa'i nad 'gog par nus} 3) {gnag phyugs la glo nad dang hon nad phog skabs nad phog zin pa'i phyug kha chung zhig gi khrag dang/ ri bong gi khrag mnyam du bsres te nad ma phog pa'i gnag phyugs rnams nad yang ba dang/ thar thub pa'i ched du ster rgyu'i 'gog sman zhig} 4) {gtor ma la byug rgyu'i mar khu/}
 dkar rtsis|{skar rtsis dang 'dra/}
@@ -920,7 +929,7 @@ dkar yol|{dkar po'i yol go / dkar yol cha gcig dkar yol rnying ma/}
 dkar yol rdo rtsi|{dkar yol la byug bya'i rtsi/}
 dkar yol yu ring|{sngar bod kyi bla dpon sogs la ja sogs 'dren snod kyi dkar yol yu ba ring po zhig dkar g.ya' gsha' dkar gyi rtsi/ zangs la dkar g.ya' gtong ba/}
 dkar g.yeng|{(rnying) bzang ngan dbye 'byed/}
-#dkar rag khang pa sogs la byug rgyu'i sa dkar|
+dkar rag|{khang pa sogs la byug rgyu'i sa dkar/}
 dkr rigs|{mar phyur 'o zho sogs/}
 dkar ru|1) {dkar po/} 2) {lug gi khyu/}
 dkar la lha mtsho|{mtsho zhig mtsho sngon zhing chen khongs mgo log bod rigs rang skyong khul gyi rma stod rdzong du yod/}
@@ -957,11 +966,11 @@ dku ma rnyongs pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang
 dku mtshams|{dpyi mgo'am/ sked pa'i thad/}
 dku zlum pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang gses shig ste/ slob ma tshul khrims phun sum tshogs par gyur pa nyid kyis dku zlum pa ste/ dpyi'i sta zur gyis mtshon pa'i sked pa zlum pa/}
 dkog nyul|{(rnying) so lta byed mkhan/}
-dkon cog dkon mchog gi brda rnying ste de ni dkon gyi brdar da drag yod pas pho yis pho yi ming mtha' drang zhes gsungs pa ltar ming mtha' mchog ces pa'i ming gzhi cha yig de ca yig tu bsgyur cing sngon 'jug ma yig dor nas de ltar du brjod pa|{dkon dkond dkond mchog cha ca / ca ? ma/ mchog cog / dkon mchog dkond cog ?}
+dkon cog|{dkon mchog gi brda rnying ste de ni dkon gyi brdar da drag yod pas pho yis pho yi ming mtha' drang zhes gsungs pa ltar ming mtha' mchog ces pa'i ming gzhi cha yig de ca yig tu bsgyur cing sngon 'jug ma yig dor nas de ltar du brjod pa/}
 dkon cog brtsegs pa|{theg pa chen po'i mdo zhig ste 'phags pa dkon cog brtsegs pa le'u bzhi bcu rtsa dgu'i bdag nyid can ni rgya gar dang/ li yul/ rgya las bsgyur ba/}
 dkon mchog|1) {rin po che lta bu 'jig rten na dkon zhing mchog tu gyur pa ste/bsod nams ma bsags pa la snang ba min pas 'byung ba dkon pa dang/ rang bzhin gyis rnyog pa'i chos can ma yin pas dri ma med pa dang/ rang gzhan gyi don sgrub pas mthu dang ldan pa dang/ 'gro ba rnams kyi bsam pa dge ba'i rgyu yin pas 'jig rten gyi rgyan dang/ 'jig rten las mchog tu gyur pa dang/ rnam par 'gyur ba'i rang bzhin can ma yin pas 'gyur ba med pa bcas kyi yon tan dang ldan pas dkon mchog ces bya'o/} 2) {dkon mchog dpang btsugs kyi bsdus tshig}
 dkon mchog kun 'dus|{dkon mchog gsum po gcig tu 'dus pa rang gi rtsa ba'i bla ma/}
-dkon mchog gi za ma tog mdo sde zhig ste|{bam po bzhi pa/ lo tsA ba bande ratna rakshi tas bsgyur cing skad gsar bcad kyis bcos pa/}
+dkon mchog gi za ma tog|{mdo sde zhig ste/ bam po bzhi pa/ lo tsA ba bande ratna rakshi tas bsgyur cing skad gsar bcad kyis bcos pa/}
 dkon mchog mngon rtogs|{lhag pa'i lha'i sgrub thabs shig}
 dkon mchog ta la la'i gzungs|{'phags pa dkon mchog ta la la'i gzungs/ pandi ta su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
 dkon mchog dpang btsugs|{mna' skyel ba'i tshig}
@@ -1007,11 +1016,11 @@ dkyil 'khor can|{(mngon) zla ba/}
 dkyil 'khor thig tshad|{rdul tshon dang/ ras bris kyi gzhal yas khang bzheng rgyu'i cha tshad/}
 dkyil 'khor bdag po|{rgyud sde spyi dang bye brag gi lha'i gtso bo/}
 dkyil 'khor sdings|{gzhal yas khang gi dkyil phyogs sam/ lte ba'i phyogs/}
-#dkyil 'khor yongs dag gnas yongs dag ste gsang sngags kyi thabs mkhas khyad chos bzhi'i gras gnas yongs su dag pa|
+dkyil 'khor yongs dag|{gnas yongs dag ste gsang sngags kyi thabs mkhas khyad chos bzhi'i gras gnas yongs su dag pa}
 dkyil gu|1) {lham gyi snga rting dang phyi rting bar gyi rgyong byed shing gru bzhi/} 2) {shing chas bzo skabs kyi shing rtsab bam shing gzer/}
 dkyil rgyud|{lte ba'am/ sked pa'i rgyud/}
 dkyil sgo|{sgo dbus ma/}
-#dkyil chog yi dam lha'i dkyil 'khor gyi las byang|
+dkyil chog|{yi dam lha'i dkyil 'khor gyi las byang/}
 dkyil thang|1) {gsang sngags kyi yi dam lha'i dkyil 'khor gyi thang ga/} 2) {thang ga cha tshang ba zhig gi dkyil du yod pa'i gtso thang/}
 dkyil thad|{dbus kyi thad/ sa cha'i dkyil thad/ khrom gyi dkyil thad/}
 dkyil thig|1) {ri mo sogs kyi lte bar 'khel ba'i thig /}2) {dkyil 'khor gyi ri mo/}
@@ -1028,10 +1037,10 @@ dkyu bo|{(rnying) cas cus sam 'chus po/}
 dkyu sa|{rta rgyug sa'i lam/ mi 'gro sar mi 'gro/ rta dkyu sar rta dkyu/}
 dkyus|{/}1. {dkyu ba'i skul tshig }2. 1) {srid dam/ gzhung/ mig dkyus ring ba/} 2) {rgyu spun gyi rgyu/} 3) {dpe cha'i gzhung dngos/}
 dkyus dkar|{dkar yol dkyus ma/}
-#dkyus gcig gzhung gcig pa'am star gcig pa|
+dkyus gcig|{gzhung gcig pa'am star gcig pa/}
 dkyus ja|{rgyun du 'thung rgyu'i ja spus ka phal pa/}
 dkyus btags|{kha btags dkyus ma/}
-dkyus thag ring tshad|{lung pa dkyus thag ring po/ dkyus thag ring thung 'tshams po/}
+dkyus thag|{ring tshad/ lung pa dkyus thag ring po/ dkyus thag ring thung 'tshams po/}
 dkyus thog bcad pa|{rta rgyug rtsal gzhan las lhag pa'i khyad chos bton pa/}
 dkyus pa|{dkyu ba'i 'das pa/}
 dkyus bur|{bu ram dkyus ma/}
@@ -1061,9 +1070,8 @@ bka'|1) {gsung ste skad cha'i zhe sa/ rim pa gong ma'i bka'/ ji ltar bka' bstsal
 bka' bkod|{bka' khyab dang bkod pa/ bka' bkod khang/ bka' bkod sdings cha/ bka' bkod pa/}
 bka' bkyon|{sdigs mo'am gshe gshe/ las don byas nyes la bka' bkyon gnang ba/ bka' bkyon drag po gnang ba/ bka' bkyon med pa zhu rgyu/}
 bka' khyab|{ngag bkod/}
-bka' khyab|{khrims thag bcad pa'i dpyad mtshams khra ma/}
-bka' khra gtan tshigs|{phugs thub kyi dpyad mtshams/}
-#bka' khra gtan tshigs thu mo che|
+bka' khra|{khrims thag bcad pa'i dpyad mtshams khra ma/}
+bka' khra gtan tshigs|{phugs thub kyi dpyad mtshams/ bka' khra gtan tshigs thu mo che/}
 bka' khrims|{khrims/ bka' khrims gsar du bcas/ bka' khrims kyis bda' 'ded byed/}
 bka' khrims kyi ga'u le|{bka' khrims kyi sa bcad go rim bkod deb/}
 bka' khrims tshod lon|{bka' khrims kyi nyams lon nas mthong chung byed pa/}
@@ -1077,9 +1085,10 @@ bka' 'go|{sngar bod kyi bka' shag nas btang ba'i 'go mchan te snyan zhu'i 'gor b
 bka' 'go dam dmar|{sngar bod sa gnas srid gzhung skabs tA la'i bla ma'am/ srid skyong nas btang ba'i 'go mchan te snyan zhu'i 'gor bkod pa'i yi ge mtshal dam can/}
 bka' 'gyangs|{dus 'gyangs/ bka' 'byangs gnang skyong yod pa zhu/}
 bka' 'gyur|{sangs rgyas kyis gsungs pa'i bka' sde snod gsum dang/ rgyud sde bzhi bod du 'gyur ro cog phyogs gcig tu bsgrigs pa glegs bam brgya dang bzhi'am brgyad yod do/}
-bka' 'gyur ri nyag mtsho sngon zhing chen khongs mtsho nub sog rigs bod rigs ha sag rigs rang skyong khul then cun rdzong gi la zhig bka' 'grel|{bka'i don gsal bar 'byed pa/}
+bka' 'gyur ri nyag|{mtsho sngon zhing chen khongs mtsho nub sog rigs bod rigs ha sag rigs rang skyong khul then cun rdzong gi la zhig}
+bka' 'grel|{bka'i don gsal bar 'byed pa/}
 bka' 'gros chen mo drug|{rje'i sku 'tsho zhing zho sha slar dbul ba dang rgod kyi gnya' mnan zhing yang kheng gi rgyab brten pa/ kheng rgod du mi btang zhing mo btsun bka' la mi gdags pa/ sa mtshams srung zhing 'bangs kyi tshal zhing rta dkyus kyis mi gcad pa/ dgra 'dul zhing 'bangs skyong ba/ dge bcu sgrub cing mi dge ba bcu spong ba (ab hier nacherfasst) ste srong btsan sgam po'i skabs bod du lag len bstar ba'i bya gzhag gi rigs shig}
-bka' brgya|1) {gsang ba dam po'i don/} 2) {bka' yig dam 'byar ma/ bkag sdom bka' rgya/}
+bka' rgya|1) {gsang ba dam po'i don/} 2) {bka' yig dam 'byar ma/ bkag sdom bka' rgya/}
 bka' rgya ma|{gsang ba dam por byed dgos pa'i yi ge/}
 bka' sgyur|{gong rim gyi gsung bkod gzhan la sgrog pa/}
 bka' sgrog pa|1) {bka' khyag bsgrags gtong ba/} 2) {rgyal ba'i gsung rab klog pa/}
@@ -1117,13 +1126,12 @@ bka' drin bsam shes|{bka' drin shes shing bsam pa/ bka' drin bsam shes kyis zhab
 bka' drung|{sngar bod kyi bka' shag gi drung yig}
 bka' gdams glegs bam|{bka' gdams pha chos dang bu chos kyi po ti/}
 bka' gdams rnying ma|{'brom ston rje nas rje tsong kha pa'i bar gyi bka' gdams lha chos bdun ldan gyi brgyud 'dzin snga rabs/}
-bka' gdams gdams ngag lta ba gtso bor ston pa jo bo'i gdams ngag spyan snga ba nas brgyud pa'i bden bzhi'i khrid|{phu chung ba nas brgyud pa'i rten 'brel gyi khrid/ rnal 'byor pa nas brgyud pa'i bden gnyis kyi khrid bcas/}
-bka' gdams pa|{sangs rgyas kyi bka' las}
-yig 'bru gcig kyang ma lus par tshang ma gdams ngag tu go ba'i grub mtha' zhig ste|{jo bo rje a ti sha nas dbu brnyes/ 'brom ston pa rgyal ba'i 'byung gnas kyis srol phyes/ po to ba dang/ spyan snga ba/ phu chung ba bcas sku mched gsum gyis dar zhing rgyas par mdzad/ glang ri thang pa dang sha ra ba gnyis dang/ bya yul ba sogs kyis de bas kyang rgyas par mdzad/ bka' gdams pa'i slob brgyud yongs su grags pa la gzhung pa dang gdams ngag pa gnyis sam/ yang na man ngag pa dang gsum du gyes so/}
+bka' gdams gdams ngag|{lta ba gtso bor ston pa jo bo'i gdams ngag spyan snga ba nas brgyud pa'i bden bzhi'i khrid/ phu chung ba nas brgyud pa'i rten 'brel gyi khrid/ rnal 'byor pa nas brgyud pa'i bden gnyis kyi khrid bcas/}
+bka' gdams pa|{sangs rgyas kyi bka' las yig 'bru gcig kyang ma lus par tshang ma gdams ngag tu go ba'i grub mtha' zhig ste/ jo bo rje a ti sha nas dbu brnyes/ 'brom ston pa rgyal ba'i 'byung gnas kyis srol phyes/ po to ba dang/ spyan snga ba/ phu chung ba bcas sku mched gsum gyis dar zhing rgyas par mdzad/ glang ri thang pa dang sha ra ba gnyis dang/ bya yul ba sogs kyis de bas kyang rgyas par mdzad/ bka' gdams pa'i slob brgyud yongs su grags pa la gzhung pa dang gdams ngag pa gnyis sam/ yang na man ngag pa dang gsum du gyes so/}
 bka' gdams pha chos bu chos|{jo bo yab sras kyi gsung ? chos bka' gdams glegs bam du grags pa'i man ngag ste pha 'brom ston pa rgyal ba'i 'byung gnas kyis zhus pa la pha chos/ bu rngog lo legs pa'i shes rab dang/ khu ston brtson 'grus g.yung drung gnyis kyis zhus pa la bu chos su grags/}
 bka' gdams pho brang|{rwa sgreng dang bkra shis lhun po'i gzim chung re'i ming/}
 bka' gdams rtsa gzhung|{lta ba gtso bor ston pa jo bo rjes mdzad pa'i bden gnyis la 'jug pa dang/ dbu ma'i man ngag sogs dang/ spyod pa gtso bor ston pa spyod bsdus sgron me dang/ spyod bsdus sogs/ gnyis ka ston pa byang chub lam sgron bcas/}
-bka' gdams gzhung drug bka' gdams pa'i dge ba'i bshes gnyen rnams kyis nyams len mdzad pa'i gzhung gtso bo drug ste|{skyes rabs dang ched du brjod pa'i tshoms gnyis dad pa'i gzhung dang/ byang sa dang mdo sde rgyan gnyis ting nge 'dzin gyi gzhung dang/ spyod 'jug dang bslab btus gnyis spyod pa'i gzhung rnams so/}
+bka' gdams gzhung drug|{bka' gdams pa'i dge ba'i bshes gnyen rnams kyis nyams len mdzad pa'i gzhung gtso bo drug ste/ skyes rabs dang ched du brjod pa'i tshoms gnyis dad pa'i gzhung dang/ byang sa dang mdo sde rgyan gnyis ting nge 'dzin gyi gzhung dang/ spyod 'jug dang bslab btus gnyis spyod pa'i gzhung rnams so/}
 bka' gdams gsar ma|{rje tsong kha pa nas bzung bka' gdams pa'i rnam thar dang mdzad spyod gzhir bzhag thog dbu ma'i lta ba dang gsang sngags kyi thabs lam bsnan pa'i dge lugs pa'i ming gi rnam grangs/}
 bka' gdams lha chos bdun|{thub dbang/ spyan ras gzigs/ sgrol ma/ mi g.yo ba ste lha bzhi dang/ sde snod gsum ste chos gsum bcas bdun/}
 bka' gdams lha bzhi|{thub pa dang/ spyan ras gzigs/ mi g.yo ba/ sgrol ma bcas so/}
@@ -1185,15 +1193,15 @@ bka' zhu dam 'bebs|{sger dbang gi sa rigs sogs la rang 'dod kyi gtan tshigs yi g
 bka' bzhi pa|{gzhung chen po dbu phar 'dul mdzod bcas bzhi sbyangs te dam bca' bzhag pa'i dge bshes/}
 bka' bzang spyi smin|{yig lan gtong rogs zhes pa/}
 bka' yang dag pa'i tshad ma|{khri srong lde'u btsan gyis brtsams pa'i tshad ma'i bstan bcos shig}
-#bka' yig gong rim nas gnang ba'i yi ge|
+bka' yig|{gong rim nas gnang ba'i yi ge/}
 bka' rams pa|{bka' rab 'byams pa ste gsung rab mtha' yas pa shes pa'i mkhas pa/}
 bka' lan|1) {brda lan/} 2) {yig lan/}
 bka' lung|1) {gong ma'i bka' shog} 2) {sangs rgyas kyi gsung gi lung bstan/} 3) {lha'i mo brtag}
 bka' log pa|{grwa pa log pa/}
-bka' shag sngar gyi bod sa gnas srid gzhung ste ching rgyal rabs gnam skyong rgyal po'i khri lo bcu drug par 'gyur med rnam rgyal gyi zing 'khrug byung rkyen de snga cun wang ngam pe tses chab srid kyi gtso 'gan 'khur ba'i lam lugs kha bsgyur gyis skya gsum ser gcig tshud pa'i bka' blon bzhi bskos pa dang|{gzhan yang bka' drung gnyis dang/ bka' mgron bzhi/ gzim 'gag bzhi/ e drung gnyis bcas yod pa'i bka' shag gsar 'dzugs byas pa des bod bzhugs am ban dang/ tA la'i bla ma gnyis kyi bka' bkod gzhir bzhag gis bod sa gnas kyi las don thag gcod byed cing/ 1959 lor rgyal srid spyi khyab khang gis bka' phab pa ltar mjug bsgril ba red/ (1751 )}
-bka' shag 'gag bka' drung gnyis dang bka' mgron bzhi 'tshog sa'i las khungs shig yin zhing|{las 'gan ni bka' bsgyur rgyu dang yig rigs gtong len byed rgyu de yin/}
+bka' shag|{sngar gyi bod sa gnas srid gzhung ste ching rgyal rabs gnam skyong rgyal po'i khri lo bcu drug par 'gyur med rnam rgyal gyi zing 'khrug byung rkyen de snga cun wang ngam pe tses chab srid kyi gtso 'gan 'khur ba'i lam lugs kha bsgyur gyis skya gsum ser gcig tshud pa'i bka' blon bzhi bskos pa dang/ gzhan yang bka' drung gnyis dang/ bka' mgron bzhi/ gzim 'gag bzhi/ e drung gnyis bcas yod pa'i bka' shag gsar 'dzugs byas pa des bod bzhugs am ban dang/ tA la'i bla ma gnyis kyi bka' bkod gzhir bzhag gis bod sa gnas kyi las don thag gcod byed cing/ 1959 lor rgyal srid spyi khyab khang gis bka' phab pa ltar mjug bsgril ba red/}
+bka' shag 'gag|{bka' drung gnyis dang bka' mgron bzhi 'tshog sa'i las khungs shig yin zhing/ las 'gan ni bka' bsgyur rgyu dang yig rigs gtong len byed rgyu de yin/}
 bka' shags|{(rnying) gdong bsher rgyag pa/}
-bka' shog gong rim nas gnang ba'i yi ge|{bka' shog tham ldan/ don gnad 'di bka' shog tu gsal/ bka' shog bkram/}
+bka' shog|{gong rim nas gnang ba'i yi ge/ bka' shog tham ldan/ don gnad 'di bka' shog tu gsal/ bka' shog bkram/}
 bka' srung|{chos skyong srung ma/}
 bka' slob|{bslab bya/ bka' slob gsal po gnang song/}
 bka' gsal|{lan gsal/ byed sgo'i skor snyan seng zhus par bka' gsal phebs yod pa/}
@@ -1203,16 +1211,16 @@ bka'i rnga bo che|{bka' gsal bsgrags byed pa de rnga bo che'i gzugs su bkod pa/}
 bka'i cod pan|{bka' cod pan gyi gzugs su bkod pa/ bka'i cod pan spyi bor bcings/}
 bka'i mdun blon|{rgyal po'i mdun du 'khod pa'i blon po/}
 bka'i spring blon|{(rnying) bka' blon chen po/}
-bka'i phyag rgya drug bka' rtags kyi phyag rgya sgrom bu dang|{khrom rtags kyi phyag rgya ru mtshon/ yul rtags kyi phyag rgya sku mkhar/ chos rtags kyi phyag rgya lha khang/ dpa' rtags kyi phyag rgya stag slog mdzangs kyi phyag rgya yig tshang ste srong btsan sgam po'i skabs bod du lag len bstar ba'i bya gzhag rigs gcig}
+bka'i phyag rgya drug|{bka' rtags kyi phyag rgya sgrom bu dang/ khrom rtags kyi phyag rgya ru mtshon/ yul rtags kyi phyag rgya sku mkhar/ chos rtags kyi phyag rgya lha khang/ dpa' rtags kyi phyag rgya stag slog mdzangs kyi phyag rgya yig tshang ste srong btsan sgam po'i skabs bod du lag len bstar ba'i bya gzhag rigs gcig}
 bka'i phying sang|{(rgya) blon po/}
 bka'i lus|{gsung rab kyi gzhung dngos gzhi/}
 bkar skyin|{bkar mdzod nas bton te bskyar du 'jug pa rnams/}
 bkar khang|{phugs gsog gi 'bru sogs dngos rigs 'jug khang/}
 bkar rgya|{bkar mdzod kyi phyi nang dam rgya/ bkar rgyar 'jug pa/}
 bkar rgya ba|{bkar khang bdag gnyer byed mkhan/}
-#bkar 'jug logs su bcug nas 'jog rgyu|
+bkar 'jug|{logs su bcug nas 'jog rgyu/}
 bkar 'jug pa|{dngos rigs bkar 'jug rgyag mi/}
-#bkar 'jog logs su bkar te 'jog pa|
+bkar 'jog|{logs su bkar te 'jog pa/}
 bkar btags|1) {thugs la mnga' ba'am/ nges par byas pa/} 2) {dam la btags pa/} 3) {dus dang rnam pa kun tu yang yang gsungs pa'i chos kyi sdom tshig}
 bkar btags bzhi|{lta ba bka' rtags kyi phyag rgya bzhi dang don gcig}
 bkar btags gsum|{bkar btags kyi phyag rgya gsum ste/ chos thams cad bdag med pa/ 'dus byas thams cad mi rtag pa/ zag bcas thams cad sdug bsngal ba/}
@@ -1234,7 +1242,8 @@ bkug pa|{'gugs pa'i 'das pa/}
 bkums pa|{'gums pa'i 'das pa/}
 bkur sti|{brtsi bkur ram/ bsnyen bkur/ slob dpon la bkur sti byed pa/ rgan rgon rnams la bkur sti byed 'os/ ming gi rnam grangs la bkur ba dang/ gus bkur/ bsnyen bkur/ zhabs tog zhabs 'bring/ ri mor byed/ rim gro bcas so/}
 bkur ba|{(tha dad pa) mchod pa dang/ nye bar gnas pa/ mang pos bkur ba/ lha ltar bkur ba/ pha ma gong du bkur ba/}
-bkur tshig bstod pa'i tshig bkur bzos|{che bstod/ yon tan can la bkur bzos byed pa/}
+bkur tshig|{bstod pa'i tshig}
+bkur bzos|{che bstod/ yon tan can la bkur bzos byed pa/}
 bkur 'os|{gong du 'khur 'os pa dang/ gus pas bkur bar 'os pa'am bsten par 'os pa/}
 bkus|{bku ba'i skul tshig}
 bkus te bor ba|{(rnying) khu ba bton pa'i snyigs ma/}
@@ -1243,15 +1252,14 @@ bkog pa|{'don pa dang sbyar sa nas mar len par go ba'i 'gog pa'i 'das pa/}
 bkong ba|{(tha dad pa) 'jigs su 'jug pa'am/ zhum du 'jug pa/ pha rol po'i spa bkong ste sems zhum par byas so/}
 bkod khyab|{gong nas 'bebs pa'i bka'/ byed sgo rnams 'thus tshang yong ba'i bkod khyab nan po byed pa/}
 bkod rgya|{las khungs so sos gsham du btang ba'i yi ge / bkod rgya 'di bzhin lag len byed dgos/}
-bkod sgrig bkod pa btang nas gra sgrig byed pa|{gcig gyur gyis bkod sgrig byed pa/}
+bkod sgrig|{bkod pa btang nas gra sgrig byed pa/ gcig gyur gyis bkod sgrig byed pa/}
 bkod 'chun|{ngag bkod kyis bcun nas 'chun pa/}
 bkod 'doms|1) {bkod pa/ dmag las la bkod 'doms byed pa/ blo 'dod ltar bkod 'doms byed pa/ bkod 'doms nor ba/} 2) {bkod pas 'doms pa ste/ bkod pa btang nas 'chun pa/ 'grim 'grul bkod 'doms/ khrims 'gal nyes can rnams la bkod 'doms byas pa/}
 bkod ldan|1) {khyim bcu gnyis kyi gzhu yi khyim/} 2) {zla ba bcu gcig pa'am dgun zla 'bring po/}
 bkod pa|1. {'god pa'i 'das pa/ }2. {thabs shes/ bkod pa gtong ba/ khang pa 'di'i bkod pa ha cang legs/ las ka la bkod pa gtong ba/ bkod pa rang gi sems na yod/ rtsam pa rtsam sgye'i nang na yod/}
 bkod pa mtha' yas|{byang sems shig gi mtshan/}
 bkod pa mdzes pa|1) {sgrig stangs legs pa/} 2) {sangs rgyas shig gi mtshan/}
-bkod pa bshad pa|{bkod thabs nan pos}
-btul ba|{mi ngan nyes can la khrims sa nas bkod pa bshad de phyis lam 'doms pa bzos yod/}
+bkod pa bshad pa|{bkod thabs nan pos btul ba/ mi ngan nyes can la khrims sa nas bkod pa bshad de phyis lam 'doms pa bzos yod/}
 bkod pa'i gtsug tor|{lha khro bo zhig}
 bkod byus|{dbang sgyur mkhan gyi bkod pa dang byus/ bkod byus mkhas pa/}
 bkod 'brel|{gong rim gyi ngag bkod dang 'brel ba/}
@@ -1266,7 +1274,7 @@ bkyag pa|{'gyog pa'i ma 'ongs pa/}
 bkyags pa|{'gyog pa'i 'das pa/}
 bkyal ba|{don med dam 'brel med kyi ngag ngag bkyal/ tshig bkyal/}
 bkyi ba|{bkyil ba dang 'dra/}
-bkyig thag sdom byed kyi thag pa|{bkyig thag gis bsdams nas bzhag bkyig thag glod pa/}
+bkyig thag|{sdom byed kyi thag pa/ bkyig thag gis bsdams nas bzhag  bkyig thag glod pa/}
 bkyig pa|{'khyig pa'i ma 'ongs pa/}
 bkyigs pa|{'khyig pa'i 'das pa/}
 bkyil ba|{(rnying) gdams ngag mi sbyin pa/}
@@ -1291,7 +1299,8 @@ bkra shis dgu tshigs|1) {mgo bo'i rus chag gso ba dang/ chu ser skem pa/ klad sk
 bkra shis sgo mang|1) {mchod rten bkra shis sgo mang/} 2) {'bras spungs sgo mang grwa tshang/} 3) {bla brang bkra shis 'khyil dgon pa'i ming/}
 bkra shis sgor mo|1) {rten 'brel gyi bzhugs gral khyad par ba zhig} 2) {rten 'brel gyi ru sgrig khyad par ba zhig} 3) {bkras sgor te sngar bod sa gnas srid gzhung gi rten 'brel mdzad sgo'i skabs drung rigs ser skya la 'grems sprod byed pa'i kha zas kyi ming zhig}
 bkra shis brgyad pa|{'phags pa bkra shis brgyad pa zhes bya ba'i mdo/ sho lo ka lnga bcu rtsa gcig pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa/}
-bkra shis mchog bkra shis tshal te dur khrod chen po brgyad kyi gras shig bkra shis rtags brgyad|{dpal be'u dang/ pad ma/ gdugs/ dung/ 'khor lo/ rgyal mtshan/ bum pa/ gser nya ste brgyad/}
+bkra shis mchog|{bkra shis tshal te dur khrod chen po brgyad kyi gras shig}
+bkra shis rtags brgyad|{dpal be'u dang/ pad ma/ gdugs/ dung/ 'khor lo/ rgyal mtshan/ bum pa/ gser nya ste brgyad/}
 bkra shis them pa yar 'dzegs|{gsham nas gong du rim bzhin 'go 'dzugs pa/}
 bkra shis dar ras|{legs pa'i rten 'brel mtshon byed kyi rdzas shig}
 bkra shis dung|{(mngon) dung g.yas 'khyil/}
@@ -1306,9 +1315,9 @@ bkra shis tshe ring ma|{jo mo glang ma ri'i lha mo tshe ring mched lnga'i ya gya
 bkra shis rdzas brgyad|{me long dang/ zho/ rtswa dur ba/ shing tog bil ba/ dung g.yas 'khyil/ ghi wang/ li khri/ yungs kar te brgyad/}
 bkra shis zla ba|{tshes grangs chad lhag med pa'i zla ba/}
 bkra shis lugs legs|{'khon rtsod med par bsam don 'grub pa/}
-bkra shis legs skyes|{rten 'brel dga' ston}
-#gyi dus su sprod pa'i dngos rdzas|
-bkra shis shog phun sum tshogs par shog ces smon pa'i tshig bkra shis gso sbyong|{mthun pa'i gso sbyong las dus ma nges pa'i gso sbyong gi gras shig ste/ rab gnas sogs bkra shis pa'i dus dang/ char dang than pa/ rgyal po ngan pa sogs bkra mi shis pa rnams shis par bya ba'i dus su byed pa'i gso sbyong/}
+bkra shis legs skyes|{rten 'brel dga' ston gyi dus su sprod pa'i dngos rdzas/}
+bkra shis shog|{phun sum tshogs par shog ces smon pa'i tshig}
+bkra shis gso sbyong|{mthun pa'i gso sbyong las dus ma nges pa'i gso sbyong gi gras shig ste/ rab gnas sogs bkra shis pa'i dus dang/ char dang than pa/ rgyal po ngan pa sogs bkra mi shis pa rnams shis par bya ba'i dus su byed pa'i gso sbyong/}
 bkra shis lha rgyal|{bkra shis pa'i bya ba zin pa'i mjug tu bsangs dud dang 'brel ba'i rtsam phye gtor te lha rgyal 'bod pa/}
 bkra shis lhun po|{gtsang phyogs kyi dge lugs dgon chen zhig ste/ rab byung brgyad pa'i me yos lor tA la'i bla ma sku phreng dang po dge 'dun grub kyis phyag btab cing/ rje blo bzang chos rgyan nas bzung pan chen sku phreng rim byon gyi gdan sa zhig}
 bkrag 'od kyi mdangs|{lus stobs rgyas te gdong la bkrag thon pa/ yun ring na nas gdong gi bkrag shor ba/}
@@ -1316,7 +1325,7 @@ bkrag mdangs|{mdangs kyi 'od/ bkrag mdangs 'tsher ba/ zhal gyi bkrag mdangs zla 
 bkrag med pa|1) {'od mdangs med pa/} 2) {gzi mdangs nyams pa/}
 bkrag rtsi|{tshon gyi steng du 'od 'don byed kyi rtsi/}
 bkrag rtsi'i snum|{bkrag rtsi bzo ba'i snum/}
-bkrag shog snum shog gam|{shel shog ste/ chus 'jig dka' ba'i shog bu/}
+bkrag shog|{snum shog gam/ shel shog ste/ chus 'jig dka' ba'i shog bu/}
 bkrag lhag ge ba|{'od mdangs rab tu gsal ba/ nyi zla'i 'od mdangs bkrag lhag ge bar gsal/}
 bkrab pa|{(tha dad pa) bkrabs pa/ bkrab pa/ bkrobs// 'dems pa/ sa bon legs par bkrab/ 'os mi'i nang nas drag shos bkrab rgyu/}
 bkrabs pa|{bkrab pa'i 'das pa/}
@@ -1331,13 +1340,13 @@ bkri ba|{(tha dad pa) bkris pa/ bkri ba/ bkris// 'khrid pa/ lam bzang la bkri ba
 bkris|{bkri ba'i skul tshig}
 bkris pa|{bkri ba'i 'das pa/}
 bkru 'jam|{rlung nad la mi 'da' ba'i 'jam rtsi'i sbyor ba'i nang tshan rlung mkhris ldan par bsngags pa'i bkru 'jam gyi sbyor ba ste/ chur gnas kyi sems can sbal lcong sogs kyi sha khu dang/ ba'i 'o ma dang mar zhun bcas steng ru rta dang/ de ba dA ru/ pi pi ling/ rgyam tsha/ a ru ra/ dur byid rnams kyi phye ma sbyar te bshang lam nas mas btang bya dgos pa'i sman zhig}
-#bkru dag mna' bskyal te dag par byas pa|
+bkru dag|{mna' bskyal te dag par byas pa/}
 bkru ba|{'khrud pa'i ma 'ongs pa/}
 bkru ma slen|{rlung nad la mi 'da' ba'i 'jam rtsi'i sbyor ba'i nang tshan bad rlung ldan par bsngad pa'i bkru ma slen gyi sbyor ba ste/ skam na gnas pa'i srog chags rnams kyi sha khu dang/ ra'i 'o ma dang zhun mar bcas kyi steng/ ru rta dang/ de ba dA ru/ pi pi ling/ rgyam tsha/ a ru ra/ po so cha rnams kyi phye ma sbyar te bshang lam nas mas btang bya dgos pa'i sman zhig}
 bkru sman|{dur byid dang thar nu lta bu sa chu'i nus pa shas cher las byung ba'i sman mkhris nad sogs rgyu long gi nad thur du bkru bar nus pa'i bshal sman spyi la zer/}
 bkru bshal|{bkrus nas gtsang bshal gtong ba/}
 bkrums|{(rnying) phye mar gsil ba/}
-#bkrus chag sngar gyi yul srol du mna' skyel dag 'bud byas na khral 'bab chag pa|
+bkrus chag|{sngar gyi yul srol du mna' skyel dag 'bud byas na khral 'bab chag pa/}
 bkrus pa|{'khrud pa'i 'das pa/}
 bkren rngam|{nor rdzas la 'dod pa che ba/}
 bkren pa|1) {nor med dbul phongs/ mi tshang bkren pa/ 'tsho ba bkren tsam 'ong bar 'dug grwa pa bkren pa/} 2) {ser sna chen po/ lag pa bkren pa/}
@@ -1367,10 +1376,10 @@ rka deb|{rka chu 'dren tho ste/ chu rka bzo mkhan gyi mi gtong stangs dang/ chu 
 rka 'ba' sum mdo|{sa ming zhig da lta mtsho sngon zhing chen mtsho lho bod rigs rang skyong khul gyi khongs thung te rdzong mi dmangs srid gzhung gnas yul yin/}
 rka tsam|{(rnying) skad cig tsam mam ska cig tsam/}
 rka zhing|{chu rka dang ldan pa'i zhing/}
-rkang ru lhung pa|{(rnying) lus zungs zad pa/}
+rka ru lhung pa|{(rnying) lus zungs zad pa/}
 rkang|1) {rus pa'i nang gi rkang mar/} 2) {rtsa ba dang rang bzhin nam spus ka/ las 'gan gyi rkang 'khris pa/ go skabs rkang nas med/ mi rkang ngan pa/ ras rkang legs pa/} 3) {cha shas/ tshong rkang/ skar rkang/} 4) {sngar bod sa gnas su khral zhing rtsi stangs shig ste spyir btang rkang gnyis la 'don re brtsi rgyu/} 5) {nyag ma/ shing rkang gcig skra rkang gsum/ skud pa rkang gcig}
 rkang kor|{rkang rgyan gdu bu/}
-rkang kyog rkang pa la skyon shor ba|{mi rkang kyog}
+rkang kyog|{rkang pa la skyon shor ba/ mi rkang kyog}
 rkang krab|1) {thags mkhan gyi rkang pas rgyu'i snal ma'i bkad 'degs 'jog re mos byed pa'i thags chas shig} 2) {tshem bu'i 'khor lo'i rkang shing/}
 rkang dkris|{rkang par dkri bya'i ras/}
 rkang bkra ma|{(mngon) bya rkang pa khra khra ri sked/}
@@ -1384,7 +1393,7 @@ rkang 'khrab|{bro gar 'khrab pa/}
 rkang 'khrab lag 'khrab|1) {'bad brtson gang thub thub byed pa/} 2) {lus kyis zug rngu ma bzod pa'i rnam 'gyur/} 3) {sems dga' drags pa'i rnam 'gyur/}
 rkang 'khrab lag g.yob|{rkang pas 'khrab cing/ lag pas g.yab g.yob byed pa ste/ brel ba chen po'i dpe/ dus mnyam du las don khag mang bya dgos pas rkang 'khrab lag g.yob lta bu byung/}
 rkang gos|{(mngon)} 1) {lham/} 2) {dor ma/}
-#rkang gyog rkang pa 'theng po|
+rkang gyog|{rkang pa 'theng po/}
 rkang gyol po|{rkang pa kyog kyog}
 rkang gra 'grig po|{dmag dpung ru bsgrigs te 'gro skabs kyi rkang 'gros gcig mtshungs/}
 rkang gla|{bang chen sogs la sprod pa'i gla cha/}
@@ -1399,7 +1408,8 @@ rkang 'gro'i khral 'ul|{rta khal mi gsum gyi khral ming/}
 rkang 'gros|{rkang pa'i 'gro stangs/}
 rkang rgyan|{rkang gdub sogs rkang pa'i rgyan cha/}
 rkang rgyu|{rkang thang du 'gro ba/}
-rkang sgrog rkang par rgyag rgyu'i sgrog rkang brgya ma|{'bu phra la ring ba rkang lag mang po yod pa zhig}
+rkang sgrog|{rkang par rgyag rgyu'i sgrog}
+rkang brgya ma|{'bu phra la ring ba rkang lag mang po yod pa zhig}
 rkang brgya lag brgya|{'bu phra la ring ba rkang lag mang po yod pa zhig}
 rkang ngar|{rkang pa'i ngar gdong ste/ pus mo nas long tshigs bar gyi mdun ngos kyi rus pa/}
 rkang dngul|1) {ma rkang gi dngul/} 2) {rkang la 'khri ba'i dngul khral/}
@@ -1439,7 +1449,7 @@ rkang gdos|{nyes can gyi rkang par rgyag pa'i lcags sgrog}
 rkang 'don|{sngar khral 'khri'i sa rten brtsi stangs rkang zhes pa dang 'don zhes pa gnyis kyi ming/ rkang 'dred/ rkang pa 'byid pa/ rkang 'dred shor te sar 'gyel/}
 rkang 'dren pa|{zhabs 'dren zhu mkhan te rang phyogs kyi la rgyar gnod pa'i ming shas bzo mkhan/ bu ngan pha ma bzang po'i rkang 'dren pa/ mi ngan rang yul gyi rkang 'dren pa/}
 rkang rdum pa|{long tshigs man gyi rkang mgo chad pa'i mi/}
-#rkang rdog lham gyi rdog pa|
+rkang rdog|{lham gyi rdog pa/}
 rkang sdom|{gzas rkang longs longs spyad zin pa dang ma zin pa gang rung sdom pa'i chu tshod/}
 rkang brdab|{rkang pa sar brdab pa/ khong khro langs te rkang brdab lag brdab byed pa/}
 rkang snam|{dor ma'am gos thung/}
@@ -1468,7 +1478,7 @@ rkang mang|{(mngon) sdig srin nam/ rkang pa mang ba'i 'bu rigs/}
 rkang mar|{sems can gyi brla rkang dang/ dpung rkang rnams las byung ba'i rkang sbubs kyi mar/ ming gi rnam grangs la khu ba byed dang/ mdangs so/}
 rkang mig pa|{sngar rgya gar gyi grub mtha' smra ba'i ston pa zhig ste/ sngon gyi gtam rgyud du sangs rgyas shAkya thub pa 'jig rten du ma byon gong rgya gar gyi drang srong mdzes pa zhes bya ba zhig lha dbang phyug gis lha mo au ma'i srung mar bzhag pa na/au ma drang srong la chags pas sgeg pa'i rnam 'gyur mang du bstan kyang/ khong gis rkang par mig phab ste brtul zhugs bsrungs pas lha dbang phyug mnyes te bstan bcos rtsom pa'i mchog sbyin nas drang srong rkang mig pa zhes phyi rol pa'i ston par gyur nas phyogs chos kyi tshigs dgu sogs gtan tshigs rig pa'i srol btod ces grags/}
 rkang med|{(mngon) sbrul/}
-rkang dmag rkang thang gi dmag mi|{ming gi rnam grangs la rkang pas rgyu/ rkang shar ba/ dpung bu chung/ mtshon chas 'tsho ba/ rang stobs kyis bgrod/ rang thang/ lus kyis rgol/ lus kyis 'thab bcas so/}
+rkang dmag|{rkang thang gi dmag mi/ ming gi rnam grangs la rkang pas rgyu/ rkang shar ba/ dpung bu chung/ mtshon chas 'tsho ba/ rang stobs kyis bgrod/ rang thang/ lus kyis rgol/ lus kyis 'thab bcas so/}
 rkang btsugs|1) {gzhi rtsa btsugs pa/} 2) {ched du/ da res nga tsho rkang btsugs nas khyed rang gi drung du bka' lan zhu bar yong ba yin/}
 rkang rtsa|1) {lus kyi rkang pa'i khrag rtsa/} 2) {gzhi rkang ngam/ ma rtsa/}
 rkang rtse|{rkang pa'i mdun gyi sne mo/}
@@ -1479,7 +1489,7 @@ rkang tshegs|{rkang thang du 'gro ba'i dka' ngal/ grong yul 'grim rgyu rkang tsh
 rkang mdzes|{(mngon) mya ngan med pa'i shing/}
 rkang 'dzin|{las 'gan gtso bo 'khur mkhan/}
 rkang zha lag 'theng|1) {rkang lag gnyis kar skyon shor ba/} 2) {khag 'dogs/ rang 'khris las 'gan sgrub skabs rkang zha lag 'theng byas na mi 'grig}
-#rkang bzhag rkang pa'i brla sha|
+rkang bzhag|{rkang pa'i brla sha/}
 rkang bzhi|{(mngon)} 1) {rkang pa bzhi yod pa'i dud 'gro spyi'i ming/} 2) {byed pa bcu gcig nang gi bzhi mdo'i ming/}
 rkang bzhi'i nor ldan|{(mngon) 'brog pa/}
 rkang zam|1) {rkang thang bgrod pa'i zam pa/} 2) {bang mi/}
@@ -1487,7 +1497,7 @@ rkang 'og|{(mngon)} 1) {sa gzhi'am/sa cha/} 2) {sa 'og gam/ klu'i 'jig rten/}
 rkang 'og rde'u|{rkang 'og gi rde'u lta bu zhes mthong chung byed pa'i dpe/}
 rkang yon|{rkang pa skyon can nam/ rkang 'khyog}
 rkang brlag pa|{rtsa ba brlag pa/ tshong nyes byung ste ma rtsa'i rkang brlag pa/}
-rkang lag rkang pa dang lag pa'i bsdus ming|{rkang lag bzhi/ rkang lag bkyigs pa/ lus rtsa tshang ma hrengs te rkang lag brkyang bskum mi thub/}
+rkang lag|{rkang pa dang lag pa'i bsdus ming/ rkang lag bzhi/ rkang lag bkyigs pa/ lus rtsa tshang ma hrengs te rkang lag brkyang bskum mi thub/}
 rkang lag krab krab|{rkang lag gi 'gul skyod byed stangs/ khong khro langs te rkang lag krab krab byed/ dbugs chad khar rkang lag krab krab byed/}
 rkang lag 'gyus pa|{(praShAkhA:) mngal gyi gnas skabs lnga'i lnga pa'am/ mi lus mngal du chags pa'i bdun phrag lnga pa ste khu khrag gnyis yongs su smin pa las lus kyi yan lag lnga so sor grub pa'i dus skabs 'di nas bzung bdun phrag so brgyad pa'i bar smin pas sas 'dzin pa dang/ chus sdud pa/ mes ma rul par smin pa/ rlung gis rgyas par byed pa bcas kyi sgo nas lus po yongs su tshang bar 'gyur/}
 rkang lam|{rkang thang thar thub tsam gyi lam chung/}
@@ -1502,25 +1512,25 @@ rkang sor|{rkang pa'i sor mo ste mdzu gu/}
 rkang gsum|1) {lcags sogs las bzos pa'i stegs rkang pa gsum ldan/} 2) {(mngon) dre'u/}
 rkan|{kha nang gi rkan/ ya rkan/}
 rkan gyi sum mdo|{kha'i nang gi rtsa zhig}
-rkan sgra|{lce ya rkan dang sbyar nas gtogs te thon pa'i sgra/}
-#rkan sgra gtog pa|
+rkan sgra|{lce ya rkan dang sbyar nas gtogs te thon pa'i sgra/ rkan sgra gtog pa/}
 rkan rnyil|{rkan mtha'i rnyil te/ so rnyil/}
 rkan 'debs|1) {lce rkan gnyis 'thab pa/} 2) {so med rkan gyis rmur ba/}
 rkan rdeb|{rkan sgra sgrog pa/}
-rkan phug ya rkan gyi sbug rkan dbus|{ya rkan gyi dbus sam dkyil/}
+rkan phug|{ya rkan gyi sbug}
+rkan dbus|{ya rkan gyi dbus sam dkyil/}
 rkan 'brum|{rkan la skyes pa'i thor pa/}
 rkan mar|{byis pa dang rte'u sogs btsas ma thag tu khas 'jib rgyu gom ched rkan la sbyor ba'i mar 'jam po/}
 rkan rmen|{rkan la skyes pa'i thor pa/}
 rku thabs su gnas pa|{'dul ba'i brda chad cig ste/ grub mtha' smra ba gzhan pa'i gang zag cig sangs rgyas kyi dge sbyong du brdzu ba sogs rab byung min kyang yin pa'i zol gyis gnas pa/}
 rku rdo|{(rnying) rdab dkrugs sam/ dbyen sbyor phra ma/}
-rku 'phrog gzhan nor thabs kyis rku ba dang|{stobs kyis 'phrog pa/}
+rku 'phrog|{gzhan nor thabs kyis rku ba dang/ stobs kyis 'phrog pa/}
 rku ba|{(tha dad pa) brkus pa/ brku ba/ rkus// ma byin pa dang/ rin ma sprad par gzhan nor thabs kyis len pa/ gzhan nor rku ba/ 'jab bus rku ba/ brnogs te rku ba/}
 rku ba bcu|{ma byin par len pa'i thabs tshul bcu ste/ mthus rku ba dang/ sgyu thabs kyis rku ba/ 'brid pas rku ba/ gtam pas rku ba/ slar byin zer nas rku ba/ phyir bsab zer nas rku ba/ nan dgug pa'i rku ba/ dngan 'then gyis rku ba/ 'jam pos rku ba/ chos kyis rku ba rnams so/}
 rku ba'i las|{ma byin par len pa'i spyod ngan/}
 rku shas|{brkus pa'i rdzas kyi cha shas/}
 rku sems|{gzhan nor rku ba'i sems/}
 rkun rgyab rdzun langs|{tshul dang mi mthun pa la tshul dang mi mthun pas rgyab rtsa byas pa/}
-#rkun jag rkun ma dang jag pa|
+rkun jag|{rkun ma dang jag pa/}
 rkun tho|{khyim nang gi ca dngos rkun mas brkus rjes khrims khang du phul ba'i dngos tho/}
 rkun dong|{rkun pos brkus nor sbed yul gyi dong khung/}
 rkun nor|{rkun po'i nor rdzas/ ming gi rnam grangs la brku dngos dang/ rkun rdzas so/}
@@ -1530,7 +1540,7 @@ rkun dpon|{rkun ma'i 'go byed/}
 rkun bu|1) {rkun chung ngam mtheb dras pa/} 2) {rkang pa grang ba dang/ ro stod gzer zhing mig zum mi thub pa sogs kyi mchin nad cig} 3) {(mngon) byi ba/}
 rkun byi|{gzhan gyi rgyu nor ma byin par len pa po dang/ gzhan gyi chung mar gsang thabs kyis log g.yem byed pa po gnyis kyi bsdus ming/}
 rkun ma|1) {gzhan nor rku mkhan/ rta rkun/ nor rkun/ rkun mas rkun rjes gcod khul gyis ram 'degs byed/ rkun ma nang la bzhag nas sgo lcags phyi la brgyab pa/} 2) {(yul) rku byed kyi bya spyod/ rkun ma rku ba/}
-#rkun ma jag rkun jag gnyis ka byed pa'i mi ngan|
+rkun ma jag|{rkun jag gnyis ka byed pa'i mi ngan/}
 rkun ma tshabs chen|{khrims la mi 'jigs par gzhan nor mang po rku ba'i rkun ma/ rkun ma tshabs chen la khrims thag nan po gcod pa/}
 rkun ma rdzab chen|{rkun ma tshabs chen dang 'dra/}
 rkun mo|{rku byed mkhan bud med/}
@@ -1539,7 +1549,7 @@ rkun rdzas|{brkus pa'i nor rdzas/}
 rkun rogs|{rkun ma'i rogs pa/}
 rkun srung|{rkun ma'i nyen kha srung mkhan/}
 rkub|1) {'phongs/} 2) {bshang lam/ rkub tshums/ ming gi rnam grangs la 'phongs dang/ 'og sgo'o/} 3) {mthil lam zhabs/ snod kyi rkub rdol ba/}
-rkub bkyag rkub skyags kyang zer|{khri'u shing ngam/ 'phongs stegs/}
+rkub bkyag|{rkub skyags kyang zer/ khri'u shing ngam/ 'phongs stegs/}
 rkub bcad|{(rnying)} 1) {mjug 'gril ba/} 2) {thag bcad pa/}
 rkub stegs|{khri'u shing ngam/ 'phongs stegs/}
 rkub sdod|{gral gyi mtha' mar sdod pa'am/ mjug mthar lus pa/}
@@ -1569,7 +1579,7 @@ rkom tshugs|{lag pa'am dbyug pa'i rtse mor brten pa'i om tshugs/}
 rkos|1. {rko ba'i skul tshig }2. {lcags shing rdo sogs yig ris rko ba'i las ka/ rkos mkhan/}
 rkos rgyag pa|{zangs lcags shing sogs la ri mo dang/ yi ge rko ba/}
 rkya|1) {cha min pa'i ya/ chig rkya/ rang rkya/} 2) {skud pa'i rkya dang thag pa'i rkya/ skud pa rkya gcig ma/ thag pa sum rkya ma/ skud pa'i rkya bshig pa/ thag pa'i rkya bkal ba/ snam bu rkya ya ma/} 3) {(mngon) zam pa/}
-rkya rgyag phan tshun snol ba'am 'brel ba|{thag pa gnyis rkya rgyag}
+rkya rgyag|{phan tshun snol ba'am 'brel ba/ thag pa gnyis rkya rgyag}
 rkya 'thab|1) {phan tshun snol ba'am 'brel ba/ thag pa gnyis rkya 'thab rgyag pa/} 2) {ngan pa lag sbrel/ mi ngan rkya 'thab byed pa/}
 rkya pa|{skya mi dang 'dra/}
 rkya ba|{skya ba dang 'dra/}
@@ -1581,12 +1591,12 @@ rkyang|1. {lus po drel dang 'dra ba'i ri dwags shig }2. {kho na dang/ de nyid de
 rkyang dkar|{rta dang dre'u spu mdog dkar dmar 'dres pa/}
 rkyang rkyang|1) {gcig pu/ chu rkyang rkyang 'thung ba/} 2) {spu mdog rkyang po/}
 rkyang rkyong|{rkyang nge rkyong nge'i bsdus tshig}
-#rkyang khug ya dang cha|
+rkyang khug|{ya dang cha/}
 rkyang gos|{gos gcig rkyang/}
 rkyang bgod|{bgod byed kyi grangs gnas gcig las med pa'i bgo rtsis/}
 rkyang nge rkyong nge|{shes rgyud gyang nge gyong nge'am/ las ka byed snying mi 'dod pa'i gshis rgyud/ las ka hur brtson min par rkyang nge rkyong nge 'ba' zhig byed/}
 rkyang chu|{mtsho sngon zhing chen khongs mgo log bod rigs rang skyong khul gyi rma stod rdzong gi lho rgyud du yod pa'i rma chu'i chu lag cig}
-#rkyang thag thag pa ring ba|
+rkyang thag|{thag pa ring ba/}
 rkyang thang|{ri dwags rkyang sdod sa'i mi med rtswa thang/}
 rkyang 'ded|{phyogs gcig tsam la zhen nas de kho na rtsad gcod pa/ man ngag de tsam la nyams len chig dril gyis rkyang 'ded byed pa/}
 rkyang pa|1) {lhad ma med pa'i gtsang ma/ gser rkyang/ dngul rkyang/ bal rkyang/ khe bzang rkyang pa/ gcig pa gcig rkyang/ nang mi rkyang pa/} 2) {nyag gcig gam/ gcig pu/ mi so so rkyang pa/ pho mo rkyang pa/ mi rkyang rta rkyang/ grwa pa grwa rkyang/ nga rkyang pas las 'gan bsgrub thub pa/} 3) {ming rkyang/ 'phul dang/ brtsegs med pa'i ming gzhi rkyang pa/}
@@ -1624,25 +1634,25 @@ rkyen rnyed|{rkyen dang phrad pa/ bzang rkyen rnyed pa/ ngan rkyen rnyed pa/}
 rkyen bstun 'phrog bcom|{gzhan nor len bde'i go skabs btsal nas rnyed mtshams 'phrog bcom byed pa/}
 rkyen thub pa|{sran thub pa'am/ bzod thub pa/ las ka'i rkyen thub pa la snying rus che dgos/}
 rkyen theg pa|{sran thub pa'am/ bzod thub pa/ ngan pa'i nad rkyen mi theg pa/ dka' tshegs sdug bsngal gyi rkyen theg pa/}
-rkyen drug dpa' bo'i rkyen du gung dang stag dang|{sngar ma'i rkyen du wa zhu/ ya rabs kyi rkyen du lha chos/ g.yung po'i rkyen du thags dang bon/ mdzangs pa'i rkyen du yig tshang/ ngan pa'i rkyen du rkun ma ste srong btsan sgam po'i skabs bod du lag len bstar ba'i bya gzhag rigs gcig}
+rkyen drug|{dpa' bo'i rkyen du gung dang stag dang/ sngar ma'i rkyen du wa zhu/ ya rabs kyi rkyen du lha chos/ g.yung po'i rkyen du thags dang bon/ mdzangs pa'i rkyen du yig tshang/ ngan pa'i rkyen du rkun ma ste srong btsan sgam po'i skabs bod du lag len bstar ba'i bya gzhag rigs gcig}
 rkyen drung|{(rnying) sa mi phyugs gsum gyi bdag gnyer/}
 rkyen 'bab|{skabs dang 'tsham par 'byung ba/ rkyen 'bab yo byad/}
 rkyen sman|{nad gso byed kyi sman/}
 rkyen rtsi|{rkyen sman dang don gcig}
 rkyen bzhi|1) {nad gang slong bar byed pa'i rkyen rnam par bzhi ste/ dus dman lhag log pa dang/ gdon gyis blo bur du 'tshe ba/ zas dman lhag log pa/ spyod lam dman lhag log pa bcas so/} 2) {rgyu'i rkyen dang/ de ma thag rkyen/ dmigs rkyen/ bdag rkyen te bzhi/}
-rkyen zlog bar chad sel ba|{'gal rkyen zlog pa'i thabs la 'bad/}
+rkyen zlog|{bar chad sel ba/ 'gal rkyen zlog pa'i thabs la 'bad/}
 rkyen ris|{cha rkyen/}
 rkyen lam|{mtshon 'og tu 'chi ba/ rkyen lam du 'das pa/ rgyal po rkyen lam du btang ba/ mi mang po rkyen lam du gyur pa/}
 rkyen sa|{(rnying) sa gzhis/}
 rkyen sel|{bar chad med pa bzo ba/}
 rkyen gsum|1) {g.yo ba med pa'i rkyen/ mi rtag pa'i rkyen/ nus pa'i rkyen no/} 2) {dmigs rkyen dang/ bdag rkyen/ de ma thag rkyen no/}
 rkyong gdan|{bar tshangs srab cing lteb brtsegs brgyab chog pa'i gdan ring tsam zhig}
-rkyong ba|{(tha dad pa) brkyangs pa/ brkyang ba/ rkyongs/ /snar ba/ rkang lag brkyangs te nyal/ lag pa yar rkyongs/ nyal sa byung na rkyong sa dran/ lha lung la 'dre lag brkyangs/ brkyang bskum gnyis thub/}
-brkyangs phyag rkyong ring|{rkyong gdan dang don gcig}
+rkyong ba|{(tha dad pa) brkyangs pa/ brkyang ba/ rkyongs/ /snar ba/ rkang lag brkyangs te nyal/ lag pa yar rkyongs/ nyal sa byung na rkyong sa dran/ lha lung la 'dre lag brkyangs/ brkyang bskum gnyis thub/ brkyangs phyag}
+rkyong ring|{rkyong gdan dang don gcig}
 rkyong shad|{bya rmyang ngam rkang lag rkyong ba/}
 rkyongs|{rkyong ba'i skul tshig}
 rkyol|{rkyal ba'i skul tshig}
-lkag lkog sa cha khug kyog gam|{dben pa'i sa/ lung pa lkag lkog}
+lkag lkog|{sa cha khug kyog gam/ dben pa'i sa/ lung pa lkag lkog}
 lkal|{(rnying) med pa'i don/}
 lku|{(rnying) rkun ma/}
 lkug rtags|{gnad 'gag mi shes par au tshugs byed stangs/ lkug rtags tsha po/ lkug gad shor ba/ lkug rtags bstan pa/}
@@ -1651,8 +1661,8 @@ lkug brda|{skad cha'i tshab kyi lag brda/}
 lkug pa|1) {smra mi shes mkhan/ gtam lan po med na lkug pa red/ ming gi rnam grangs la ngag gis dbul dang/ ngag mi ldan/ smra bcad/ smra mi shes/ tshig nyams/ tshig mi gsal bcas so/} 2) {glen pa/ lkug pa au tshugs/} 3) {bad kan shas che ba'i smra brjod mi shes pa'i nad cig}
 lkugs pa|{(tha mi dad pa) skad cha lab mi shes par 'gyur ba/ lce lkud/ ngag lkugs pa/ phru gu de lkugs 'dug}
 lkugs se|{smra lce dig lkugs cung zad yod pa/}
-lko mog chu 'khyil ba'i sa kyong kyong|{lko mog gi chus lto chu mi nyan/}
-lkog rgyab logs dang|{phag gam mi mngon pa'i gnas/ mngon lkog mi mthun pa/ ngo lkog med pa/ sgog pa lkog tu bzas kyang/ sgog dri ngos la kha yong/}
+lko mog|{chu 'khyil ba'i sa kyong kyong/ lko mog gi chus lto chu mi nyan/}
+lkog|{rgyab logs dang/ phag gam mi mngon pa'i gnas/ mngon lkog mi mthun pa/ ngo lkog med pa/ sgog pa lkog tu bzas kyang/ sgog dri ngos la kha yong/}
 lkog lkog sud sud|{ngo lkog mi mthun par g.yo rdzu byed stangs/ lkog lkog sud sud du rang don sgrub pa/}
 lkog kha gtong ba|{mi mngon par 'phya smod dam/ dma' 'bebs byed pa/ dkrog gtam ched bzos kyis lkog kha gtong ba/}
 lkog gyur|{gzhal bya gsum gyi nang gses/ myong stobs kyis rtogs mi nus shing rtags stobs kyis rtogs nus pa/ dper na/ nang gi dbang po gzugs can pa rnams dang/ bdag med dang/ sgra mi rtag pa dang/ du ldan gyi la'i me lta bu'o/ lkog gyur gyi chos rnams rjes dpag tshad mas gzhal dgos/ phyi'i byed lugs la brten nas lkog gyur rtogs thub/ bya spyod lkog gyur/mig gis lkog gyur mi mthong/}
@@ -1692,7 +1702,8 @@ lkog shal can|{(mngon) ba lang/}
 lkog gshom|{gsang ba'i gra sgrig ngan g.yo lkog gshom byed pa/}
 lkog gsog|1) {bya'i og ma'i 'og gi zas gsog snod/} 2) {lkog tu rgyu nor gsog pa/}
 lkog gsod|{gzhan gyis mi tshor bar gsod pa/ 'gran zla byed mkhan kha gtad pa lkog gsod btang ba/ rgyal po lkog gsod byas pa/}
-ska cig skad cig ma dang don gcig ska cog zhang gsum|{lo tsA ba gzhon pa gsum ste/ dus rabs brgyad pa bod rgyal khri srong skabs kyi lo tsA ba ska ba dpal brtsegs dang/ cog ro klu'i rgyal mtshan/ zhang ye shes sde gsum gyi bsdus ming/}
+ska cig|{skad cig ma dang don gcig}
+ska cog zhang gsum|{lo tsA ba gzhon pa gsum ste/ dus rabs brgyad pa bod rgyal khri srong skabs kyi lo tsA ba ska ba dpal brtsegs dang/ cog ro klu'i rgyal mtshan/ zhang ye shes sde gsum gyi bsdus ming/}
 ska ba|1. 1) {sngar bod kyi rigs rus shig ste lo tsA ba ska ba dpal brtsegs kyi rus rgyud/} 2) {ro drug gi bye brag a ru ra'i ro lta bu/ }2. {zan dang thug pa sogs sla min gar po/ 'bras thug ska ba/ thug pa ska sla ran pa/}
 ska ba dpal brtsegs|{khri srong sde btsan skabs su byung ba'i lo tsA ba ska cog zhang gsum gyi ya gyal zhig}
 ska rags|{sked pa 'ching byed/}
@@ -1706,8 +1717,8 @@ skag las skyes|{(mngon) du ba mjug ring/}
 skang ra|{'khang ra ste yid tshim par ma byas pa la ma dga' bar bshad pa'i skad cha/}
 skad|1. 1) {skad cha'i bsdus tshig} 2) {don ldan pa dang mi ldan pa'i mnyan bya'i sgra/ 'brug skad/ khyi skad/ bya skad/ snying rje'i skad/ 'ur skad/ sdug skad/ skad phra ba/ skad sbom pa/ skad 'byin pa/ skad grag pa/ khu byug gis skad 'don pa/ }2. {lo grag zer gsum gyi don/ sang nyin yong gi yin skad/ khong yon tan can yin skad/}
 skad kyi nga ro|{skad kyi gdangs te/ skad cha bshad pa dang dpe cha klog pa sogs kyi sgra gdangs/}
-skad kyi yan lag drug 'gyur ba dang|{khug pa/ 'degs pa/ 'jog pa/ sbom po/ phra ba ste drug}
-skad grag grag pa ste sgrog pa|{tho rengs bya skad grag nyin mo khyi skad grag gnam nas 'brug skad grag}
+skad kyi yan lag drug|{'gyur ba dang/ khug pa/ 'degs pa/ 'jog pa/ sbom po/ phra ba ste drug}
+skad grag|{grag pa ste sgrog pa/ tho rengs bya skad grag  nyin mo khyi skad grag  gnam nas 'brug skad grag}
 skad grags|{ming grags/ skad grags yongs su khyab pa/ skad grad chen po/ kho sman pa mkhas pa skad grags yod pa zhig red/}
 skad 'gags|{rlung mkhris bad kan khrag la sod pa'i rkyen gyis gre bar nad phog nas skad 'gags pa'i nad rigs shig}
 skad 'gyur|1) {gzhan yul du yun ring bsdad nas rang yul gyi skad brjed de 'gyur ba/} 2) {glu dbyangs kyi 'gyur khug}
@@ -1716,7 +1727,8 @@ skad sgyur|1) {skad sgyur ba po/} 2) {skad rigs gcig nas skad rigs gzhan zhig tu
 skad sgra|{skad dam sgra/ mi mang po'i skad sgra/}
 skad ngan|1) {mi shis pa'i skad/} 2) {sdug bsngal ba'i skad/}
 skad ca|{skad cha dang 'dra/}
-skad cig skad cig ma'i bsdus tshig skad cig dkrong bskyed|{lha sku dkyil 'khor dang bcas pa glo bur du yongs su rdzogs par gsal 'debs pa/}
+skad cig|{skad cig ma'i bsdus tshig}
+skad cig dkrong bskyed|{lha sku dkyil 'khor dang bcas pa glo bur du yongs su rdzogs par gsal 'debs pa/}
 skad cig cha med|{rang gi bdag nyid du gyur pa'i skad cig snga phyi med pa'i dngos po ste/ dus yun shin tu thung ba las kyang ches thung ba zhig}
 skad cig 'dod ldan|{(mngon) phug ron/}
 skad cig dbugs|{(mngon) sram/}
@@ -1756,12 +1768,12 @@ skad zur nyams pa|{skad zur chag pa dang don gcig}
 skad gzengs|{skad gsang ngam/ skad 'phang/}
 skad bzang|1) {skad gsang mtho ba/} 2) {skad snyan po/}
 skad 'ur|{mi mang 'tshogs nas skad sgra chen po sgrog pa/}
-skad yig skad cha dang yi ge|{bod kyi skad yig rgya'i skad yig snga rabs kyi skad yig mi rigs kyi skad yig}
+skad yig|{skad cha dang yi ge/ bod kyi skad yig  rgya'i skad yig  snga rabs kyi skad yig  mi rigs kyi skad yig}
 skad rigs|{mi rigs mi 'dra ba'i skad cha'i rnam grangs te dper na/ rgya skad dang/ bod skad lta bu/ skad rigs mi 'dra ba/}
 skad rigs chen po bzhi|{sngar rgya gar gyi skad rigs bzhi ste/ sam skri ta ni legs sbyar gyi skad dang/ pra kri ti ni rang bzhin gyi skad/ pi sha tsi ni sha za'i skad/ a ba bhram sha ni zur chag gi skad bcas bzhi/}
 skad ring|1) {gdangs ring por 'don pa'i skad/} 2) {thag ring nas phar tshur 'bod pa'i brda gtong gi ngag}
 skad lugs|{skad rigs so so'i nang gses yul lung mi 'dra ba'i skad cha'i 'gro stangs sam shod stangs/ dper na/ khams skad dang/ dbus skad/ gtsang skad lta bu/ lung pa re re la skad lugs re re/}
-skad log skad cor che ba|{tshogs 'du'i gral du skad log ma rgyag}
+skad log|{skad cor che ba/ tshogs 'du'i gral du skad log ma rgyag}
 skad shor ba|1) {sdug bsngal lam/ 'jigs skrag gis skad thon pa/ dngangs skrag skyes te skad shor ba/ g.yang du lhung grabs byas pas skad shor ba/} 2) {'u thug pa'i gtam thon pa/ tsha nad ma bzod par skad shor ba/ nyin mtshan dal khom med pa'i las brel gyis ji tsam mnar kyang skad shor ma myong/} 3) {skad gdangs nyams pa/}
 skad gsang|{skad kyi gdangs/ skad gsang mthon pos dga' 'bod byed/ skad gsang mthon pos snyan tshig klog}
 skad gsang po|{sgra gdangs gsal zhing mtho ba/ skad gsang po phyogs kun la go /}
@@ -1801,15 +1813,15 @@ skam 'khol|{cham tshad kyis na tshul zhig}
 skam gyong|{skam po dang gyong po/ sa skam gyong/ shing cha skam gyong/}
 skam glog|1) {char med par glog 'khyug pa} 2) {bzha' med pa'i glog rdzas}
 skam rgyags|{lam rgyags za chas skam po/}
-#skam sgrig 'phrul chas sogs la tshod lta'i sgo nas lhu chas sgrig sbyor byed pa|
+skam sgrig|{'phrul chas sogs la tshod lta'i sgo nas lhu chas sgrig sbyor byed pa/}
 skam chag bcu zur|{sngar bod sa gnas kyi gzhung 'bru bkar 'jug skabs bcu zur gcig skam dpyar bcag ste rtsis sprod len byed pa'i brtsi stangs shig}
 skam chas|{'dzin chas sam/ khyim nang gi dngos chas/}
 skam chung|{mgar ba'i skam pa chung ba/}
 skam rnyid|{bzha' thag phal cher chod nas skam la nye ba/ lo ma skam rnyid/ nyung ma skam rnyid/ me tog skam rnyid/}
 skam thag chod pa|{rab tu bskams pa/}
-skam thag thag bzha' thag rbad de chod pa|{gyon chas bkrus rjes skam thag thag byas nas gyon na legs/}
+skam thag thag|{bzha' thag rbad de chod pa/ gyon chas bkrus rjes skam thag thag byas nas gyon na legs/}
 skam thal|{phyugs lhas kyi thal ba/}
-#skam thog sa ming zhig bod rang skyong ljongs kyi 'jo mda' rdzong khongs 'bri chu'i nub 'gram gyi sde zhig yin|
+skam thog|{sa ming zhig bod rang skyong ljongs kyi 'jo mda' rdzong khongs 'bri chu'i nub 'gram gyi sde zhig yin/}
 skam dras|{slob phrug gis dper blta ba'i ched du dge rgan gyis sbyang shing ngos su snag tsha med par bris pa'i yi ge / skam dras brgyab pa/}
 skam sdeb|{gser shog sbyor thabs shig}
 skam gnon|{bod mda'i skam pa 'then byed lcags mda'/}
@@ -1819,12 +1831,12 @@ skam po|1) {rlan gsher med pa/ lo ma skam po/ sa zhing skam po/} 2) {sha shed ny
 skam dpya bcu zur|{sngar bod sa gnas su 'bru bun gtong skabs ngo bo khal bcu re la skyed khal gcig re len pa'i brtsi stangs shig skam phogs/ sngar gla pa dang bran g.yog la 'bru rigs ma gtogs ja chang sogs btung bya med pa'i gla phogs kyi srol zhig}
 skam bris|{sol pir sogs kyis bris pa'i ri mo rags pa/ skam bris ri mo/}
 skam sbyong|{dngos gzhi'i gong du byed pa'i nang sbyong/}
-#skam dmag skam sar dmag 'thab byed mkhan dmag dpung|
+skam dmag|{skam sar dmag 'thab byed mkhan dmag dpung/}
 skam tshag|1) {lus kyi sha zhan pa/} 2) {mig nad kyi bye brag mig skam zhing mi bde ba dang rtsub cing bser bus gnod pa zhig}
 skam tshogs|{bza' btung med par tshogs 'tshogs pa/}
 skam zhing|{chu gtong sa med pa'i zhing kha/}
 skam zan|{za chas skam po'i rigs/}
-#skam zug tshad nad sogs kyi sngon bsu'i zug rngu|
+skam zug|{tshad nad sogs kyi sngon bsu'i zug rngu/}
 skam 'on|{nad kyis rkyen pas rna ba 'on pa'i nad cig}
 skam rid|{lus shin tu skam la stobs zhan pa/}
 skam rlon|1) {skam po dang rlon pa'i bsdus tshig} 2) {chu mang nyung gi rlon tshad/}
@@ -1859,13 +1871,13 @@ skar phyed brgyad|{snga dus bod dngul zho gang gi bzhi cha gsum ste bod tam gyi 
 skar phyed gsum|{snga dus bod dngul gyi zho gang gi bzhi cha gcig ste bod tam gyi drug cha gcig}
 skar ma|1) {nam mkha'i dbyings nas 'od khra lam lam du 'byin zhing 'phro ba'i skar ma/ sprang khyi thog kar bzhag na gnam gyi skar mar rmugs yong/ nyi zla skar gsum dus mnyam mthong/} 2) {rgya thur gyi srang mdar bkod pa'i ljid tshad kyi rtags/} 3) {ljid tshad zho'i bcu cha gcig} 4) {dus yun chu tshod gcig gi drug cu'i cha gcig} 5) {(mngon) gro bzhin dang byi bzhin gnyis gcig tu byas na rgyu skar la nyer bdun yod pas grangs nyer bdun mtshon/}
 skar ma tshom tshom|{skar ma sum tshom bzhi tshom sogs yod pa/ skya rengs tha mar skar ma tshom tshom du shar/}
-#skar ma zho brlag skar ma gang la bltas nas zho gang brlag pa ste bya ba chung chung la mgo 'khor nas chen po brlag 'gro ba'i dpe|
+skar ma zho brlag|{skar ma gang la bltas nas zho gang brlag pa ste bya ba chung chung la mgo 'khor nas chen po brlag 'gro ba'i dpe/}
 skar ma 'od chen|{'od chen po yod pa'i skar ma/}
 skar ma ri shi|{skar ma ri 'dor te/ rtsis gzhung las/ zla drug nyin 'char dang/ zla drug mtshan 'char zhes gsal zhing/ bod zla bdun pa'i gnam gang nas brgyad pa'i tshes pa gnyis kyi bar 'char rgyu'i rgyu skar zhig yin pa 'di'i 'od zer phog tshad kyi chu tshang ma sman chur gyur pas bod kyi chab zhugs dus chen zer ba'i srol rgyun 'di las byung/}
 skar ma'i 'gros|{myur ba dang/ dal bu/ 'khyog po/ thad kar sogs rgyu skar 'pho stangs/}
 skar ma'i rgyal po|{(mngon) zla ba/}
 skar mar 'tshe ba|{(mngon) zla ba/}
-#skar med rkub skyog 'byor med 'byor yod du rlom pa'i che 'gying gi 'gro tshul|
+skar med rkub skyog|{'byor med 'byor yod du rlom pa'i che 'gying gi 'gro tshul/}
 skar rtsis|{rig gnas chung ba lnga'i nang gses shig ste gza' skar dus tshigs sogs brtsi tshul/}
 skar rtsis skor gyi gzhung|{rgya gar nas bsgyur ba'i gzhung gi gras la dus 'khor rtsa rgyud dang/dus 'khor bsdus rgyud/ bde mchog rdo rje mkha' 'gro'i rgyud/ dpal ldan swarod yi rgyud dam dbyangs 'char gyi rgyud/ mig bcu gnyis pa'i mdo/ stag rna'i rtogs brjod/ nyi ma'i snying po'i mdo sogs mdo rgyud mang po dang stod 'grel/ bod gzhung la mtshon na/ rje rang byung zhabs kyi rtsis gzhung kun las btus pa/ bu ston gyi mkhas pa dga' byed/ mkhas grub rje'i tik chen de nyid snang ba/ mkhas grub nor bzang rgya mtsho'i dri med 'od rgyan/ phug pa lhun grub rgya mtsho'i pad dkar zhal lung ma bu/ lo chen dharma shrI'i nyin byed snang ba/ sde srid sangs rgyas rgya mtsho'i beedUrya dkar po ma bu/ sum pa ye shes dpal 'byor gyi dge ldan rtsis gsar ma bu/ thu'u bkwan chos kyi nyi ma'i mkhas pa'i snying nor/ phyag mdzod gsung rab kyi rigs ldan snying thig brag dgon bstan pa rab rgyas kyi rigs ldan mchod pa'i 'od snang sogs skar rtsis kyi khungs shin tu mang ngo/}
 skar rtsis mkhan|{gza' skar lta mkhan/ ming gi rnam grangs la skar mkhan dang/ ltas rtog pa/ ltas shes/ dus mkhyen/ dus shes/ rtsis pa/ ye mkhyen/ lo shes bcas so/}
@@ -1875,8 +1887,7 @@ skal ngan|{bsod nams dman pa/}
 skal chad|1) {rang la bgo skal ma byung ba/} 2) {lam 'gro med pa/}
 skal 'jig|{(mngon) 'chi ba/}
 skal mnyam|1) {rigs gcig pa'am/ rigs mtshungs/ skal mnyam gzhan la phan phyir gzhung 'di brtsams/} 2) {sems can so so'i ris su skyes te 'dra ba'i chos de la skal mnyam mam ris mthun pa zer/ ldan min 'du byed kyi gras shig}
-skal mnyam gyi rgyu|{rgyu drug gi nang gses shig}
-ste|{rang 'bras rang dang rigs 'dra skyed par byed pa/ nas las nas dang/ dge ba las dge ba skye ba dang 'phel ba lta bu/}
+skal mnyam gyi rgyu|{rgyu drug gi nang gses shig ste/ rang 'bras rang dang rigs 'dra skyed par byed pa/ nas las nas dang/ dge ba las dge ba skye ba dang 'phel ba lta bu/}
 skal thob|{rang gi thob cha/}
 skal ldan|{bsod nams can/ skal ldan gyi nya ma/ skal ldan gyi gdul bya/ legs par nyon cig skal ldan rigs kyi bu/}
 skal ldan shing rta|{(mngon) chu bo gang gA'i ming/}
@@ -1888,14 +1899,15 @@ skal dmyigs|{(rnying) skyin tshab/}
 skal rdzongs|{mna' ma dang mag par skal ba bskur ba'i dngos po/}
 skal bzang|1) {bsod nams chen po dang go skabs yag po/} 2) {sbyor ba nyer bdun gyi nang gses shig}
 skal bzang bgrod pa'i myur lam|{tsha rong ba tshe dbang rig 'dzin gyis mdzad pa'i sman gyi chos 'byung zhig}
-skal bzang me tog ston dus su 'char ba'i me tog ser po zhig skal bzang sems can|{bsod nams che ba'i mi/}
+skal bzang me tog|{ston dus su 'char ba'i me tog ser po zhig}
+skal bzang sems can|{bsod nams che ba'i mi/}
 skas ka|{thog kar yar 'dzeg mar 'bab byed pa'i skas ka/ skas ka ma 'dzegs par thog kar mi slebs/ shing skas/ rdo skas/ 'dre skas/ glog skas/ ming gi rnam grangs la them skas dang/ 'dzeg rten/ ya gad bcas so/}
 skas 'go|{skas ka'i 'go /}
 skas 'gram|{skas kyi 'gram pa gnyis kyi shing ste skas ru yang zer/}
 skas rting|{skas ka'i gsham/}
 skas them|{rdo skas dang shing skas kyi gdang bu'am bang rim/}
 skas gdang|{shing skas kyi gdang bu/}
-skas gdang mas 'dzeg rim 'dzeg ste|{rim gyis yar rgyas su gtong ba'am bgrod pa'i dpe/}
+skas gdang mas 'dzeg|{rim 'dzeg ste/ rim gyis yar rgyas su gtong ba'am bgrod pa'i dpe/}
 skas 'dzeg|1) {khang pa'i skas sam 'dzeg skas/} 2) {skas la 'dzeg pa/}
 skas rim|1) {skas 'dzeg gi bang rim mam gdang bu/} 2) {skas 'dzeg khag mang gi steng shod rim pa/}
 skas ru|{skas kyi gdang bu'i g.yas g.yon gyi rten sa'i ru/}
@@ -1914,7 +1926,7 @@ sku khams|{lus kyi 'du ba'am khams/ sku khams bzang po/}
 sku khrus gsol ba|1) {khrus brgyab pa/} 2) {lha'i gzugs brnyan la khrus gsol ba'i chos spyod cig}
 sku mkhar|{rgyal po sdod sa'i mkhar/}
 sku mkhar nyi gzungs|{bod rgyal nyi ma mgon mnga' ris su spyugs pas spu hreng du brtsigs pa'i mkhar/}
-khar ma ru|{lha sa'i byang phyogs se ra'i nye 'dabs dben gnas pha bong kha la yod pa'i pho brang zhig ste/ de na chos rgyal srong btsan sgam po lo bzhi'i ring sku mtshams su bzhugs nas thu mi sam bho tas srol btod pa'i bod kyi yi ge'i gzugs dang sbyor ba rnams la mthar phyin pa sbyong tshul mdzad pa'i gnas te/ sngar thog so dgu brtsegs su yod/}
+sku mkhar ma ru|{lha sa'i byang phyogs se ra'i nye 'dabs dben gnas pha bong kha la yod pa'i pho brang zhig ste/ de na chos rgyal srong btsan sgam po lo bzhi'i ring sku mtshams su bzhugs nas thu mi sam bho tas srol btod pa'i bod kyi yi ge'i gzugs dang sbyor ba rnams la mthar phyin pa sbyong tshul mdzad pa'i gnas te/ sngar thog so dgu brtsegs su yod/}
 sku mkhyen|{thugs rjes gzigs zhes gzhan la zhu gsol 'debs pa'i tshig}
 sku 'khor|{gtso bo dang mnyam du 'gro mkhan/ sku 'khor stos bcas/ sku 'khor gtos che/}
 sku 'khril bag chags pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang gses shig ste yon tan yang dag par brjod par mdzad pa nyid kyis sku 'khril bag chags pa ste/ mnyen zhing 'gying legs pa/}
@@ -1964,15 +1976,16 @@ sku bltams|{sku 'khrungs pa/}
 sku bstod|1) {bstod bsngags/} 2) {sangs rgyas kyi sku'i yon tan la bstod pa/}
 sku thang|{ri mo'i gzugs brnyan/}
 sku thim pa|{shi ba'i zhe sa/ sku thim khar zhal chems gsungs pa/}
-sku thog mi tshe'i ring ngam mi rabs|{sku thog sngon ma/ sku thog rjes ma/ sku thog mang po/ srong btsan sgam po'i sku thog}
+sku thog|{mi tshe'i ring ngam mi rabs/ sku thog sngon ma/ sku thog rjes ma/ sku thog mang po/ srong btsan sgam po'i sku thog}
 sku dag pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang gses shig ste/ thugs rnam par dag pa'i phyir sku rnam par dag pa/}
-sku drag mi drag sku drin|{phan pa'am drin/ sku drin shes pa/ sku drin gzo ba/}
+sku drag|{mi drag}
+sku drin|{phan pa'am drin/ sku drin shes pa/ sku drin gzo ba/}
 sku drung|{sku'i gam mam 'khris/}
 sku drung pa|{mdun du sdod mkhan/}
 sku gdung|1) {phung po'am ro/ sku gdung mjal/ sku gdung zhud 'bul byas/} 2) {ring bsrel/} 3) {ring bsrel lam gdung bcug pa'i mchod rten/ sku gdung mchod rten/}
 sku gdung cha brgyad|{ston pa'i ring bsrel cha brgyad du bgos te bzhengs pa'i mchod rten/}
 sku mdun|1) {drung ngam lus kyi 'khris sam mdun/} 2) {sku ngo ma rang/}
-sku mdog gzugs po'i sha mdog sku mdog ser po|{sku mdog rab dkar/}
+sku mdog|{gzugs po'i sha mdog sku mdog ser po/ sku mdog rab dkar/}
 sku 'dra|{gser zangs dang 'jim pa sogs las bzos pa'i 'dra brnyan/ ming gi rnam grangs la nges snang dang/ sku mtshungs pa/ sku yi gzhi 'dzin/ 'dra bar bzhengs/ 'dra 'bag lder bzo/ pra phab bzhin/ dpe dang mnyam pa/ dpe dang mtshungs pa/ gzugs brnyan/ rab tu 'dra/ legs par bzhengs/ slar bris ma/ slar gzugs/ slar byas 'dra/ so sor mtshungs bcas so/}
 sku rdo rje|{rdo rje gsum gyi nang gses/ gzugs rnam par dag pa snang stong gnyis su med pa'i sku rdo rje'i chos bdun gyi rang bzhin tshang ba/}
 sku lder|{'jim pa las bzos pa'i sku/}
@@ -2028,7 +2041,7 @@ sku shin tu gzhon sha can gyi dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad
 sku gshegs|{shi ba/ sku gshegs dpa' bo/ sras bgres pa sngar nas sku gshegs/}
 sku gshen|{bon po'i chos skad du chos sku/}
 sku srung ba|1) {sku'i nyen kha las skyob pa/} 2) {sku srung mkhan/ sku srung dmag dpung/}
-#sku srog srog sku srog skyel ba'i mdzad pa gnang mi 'tshal|
+sku srog|{srog  sku srog skyel ba'i mdzad pa gnang mi 'tshal/}
 sku gsung thugs|{lud ngag yid/}
 sku gsung thugs kyi rtsa|{mi lus kyi rtsa dbu ma dang ro rkyang/}
 sku gsung thugs rten|{sangs rgyas kyi 'dra sku dang/ gsung rab glegs bam/ mchod rten bcas/}
@@ -2068,7 +2081,7 @@ sku'i skyon med pa'i dpe byad bzhi|{dpe byad bzang po brgyad cu'i gras shig ste/
 sku'i kho lag yangs shing bzang ba'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang gses shig ste/ yangs shing mdzes pa'i yon tan rdzogs pa'i phyir sku'i kho lag yangs shing bzang ba ste sku khyon che ba/}
 sku'i stobs|{gzugs po'i stobs/}
 sku'i thig le|{sa bon nam/ khu ba/}
-sku'i mdog lus kyi kha dog sku'i mdog dkar po|{sku'i mdog nag po/}
+sku'i mdog|{lus kyi kha dog sku'i mdog dkar po/ sku'i mdog nag po/}
 sku'i gnas bdun mtho ba'i mtshan bzang|{bza' btung rgya chen po byin pas phyag zhabs kyi rgyab bzhi dang/ phyag gong gnyis dang/ ltag pa ste bdun rnams shas khengs pa/}
 sku'i rnam 'gyur|{lus kyi rnam pa/ gsung skad gsang zhing sku'i rnam 'gyur spam po zhig 'dug}
 sku'i phyal|{(rnying) lto ba'i zhe sa/}
@@ -2091,28 +2104,30 @@ skul spel|{yar rgyas dang khyab gdal gtong ba/}
 skul ba|{(tha dad pa) bskul ba/ bskul ba/ skul//} 1) {byed du 'jug pa dang/ gsal 'debs pa/ lag len byed par skul ba/ khur sems skul ba/ nan gyis skul ba/ khral 'ul skul pa/} 2) {skyod pa dang rlom pa/ zing 'khrug bskul ba/ rgyu nor gyis sems bskul ba/ lha 'dres rgyud bskul ba/}
 skul byed|1) {(tsunda) byang chub sems dpa' zhig} 2) {(mngon) lcag tshan nam/ rta lcag}
 skul ma|{blo sems skyed thabs dang/ bya spyod dngos su byed du 'jug pa'i ming/ phan tshun skul ma gtong res byed/ yig thog nas skul ma 'debs/ mos mthun dgos lugs kyi skul ma yang yang btang ba yin/}
-skul tshig mi gzhan la bya ba byed par skul ba'i tshig ste|{spyir bya byed tha dad pa'i byed tshig la 'jug pa dang/ skabs 'gar bya byed tha dad pa la mi 'jug pa dang/ tha mi dad pa la 'jug pa'ang yod/ skul tshig gi rjes su tshig grogs cig dang/ zhig shig dang sgra sogs sbyar ba sdod cig gyis shig lta bu skul tshig tshig grogs dang ldan pa yin zhing/ dang sgra la ni ltos dang mthong gi red lta bu skul tshig gi mthar gdams ngag ston pa'i dang sgra'i phrad sbyar ba yin/ cig zhig shig dang mar sdod/ mar sdod cig mar sdod dang khos 'khyer yong/ mig gis ltos/ mig gis ltos shig mig gis stos dang mthong gi red/}
+skul tshig|{mi gzhan la bya ba byed par skul ba'i tshig ste/ spyir bya byed tha dad pa'i byed tshig la 'jug pa dang/ skabs 'gar bya byed tha dad pa la mi 'jug pa dang/ tha mi dad pa la 'jug pa'ang yod/ skul tshig gi rjes su tshig grogs cig dang/ zhig shig dang sgra sogs sbyar ba sdod cig gyis shig lta bu skul tshig tshig grogs dang ldan pa yin zhing/ dang sgra la ni ltos dang mthong gi red lta bu skul tshig gi mthar gdams ngag ston pa'i dang sgra'i phrad sbyar ba yin/ cig zhig shig dang mar sdod/ mar sdod cig mar sdod dang khos 'khyer yong/ mig gis ltos/ mig gis ltos shig mig gis stos dang mthong gi red/}
 skul gzhung|{sngar dus khral 'u lag sogs skul ba'i gzhung khra/}
 skul slong|{skul ma byas nas brtson sems dang ngar sems sogs slong ba/}
 skus|{skud pa'i skul tshig}
 skus byin gyis brlabs pa'i bka'|{ston pas skus byin gyis brlabs te byang chub sems dpa' rnams kyis dri ba dris lan gyi tshul du gsungs pa'i mdo/ dper na/ sa bcu pa'i mdo lta bu/}
 ske|{mjing pa'am mgo'i rten/ ske 'chus 'dug ske 'tshir btang nas bsad/ ske gcod pa/ ske gtub pa/ ske bregs pa/ ming gi rnam grangs la mgur dang/ mgul/ mgo rten/ mgo stegs/ mgo 'dzin/ mgrin pa/ og kong bcas so/}
-#ske kyog kyog mjing pa yon po|
+ske kyog kyog|{mjing pa yon po/}
 ske krong krong|{ske yar bsgrengs pa'i dbyibs/ ske krong krong byas nas lta/}
 ske dkris|{ske la dkri bya'i snam ras sogs/}
 ske bkag|{(yul) ske bsdams/}
 ske khyer zhags 'dzed|{phan du re'ang don du rang gis rang la gnod skyel ba/}
 ske 'khor|1) {ske'i rgyan/} 2) {gos kyi mjing sgor/}
-ske 'gag myur du 'chi ba'i phyugs kyi ske nad cig ske sgor|1) {rta drel sogs kyi mjing par g.yog byed dam skyob byed/} 2) {ske rgyan/}
-ske gcod snum gtig ske gcod dgos sam snum gtig gi yin zhes btsan shed byed pa|{dpe 'di phru gu tshos 'bu cha ga pa bzung ste btsir nas kha'i mchil ma skyug tu bcug pa'i rtsed mo nas byung/}
+ske 'gag|{myur du 'chi ba'i phyugs kyi ske nad cig}
+ske sgor|1) {rta drel sogs kyi mjing par g.yog byed dam skyob byed/} 2) {ske rgyan/}
+ske gcod snum gtig|{ske gcod dgos sam snum gtig gi yin zhes btsan shed byed pa/ dpe 'di phru gu tshos 'bu cha ga pa bzung ste btsir nas kha'i mchil ma skyug tu bcug pa'i rtsed mo nas byung/}
 ske lcibs|{sngar gyi go cha zhig gi ming/}
 ske cha|{ske'i rgyan cha/}
 ske chas|{ske rgyan/}
 ske mjing|{ske'i mdun rgyab/}
 ske snyeng snyeng|{ske mgrin gyen nam thad kar rkyong 'gul gyi rnam pa/ sge khung nang nas ske snyeng snyeng byas nas lta gi 'dug}
 ske stong|{ol mdud 'og gi kong dong/}
-ske thag dud 'gro'i ske la 'dogs pa'i thag pa|{sgo khyi la ske thag brgyab nas btags 'dug}
-ske thig khyi dang phyugs sogs kyi ske la mdzes rgyun du 'dogs rgyu zhig ske 'dogs|1) {ske thag pas 'dogs pa/} 2) {ske nas 'dogs byed/} 3) {ske la 'dogs pa'i rgyan cha/}
+ske thag|{dud 'gro'i ske la 'dogs pa'i thag pa/ sgo khyi la ske thag brgyab nas btags 'dug}
+ske thig|{khyi dang phyugs sogs kyi ske la mdzes rgyun du 'dogs rgyu zhig}
+ske 'dogs|1) {ske thag pas 'dogs pa/} 2) {ske nas 'dogs byed/} 3) {ske la 'dogs pa'i rgyan cha/}
 ske bsdams srog gcod|{thag pa gang rung gis ske bcings nas srog gcod pa/}
 ske pang|{phor pa sogs dkrug byed kyi 'khor lo'i ske 'dzin byed kyi pang leb/}
 ske phreng|{mgul du gdags rgyu'i rgyan cha/}
@@ -2130,7 +2145,7 @@ ske yon|{skye kyog kyog grib phog nas skye yon por gyur song/}
 ske rags|{skyed pa 'ching byed/ ske rags las sne 'dzar ring ba/}
 ske ring mtsho|{bod rang skyong ljongs kyi shan rtsa rdzong gi lho rgyud du yod/}
 ske shing|{gnya' shing/}
-#skeg dus nges can gyi bar chad kyi don du go ba'i skag dang 'dra|
+skeg|{dus nges can gyi bar chad kyi don du go ba'i skag dang 'dra/}
 skegs|{sgro mdog kham ser dang/ rkang pa dang mchu shin tu ring ba/ sder mo'i bar sbrel skyi mo med pa/ dus rgyun na thang gi 'bu dang chu'i nang gi nya phrug rnams za ba'i bya zhig}
 sked dkris|{sked par dkri bya'i ming/}
 sked skabs|{sked pa'i mtshams/ sked skabs phyed pa/}
@@ -2140,7 +2155,8 @@ sked rgyan|{sked pa'i rgyan cha/}
 sked rnga|{sked par btags nas brdung rgyu'i rnga/}
 sked chings|{ska rags/}
 sked 'ching|{sked chings dang 'dra/}
-sked nyag sked pa nyag nyag sked nad|1) {sked pa na ba'i nad/} 2) {bud med kyi zla mtshan/}
+sked nyag|{sked pa nyag nyag}
+sked nad|1) {sked pa na ba'i nad/} 2) {bud med kyi zla mtshan/}
 sked nad can ma|{(mngon) bud med zla mtshan ldan ma/}
 sked pa|1) {lus kyi sked pa/ dar gyi ska rags sked par 'ching/ 'khur rgyu'i rdog khres lci drags pas sked pa 'chus 'dug sgal tshigs 'chus nas sked pa gug gug byas 'dug ming gi rnam grangs la ska rags yul lo/} 2) {bar mtshams/ ri sked la lam phran zhig 'dug}
 sked pa rgyag pa|{zla mtshan 'bab pa/}
@@ -2165,9 +2181,8 @@ sko ba|{(tha dad pa) bskos pa/ bsko ba/ bskos//} 1) {go gnas su 'jog pa'am/ go g
 sko tse|{(rgya) ja spus ka zhan pa zhig}
 skogs pa|1) {shun pa/ sgo nga'i skogs pa/ shing gi skogs pa/ star skogs/} 2) {sbun pa/} 3) {shubs/ yig skogs/ mar skogs/}
 skogs lpags|{phyi shun/}
-skogs shun|{phyi'i pags pa/ rus}
-sbal gyi skogs shun|{ka ped kyi skogs shun/}
-skong sgrig phyogs gcig tu sdud pa dang|{khag so sor bkod sgrig byed pa/ las 'dzin skong sgrig dmag dpung skong sgrig byas pa/}
+skogs shun|{phyi'i pags pa/ rus sbal gyi skogs shun/ ka ped kyi skogs shun/}
+skong sgrig|{phyogs gcig tu sdud pa dang/ khag so sor bkod sgrig byed pa/ las 'dzin skong sgrig dmag dpung skong sgrig byas pa/}
 skong ba|{(tha dad pa) }1. {bskangs pa/ bskang ba/ skongs//} 1) {yid tshim par byed pa/ thugs dam skong bar byed/ re ba bskangs/} 2) {grangs 'bor chad pa rnams tshang bar byed pa/ mi grangs kha bskang rgyu/ dpe cha'i mjug kha skong ba/ }2. {bskongs pa/ bskong ba/ skongs// 'gugs pa dang/ sdud pa/ tshogs 'du bskongs/ nus shugs ji yod bskong ba/}
 skong zhags|{nya 'dzin byed kyi dra ba/}
 skongs|{skong ba'i skul tshig}
@@ -2189,20 +2204,21 @@ skom sha|{ba lang gi sha/}
 skoms|{skem pa'i skul tshig}
 skoms pa|{skom pa'i 'das pa/}
 skor|1. {skor ba'i skul tshig }2. 1) {rigs dang sde tshan/ zhing las skor/ 'brog las skor/ rgyal dmangs dpal 'byor yar rgyas su gtong ba'i byed phyogs skor/} 2) {yul sde dang sa khul/ byang shar skor/ skam sa chen po'i skor/ mnga' ris skor gsum/} 3) {nye 'dabs/ khang skor/ grong khyer gyi nye skor/} 4) {ldab grangs/ 'bru rigs sum cu skor thon pa/ ma bu skor thang/ zhing kha'i thon skor/}
-skor kyog thad ka ma yin pa'am|{kha thug min pa/ lam skor kyog bsam slo skor kyog skad cha skor kyog}
+skor kyog|{thad ka ma yin pa'am/ kha thug min pa/ lam skor kyog bsam slo skor kyog skad cha skor kyog}
 skor skad pa|{sngar lha ldan smon lam skabs lha sa'i bar skor mtshan 'khyongs bskor te chos sgra sgrog pa po/}
 skor skyod|{sa gnas ga sa ga la bskor te 'gro ba/ ga sa gar skor skyod byas nas ltad mo ston/ skor skyod sman bcos ru khag skor skyod tshong pa/}
 skor khang|{ma ni skor sa'i khang pa/}
 skor 'go|{rtsis kyi skor 'go ste grangs brtsi sa'i thog ma'am gzhi/}
-skor rgyug phar skor tshur skor byas te 'gro ba|{yul grong nges med la skor rgyug byas/}
+skor rgyug|{phar skor tshur skor byas te 'gro ba/ yul grong nges med la skor rgyug byas/}
 skor 'chag pa|{sngar bod lha sa'i grong nang gi khrims khang snang rtse shag gi skor zhib byed mi'i gras/}
 skor thag|1) {mtha' skor gyi bar thag} 2){thad kar ma yin pa bskor nas 'gro dgos pa'i lam thag skor thag ring thag chod] mtsho'i skor thag la rta lam nyin gsum yod/}
 skor thang|1) {brje tshong skabs kyi rin thang brtsi stangs/ 'bru dang mar gyi skor thang/ tshwa dang nas kyi skor thang/} 2) {sa bon dang thon 'bab gnyis bar gyi ldab grangs/ lo legs skabs 'bru rigs la sum cu bzhi bcu skor thang thon yong/}
-skor thig ri mo sgor sgor 'bri byed kyi lag cha zhig skor deb|{sa zhing la thon skor rtsi ba'i deb yig}
+skor thig|{ri mo sgor sgor 'bri byed kyi lag cha zhig}
+skor deb|{sa zhing la thon skor rtsi ba'i deb yig}
 skor ba|1. {(tha dad pa) bskor ba/ bskor ba/ skor//} 1) {'khor du 'jug pa/ 'phrul 'khor skor ba/ rta kha skor ba/ yang skor bskyar skor/ mgo skor ba/ kha phyod bskor ba/ bskor bshad gros bsdur/} 2) {phyogs mtshams yongs nas bkag sdom byed pa/ mtha' nas rim gyis bskor ba/ gangs ris bskor ba/ lcags ris bskor ba/} 3) {rim gyis 'khyam pa dang/ phar tshur 'gro ba/ kha bskor ba/ gnas skor ba/ khrom 'khor ba/ }2.{thog mtha' med pa'i dbyibs sgor sgor/ skor ba gcig brgyab pa/ ring thung skor ba gnyis 'khor ba zhig 'dug skor lam/ chos skor/ bon skor/ nang skor/ phyi skor/ bar skor/}
 skor ba 'khor ba|1) {las ka'i rjes zin pa'am/ lcogs pa/ las ka mang po de 'dra skor ba 'khor thub bam mi thub/ dus tshod da dung skor ba 'khor ma song/} 2) {nyo tshong byed skabs ma rtsa sprod len la lag thogs med pa/ ma dngul skor ba 'khor mi thub pas tshong ha log pa/}
 skor ba 'khor tshad|{dus tshod nges can zhig gi ring la skor ba 'khor ba'i thengs grangs/ skor dbye/} 1) {'bru dang rdo dbye ba 'byed byed kyi yo byad cig} 2) {skor zhib kyis dbye ba 'byed pa/}
-skor dmag phyogs mtshams kun nas bskor te rgol ba'i dpung sde|{skor dmag rgyag pa/}
+skor dmag|{phyogs mtshams kun nas bskor te rgol ba'i dpung sde/ skor dmag rgyag pa/}
 skor tshe|{(rnying) gnas skabs sam re zhig skor tsher skyed cing/ skor tsher sdug}
 skor 'tshub|{'khyir ba'i rlung 'tshub/}
 skor g.yeng|{phyogs tshang mar phyin nas lta zhib byed pa/}
@@ -2210,7 +2226,7 @@ skor ru|{rtsid skud 'khal byed kyi shing ru bzhi yu ba can/}
 skor res|{rim bzhin skor ba'i re mos/ las ka skor res byed/}
 skor lam|{skor ba rgyag sa'am skor g.yeng 'gro ba'i lam ga /}
 skor ling|{'bru rdung byed kyi dbyug skor/}
-skor log skor ba phyin ci log pa|{mdun du skyod pa'i shing rta 'khor lo skor log tu skor mi thub/}
+skor log|{skor ba phyin ci log pa/ mdun du skyod pa'i shing rta 'khor lo skor log tu skor mi thub/}
 skol|{skol ba'i skul tshig}
 skol ba|{(tha dad pa) bskol ba/ bskol ba/ skol// 'khor bar byed pa/ sman bskol/ chu skol gyin 'dug ja skol 'bras 'tshod/}
 skos|{sko ba'i skul tshig}
@@ -2224,7 +2240,7 @@ skya khrom khrom|{gangs kyi kha dog lta bu/ kha ba skya khrom khrom/ ba mo skya 
 skya 'khogs|{bkrag mdangs dang snum zhag nyams pa'i mdog bkrag mdangs nyams nas skya 'khogs su song 'dug}
 skya ga|{mdog nag cing glo dkar po can gyi bya zhig ste bya khra'ang zer/}
 skya ga thigs tshags|{lo ltar char 'go tshugs skabs khang steng du sa bkram ste thigs pa 'gog pa'i dus tshod nges can zhig}
-skya gleg mdog skya la gang yin mi gsal ba'am dreg pa 'thug pos g.yogs pa zhig ste|{bad kan nad kyis zin pa'i lce'i mdog lta bu/}
+skya gleg|{mdog skya la gang yin mi gsal ba'am dreg pa 'thug pos g.yogs pa zhig ste/ bad kan nad kyis zin pa'i lce'i mdog lta bu/}
 skya 'grib|{skya rib dang don gcig}
 skya rgyal|1) {'bru sogs bza' btung gi rigs dkon po min pa/} 2) {blon pos rgyal po la rgol ba la skya rgyal zhes mdo sde stag rna'i brda tshig yin par bshad/}
 skya rgyas pa|{skya rgyal ba ste ston thog legs shing mtsho ba'i mthun rkyen phun sum tshogs pa/}
@@ -2233,13 +2249,13 @@ skya chas|{khyim pa'i gyon chas/}
 skya chil chil|{dkar ba'i rnam pa/ kha ba skya chil chil du 'bab/ rba rlabs skya chil chil du g.yo/}
 skya chem chem|{dkar mdangs 'phro tshul zhig gnam la skar ma skya chem chem shar ba/ gangs ri nas 'od skya chem chem zhig 'phro gin 'dug}
 skya chem me ba|{'od dkar po 'phro tshul/ shing se ba'i me tog skya chem me bar shar 'dug}
-#skya chos shog bu dkar por snag tshas bris pa'am snag tshas spar btab pa'i chos dpe|
+skya chos|{shog bu dkar por snag tshas bris pa'am snag tshas spar btab pa'i chos dpe/}
 skya nyil|{skya nyil le ba ste dkar po'i snang tshul zhig gangs skya nyil le bar 'bab/ skra skya nyil le bar zhing/}
 skya ltem me|{dkar pos gang tshul zhig dkar yol 'o mas skya ltem mer gang 'dug}
 skya tha la la|{dkar shas che ba'i thal ba langs tshul/ thal 'tshub skya tha la la langs zin 'dug}
 skya tha le|{rtswa chu med pa'i thang gi mdog}
 skya thal le ba|{dkar shig shig mi phyin pa'i rkang rjes skya thal le ba gzigs pas rkang rjes ded de ri khrod du 'byor/}
-#skya thig khang pa sogs kyi 'char 'god kyi dpe ris rags rim|
+skya thig|{khang pa sogs kyi 'char 'god kyi dpe ris rags rim/}
 skya thud|{mar mang po med pa'i thud/}
 skya thum me ba|{dkar snang gsal la mi gsal ba/ smugs pa chen po'i nang nas mig gis skya thum me ba zhig las gsal po mi mthong/}
 skya ther ther|{skye dngos sogs gang yang med pa'i sa mdog skya po/ sa skya ther ther/}
@@ -2269,7 +2285,8 @@ skya mer re|{dkar po'i rigs phyur bur gang tshul/ 'o zom skya mer rer gang 'dug}
 skya myi|{(rnying) rta pa'am skya mi/}
 skya tsa re|{mdog dkar zhing 'dzar 'dzar ram nar nar gyi tshul du 'bab pa/ kha chu skya tsa rer 'dzag pa/ 'o ma skya tsa rer 'dzag pa/}
 skya rtsa|1) {khyim gyi bu rgan pas mi skya byed rgyu'i rigs/} 2) {rtsa ba'i mi khongs/}
-skya rtsa phyir slog grwa pa log rjes rtsa ba'i mi bdag gi khyim gongs su rang slog byas pa|{skya rtsa rang bdag grwa pa log kyang mi bdag dgon pa de rang gis byed pa/}
+skya rtsa phyir slog|{grwa pa log rjes rtsa ba'i mi bdag gi khyim gongs su rang slog byas pa/}
+skya rtsa rang bdag|{grwa pa log kyang mi bdag dgon pa de rang gis byed pa/}
 skya rtsi|{nor phyugs kyi glo nad 'gog nus pa'i sman sbyor zhig}
 skya rtswa|{gzhan pa skam po/ skya tshar/ rgyab sha med pa'i pags tshar/}
 skya tshos|{mdog dkar ba'i tshos/}
@@ -2310,7 +2327,7 @@ skya gsob|1) {mdog skya bo bkrag mdangs med pa/} 2) {skya sob sob dang don gcig}
 skya bsang|{skya sang dang 'dra/}
 skya bsangs|{skya sang dang 'dra/}
 skya bseng|{skya sang dang 'dra/}
-#skya lhag 'bru rtsam gyi lhag ma|
+skya lhag|{'bru rtsam gyi lhag ma/}
 skya lhag ge ba|{mdog dkar po bkrag med pa/ ngo skya lhag ge ba de nad gcong yod pa'i rtags red/}
 skya lham|1) {tshos med pa'i lham/} 2) {mi skya'i lham/}
 skya lheb be|{mdog dkar zhing lheb lheb kyis dal por 'gul tshul/ nags tshal mtshams na dar lcog cig skya lheb ber yod pa gzigs/}
@@ -2324,7 +2341,8 @@ skyang 'phyes|{grangs gnas shig}
 skyabs|1) {srung ba po dang re ba bya yul/ mgon skyabs/ gtan gyi skyabs/ gnas skabs kyi skyabs/ 'jig rten skyabs mgon/ skyabs 'gro/ skyabs 'jug skyabs gnas/ skyabs su bsten pa/} 2) {khur dkar gyi ming gi rnam grangs shig}
 skyabs kyi sbyin pa|{mi 'jigs pa sbyin pa dang don gcig}
 skyabs mgon|1) {skyabs su 'gro sa'i mgon te skyob mkhan nam re ba bya yul gyi mgon po/ 'jig rten gyi skyabs mgon/} 2) {bla sprul khag la 'bod pa'i che ming/}
-skyabs mgon sbug tA la'i bla ma la 'bod pa'i zhe tshig skyabs mgon rtse shod|{bod srol ltar tA la'i bla ma dang rgyal tshab gnyis la 'bod pa'i zhe tshig}
+skyabs mgon sbug|{tA la'i bla ma la 'bod pa'i zhe tshig}
+skyabs mgon rtse shod|{bod srol ltar tA la'i bla ma dang rgyal tshab gnyis la 'bod pa'i zhe tshig}
 skyabs 'gro|{gnas skabs dang mthar thug gi 'jigs dang sdug bsngal las skyob pa'i ched du bla ma dkon mchog la yid khyed shes kyi dad pas brten cing gsol ba 'debs pa'o/}
 skyabs 'gro bdun cu pa|{dkon mchog gsum la skyabs su 'gro ba ston pa'i gzhung slob dpon zla ba grags pas mdzad pa zhig}
 skyabs 'gro bzhi skor|{bla ma dang/ sangs rgyas/ chos/ dge 'dun bzhi la skyabs su mchi ba/}
@@ -2336,7 +2354,7 @@ skyabs dngos|{chos 'gog bden dang/ lam bden/}
 skyabs gcig pu|{skyabs zhu yul gcig pu/}
 skyabs bca'|{skyabs su bsten pa/}
 skyabs bcol|{gzhan la skyabs kyi re ba 'chol ba/}
-skyabs 'jug rogs ram mam|{gzigs skyong ngam/ mgon grogs/ skyabs 'jug yun ring gnang ba/ dgongs 'gal med pa'i skyabs 'jug zhu/ bar chad mi yong ba'i skyabs 'jug yod pa zhu/}
+skyabs 'jug|{rogs ram mam/ gzigs skyong ngam/ mgon grogs/ skyabs 'jug yun ring gnang ba/ dgongs 'gal med pa'i skyabs 'jug zhu/ bar chad mi yong ba'i skyabs 'jug yod pa zhu/}
 skyabs rje|{srung skyong byed mkhan gtso bo ste so so'i rtsa ba'i bla ma la 'bod pa'i che ming/}
 skyabs rjes su dran pa|{rtag tu dkon mchog dran pa/}
 skyabs rten|{mgo 'dren byed rogs zhu ba'i 'bul rten/}
@@ -2368,7 +2386,7 @@ skyi gas|{pags pa'i ser ka/}
 skyi gos|{ko lpags srab mo las bzos pa'i gos/}
 skyi gri|1) {gri'i so khar spu nyag phus btab pa gcod nus pa'i gri rnon po/} 2) {ko lpags kyi skyi shun bzhar byed cig}
 skyi sgam|{skyi mo'i sgam mam/ ko lpags kyis btum pa'i sgam/}
-#skyi nag pags pa'i phyi shun mdog nag po|
+skyi nag|{pags pa'i phyi shun mdog nag po/}
 skyi lpags|{shun lpags srab mo/}
 skyi ba|1. {(tha dad pa) bskyis pa/ bskyi ba/ skyis// dngul sogs g.yar ba/ dngul skyi ba/ 'bru skyi ba/ rang la med dus gzhan nas skyis/ }2.{shing sman gyi rigs te/ ro kha/ zhu rjes bsil/ nus pas snod mkhris rgyas te mkhris khu pho bar bab pa gyen du drangs nas skyug par byed/ ming gi rnam grangs la ngang pa chig rgyug dang/ ngang pa chig thub/ ngang pa gser sgong/ gtso du/ gtso 'brum/ gtsos sla bcas so/}
 skyi bung|{(rnying) 'jigs pa'am/ bag tsha ba/}
@@ -2404,7 +2422,7 @@ skyid 'go|{skyid pa'i thog ma/ dus de nyid nas skyid 'go tshugs pa/}
 skyid rgan|{mi tshe hril por 'tsho ba skyid pos skyel mkhan/ skyid chu/ lha sa grong khyer gyi 'gram du yod pa'i gtsang po ste/ chu 'go gnyan chen thang lha'i ri rgyud kyi lho ngos nas byung zhing/ mal gro gung dkar dang/stag rtse/ 'phan po/ stod lung sogs chu bo 'di'i ma lag gi rgyud na chags yod/ mthar chu shur rdzong du yar klungs gtsang po'i nang du 'bab/}
 skyid chu'i zam pa|{spyi lo 1955 lor lha sa'i skyid chu'i steng du gsar btsugs rlangs 'khor shar gtong thub pa'i zam chen/}
 skyid ches pa|{skyid drags pa/ 'tsho ba skyid ches pa/}
-#skyid rtag yun ring du skyid pa ste rgya bod mjal dum mdzad pa'i gtan tshigs rdo ring las gsal ba ltar sngar bod rgyal khri gtsug lde btsan gyi srid lo'i ming|
+skyid rtag|{yun ring du skyid pa ste rgya bod mjal dum mdzad pa'i gtan tshigs rdo ring las gsal ba ltar sngar bod rgyal khri gtsug lde btsan gyi srid lo'i ming/}
 skyid stod|{lha sa'i gtsang chu stod rgyud kyi yul spyi/}
 skyid dar|{bde skyid dar ba/}
 skyid du phangs pa|{skyid na mi dga' ba/ bdag la yul mi khyim mtshes skyid du phangs pa 'ga' bdog}
@@ -2450,14 +2468,13 @@ skyu gang|1) {mthe bong gis kong kong bzos pa'i spags kyi mtheb skyu/} 2) {gdong
 skyu tshe|{zan gyi mtheb skyu/ mar khu'i skyu tshe bzo ba/}
 skyu ru|{(amalakI) skyu ru ra ste tshad pa che ba'i yul du skye ba'i shing sdong lo ma che tsam yod pa'i 'bras bu zhig 'dis khrag mkhris kyi tsha ba sel/ ming gi rnam grangs la rgyal 'bras dang/ bcud gnas/ na tshod gnas/ zhi byed/ lang tsho brtan byed bcas so/}
 skyu ru ra|{shing sman gyi rigs shig ste/ ro skyur la mngar kha bska ba/ zhu rjes bsil/ nus pas bad mkhris dang khrag nad sel/ mig nad dang bcud len la bzang/ ming gi rnam grangs la skom sel dang/ khrag 'byed/ gya nom/ smin 'gas/ am ? bhi bcas so/}
-skyu ru ra rlon pa|{skyu ru ra'i 'bras bu gsar pa 'di ha cang dwangs pas phyi nang thams cad gsal po mthong/}
-#shes bya'i chos rnams skyu ru ra rlon pa lag mthil du bzhag pa ltar gsal sgrib med par mthong|
+skyu ru ra rlon pa|{skyu ru ra'i 'bras bu gsar pa 'di ha cang dwangs pas phyi nang thams cad gsal po mthong/ shes bya'i chos rnams skyu ru ra rlon pa lag mthil du bzhag pa ltar gsal sgrib med par mthong/}
 skyu rum|{(rnying)} 1) {btung ba'i bye brag thug pa/} 2) {btsos nas skyur mor gyur pa'i sngo tshod/}
 skyu rum mkhan|{tshod ma bzo mkhan/}
-#skyug bad kan gyi khams kyis kha zas pho bar mi chags par gyen du skyug pa|
+skyug|{bad kan gyi khams kyis kha zas pho bar mi chags par gyen du skyug pa/}
 skyug ting ting ba|{skyug log log byed pa/ skyug ldang/ zhe mer rgyag pa/}
 skyug ldad|{mdzo g.yag sogs sgo phyugs sems can gyis gzan pa rags tsam 'chos nas grod par mid de slar yang kha'i nang du bskyugs pa de nyid zhib mor 'cha' ba/}
-#skyug ldog zhe log pa|
+skyug ldog|{zhe log pa/}
 skyug nad|{ma zhu ba sogs kyi rkyen te zas sman pho bar mi 'jug nas yar gyen du skyug pa'i nad/}
 skyug pa|1. {(tha dad pa) bskyugs pa/ bskyug pa/ skyugs// zhe mer langs te zas sogs kha nas 'byin pa/ lto ma zhu bar bskyugs/ khrag bskyugs/ }2. 1) {zas sogs ma zhu bar kha nas phyir phyung ba'i khu snyigs/ skyug pa bskyugs pa/} 2) {sbyong byed kyi nang tshan skyug gtong ba ni bad kan lcags dreg sogs pho ba'i nad gyen du 'dren par byed pa'i thabs shig}
 skyug bro po|{btsog pa'am mthong mi 'dod pa/ btsog pa skyug bro po/ spyod pa skyug bro po/ spyod pa skyug bro po/ skad cha skyug bro po/ gdong ris skyug bro po/}
@@ -2469,27 +2486,28 @@ skyugs|{skyug pa'i skul tshig}
 skyung ka|{bya spu mdog nag la mchu rkang dmar po zhig skyung kas skyung kar zer res ma byed/ mchu to dmar po cha red/ ming gi rnam grangs la grang rig pho nya dang/ byu ru'i mchu can/ yul ngan 'bod bcas so/}
 skyung ka kha leb|{tshag rgyag byed kyi yo byad bya skyung ka'i mchu dbyibs dang 'dra ba zhig}
 skyung ka rtse rkyong|{tshag rgyag byed kyi yo byad bya skyung ka'i mchu dbyibs dang 'dra ba zhig}
-skyang ka'i khrag srog chags sman gyi rigs shig ste|{ro mngar/ zhu rjes snyoms/ nus pas phru gu skye rgyun 'gog}
-skyang skyang|{bya skyung ka'i skad/}
-skyang ba|{(tha dad pa) bskyungs pa/ bskyung ba/ skyungs//} 1) {ring du 'dor ba dang/ spong ba/ sger sems bskyung ba/ nga rgyal rtsa bskyung/ khengs pa skyung ba/} 2) {nyung du'am chung du gtong ba/ mi 'bor bskyung ba/ bar thag bskyungs pa/}
-skyang bu|{snyung bu ste bu ga 'bigs byed kyi yo byad cig}
-skyang zhag nyi skar nyer bzhi dang chu tshod zhe bzhi la slebs pa dang|{spyi zla gsum pa'i tshes nyer lnga yas mas tsam nas skyung zhag dgu brtsis te sos than yod med brtag pa ste de'i ring la kha char bab nas gnam gshis grang na skyung mo'i khong khrag bton pa zhes sos than yong bar bshad/}
-skyangs|{skyung ba'i skul tshig}
+skyung ka'i khrag|{srog chags sman gyi rigs shig ste/ ro mngar/ zhu rjes snyoms/ nus pas phru gu skye rgyun 'gog}
+skyung skyung|{bya skyung ka'i skad/}
+skyung ba|{(tha dad pa) bskyungs pa/ bskyung ba/ skyungs//} 1) {ring du 'dor ba dang/ spong ba/ sger sems bskyung ba/ nga rgyal rtsa bskyung/ khengs pa skyung ba/} 2) {nyung du'am chung du gtong ba/ mi 'bor bskyung ba/ bar thag bskyungs pa/}
+skyung bu|{snyung bu ste bu ga 'bigs byed kyi yo byad cig}
+skyung zhag|{nyi skar nyer bzhi dang chu tshod zhe bzhi la slebs pa dang/ spyi zla gsum pa'i tshes nyer lnga yas mas tsam nas skyung zhag dgu brtsis te sos than yod med brtag pa ste de'i ring la kha char bab nas gnam gshis grang na skyung mo'i khong khrag bton pa zhes sos than yong bar bshad/}
+skyungs|{skyung ba'i skul tshig}
 skyud pa|{(tha mi dad pa) bskyud pa/ bskyud pa/ /mi dran par brjed pa/ ro ldan gyi zas skyud pa/ gzhon nu'i skabs kyi bya spyod phal cher bskyud pa/ sngar myong sdug bsngal ma skyud ang/}
 skyur|{skyur ba'i skul tshig}
 skyur kha|{(yul) phu thung dang lham yu sogs kyi tshem mtshams su mthud pa'i rgyu cha zhig}
-skur khu|1) {skyur mo'i khu ba/} 2) {dar ba las phyur ba bton zin pa'i khu ba/}
+skyur khu|1) {skyur mo'i khu ba/} 2) {dar ba las phyur ba bton zin pa'i khu ba/}
 skyur 'gong|{ra bzi nas spyod pa gang byung mang byung byed pa'i ming/ skyur 'gong shod mkhan chang la mi dga'/ spyang gi ltod pa lug la mi dga' zer ba rdzun red/ skyur chus myos nas skyur 'gong shod/}
 skyur chu|1){chang/} 2){chu skyur mo/}
-skyur bsnyla rgyag pa|{zho chang sogs skyur rigs snyol ba/}
-skyar dad|{chang la dga' ba/}
+skyur bsnyal rgyag pa|{zho chang sogs skyur rigs snyol ba/}
+skyur dad|{chang la dga' ba/}
 skyur 'don|{gro'i glum la nye'u byas te sman sbyar nas btsos pa'i rlung nad lus la zhen pa phyir 'don pa'i thabs kyi sman rta zhig}
-skyur rdog star bu sogs kyi skyur khu'i nang du bsnyal ba'i phyur ba rdog rdog gi rigs shig skyur mnam pa|{skyur mo'i dri ma kha ba'am snom pa/}
+skyur rdog|{star bu sogs kyi skyur khu'i nang du bsnyal ba'i phyur ba rdog rdog gi rigs shig}
+skyur mnam pa|{skyur mo'i dri ma kha ba'am snom pa/}
 skyur po|{skyur mo dang 'dra/}
 skyur sprang|{chang slong mkhan la dma' 'bebs byed pa'i tshig}
 skyur phyur|{phyur ba skyur mo/}
 skyur ba|1. {(tha dad pa) bskyur ba/ bskyur ba/ skyur//} 1) {'dor ba dang/ spong ba/ khas len dam bca' rgyab tu bskyur/ logs su bskyur/ rtsis med du bskyur ba/ mun bskyur snang 'gro/ tha mag 'then rgyu skyur cig} 2) {phar dbyug pa'am g.yug pa/ g.yang skyur thongs shig chur skyur ba/ kha lud bskyur ba/ }2. {(yul) tshos log pa/ gos kyi tshos mdog skyur 'dug }3. {skyur mo dang 'dra/}
-#skyur bag skyur po'i dri ma|
+skyur bag|{skyur po'i dri ma/}
 skyur byed gsum|{'bras bu gsum ste/ a ru ba ru skyu ru gsum/}
 skyur mo|{ro drug gi nang gses myangs na so brtse zhing bzhin gnyer shor ba'i rang bzhin can/ kha zas skyur mo/ shing tog skyur mo/ kham bu skyur mo/ skyur tshal/ sman ro skyur mo/}
 skyur mo tshwa|{lan tshwa'i rigs shig ste/ mdog dkar zhing ro lan tsha la skyur ba/ zhu rjes drod/ nus pas drod skyed/ sbos pa 'joms/ bad rlung la phan/}
@@ -2506,7 +2524,7 @@ skye dgu|{'gro ba sems can thams cad de/ 'dod pa'i khams las tshe 'phos te khams
 skye dgu ma|{(mngon) rje rigs ma/}
 skye dgu'i bdag po|{(mngon)} 1) {skar ma snar ma/} 2) {rgyal po dang rgyal rigs/} 3) {lha tshangs pa/}
 skye dgu'i bdag mo|{(mngon) rje rigs ma/}
-#skye 'gag 'byung ba dang 'jig pa gnyis kyi bsdus ming ste mi rtag pa'i dngos po|
+skye 'gag|{'byung ba dang 'jig pa gnyis kyi bsdus ming ste mi rtag pa'i dngos po/}
 skye 'gag gnyis med|{'dus ma byas sam/ rtag pa'i chos/}
 skye 'gro|{sems can spyi/ skye 'gro rnams bde legs su byed pa/}
 skye rga na 'chi|{tshe gang gi thog mtha'i bar gyi gnas skabs kyi khyad par bzhi/ skye rga na 'chi bzhi bo de/ gcig la mi tshad kun la yod/}
@@ -2520,17 +2538,16 @@ skye sgo gcod pa|1) {mngal du phru gu mi 'khor ba'i thabs shes byed pa/} 2) {bsk
 skye ngan|{skye ba ngan pa ste ngan 'gro/}
 skye chu lha khang|{srong btsan sgam po'i skabs btab pa lho 'brug spa gro sa khul du yod pa ru gnon gtsug lag khang bzhi'i ya gyal zhig}
 skye mched|{(ayatanam) sems dang sems byung rnams skye zhing 'phel ba'i sgor gyur pa'am/ gzung 'dzin gyi sgo nas rnam shes yul la skye ba dang mched par gyur pa'i gnas/}
-skye mched kyi yan lag rten 'brel yan lag bcu gnyis kyi nang gses|{ming gzugs kyi gnas skabs 'phel ba la brten nas nang gi skye mched drug 'byung ba ste lus yongs su rdzogs par byed pa'o/}
+skye mched kyi yan lag|{rten 'brel yan lag bcu gnyis kyi nang gses/ ming gzugs kyi gnas skabs 'phel ba la brten nas nang gi skye mched drug 'byung ba ste lus yongs su rdzogs par byed pa'o/}
 skye mched kyi lha|{mig gi skye mched sogs kyi lha/}
-skye mched bcu gnyis|{mig la sogs pa'i rnam par shes pa drug 'byung zhing skye ba'i rgyu'am sgo lta bur gyur pa'i mig dang/ rna ba/ sna/ lce/ lus/ yid bcas nang gi skye mched dbang po}
-drug dang|{gzugs dang/ sgra/ dri/ ro/ reg chos bcas phyi'i skye mched yul drug bcas bcu gnyis so/}
-#skye mched drug nang gi skye mched drug ste rten 'brel bcu gnyis nang gi skye mched do|
+skye mched bcu gnyis|{mig la sogs pa'i rnam par shes pa drug 'byung zhing skye ba'i rgyu'am sgo lta bur gyur pa'i mig dang/ rna ba/ sna/ lce/ lus/ yid bcas nang gi skye mched dbang po drug dang/ gzugs dang/ sgra/ dri/ ro/ reg chos bcas phyi'i skye mched yul drug bcas bcu gnyis so/}
+skye mched drug|{nang gi skye mched drug ste rten 'brel bcu gnyis nang gi skye mched do/}
 skye mched zla ba|{(mngon) nyi mas glang khyim spyod pa'i zla ba'am hor zla bzhi pa/}
 skye 'chi|{skye ba dang 'chi ba'i bsdus ming/ skye 'chi'i 'khor lo nyi zla 'char nub 'dra/}
 skye gnyis pa|{(mngon) bram ze/}
 skye rtags|{skye brtag dang 'dra/}
 skye stong|{'bras bu zas su rung ba'i chu shing gi rigs shig}
-#skye brtag mo rtsis kyi brtag 'bras las ji ltar thon pa bzhin tshe 'das ngan 'gro'i skye gnas las grol thabs su bzhengs pa'i dkon mchog gi sku bris 'bur gang rung|
+skye brtag|{mo rtsis kyi brtag 'bras las ji ltar thon pa bzhin tshe 'das ngan 'gro'i skye gnas las grol thabs su bzhengs pa'i dkon mchog gi sku bris 'bur gang rung/}
 skye mdo|{skye rgu mdo'i bsdus ming/}
 skye ldan|{(mngon)} 1) {sems can/} 2) {'jig rten/}
 skye ldan mtha' yas|{(mngon) rtswa dur ba/}
@@ -2566,7 +2583,7 @@ skye ba'i cha can|{(mngon) khyi/}
 skye ba'i chu bo|{chu bo bzhi'i gras shig}
 skye ba'i sdug bsngal|{sdug bsngal brgyad kyi gras shig ste skye ba sdug bsngal dang ldan pas sdug bsngal ba ste/ mngal skyes dang sgo nga las skyes pa de dag skye ba na sdug bsngal gyi tshor ba drag po mang po dang bcas skyes pa'o/}
 skye ba'i zla ba|{(mngon) nyi mas sdig khyim spyod pa'i zla ba'am hor zla bcu pa/}
-skye ba'i yan lag rten 'brel yan lag bcu gnyis kyi nang gses|{srid pa'i mthus nam zhig rkyen tshogs pa na/ yang srid kyi skye gnas der dngos su dang por skye ba dang/ lus rdzogs pa dang/ ris mthun par gnas pa ste/ sdug bsngal gyi phung po 'grub par byed pa'o/}
+skye ba'i yan lag|{rten 'brel yan lag bcu gnyis kyi nang gses/ srid pa'i mthus nam zhig rkyen tshogs pa na/ yang srid kyi skye gnas der dngos su dang por skye ba dang/ lus rdzogs pa dang/ ris mthun par gnas pa ste/ sdug bsngal gyi phung po 'grub par byed pa'o/}
 skye ba'i lam ster|{(mngon) a ma/}
 skye bas rgyal|{(mngon) skyes pa'am mi pho/}
 skye bas thob pa|{skye ba'i dbang gis rang shugs su byung ba/}
@@ -2577,7 +2594,8 @@ skye bo kun 'jug|{(mngon) smad 'tshong ma'i gnas/}
 skye bo tha mal ba|{mi phal pa/}
 skye bo dam pa|{gong du bkur 'os pa'i mi/}
 skye bo phal mo che|{mi phal che ba/}
-skye bo gso thig mgon po klu sgrub kyis mdzad pa'i dmangs rigs la gdams pa ste 'jig rten lugs kyi bstan bcos shig skye bo'i cod pan|{(mngon) zhwa mo/}
+skye bo gso thig|{mgon po klu sgrub kyis mdzad pa'i dmangs rigs la gdams pa ste 'jig rten lugs kyi bstan bcos shig}
+skye bo'i cod pan|{(mngon) zhwa mo/}
 skye bo'i tshogs|{mi mang po'i tshogs/}
 skye bos bskur ma|{(mngon) smad 'tshong ma'i gtso mo/}
 skye 'bras|{skye gzugs te lus po/ bu mo skye 'bras legs pa/}
@@ -2591,7 +2609,7 @@ skye dman|{bud med/}
 skye rmongs|{so so'i skye bo rmongs pa/}
 skye tshe|{ske tshe dang 'dra/}
 skye 'dzin|{(mngon) mo mtshan/}
-#skye zug phru gu skye skabs kyi na tsha|
+skye zug|{phru gu skye skabs kyi na tsha/}
 skye zla|{phru gu skye tshod la slebs dus kyi zla ba/}
 skye gzugs|{lus dang gdong gi rnam pa'am dbyibs/ skye gzugs mdzes pa lha dang 'dra/}
 skye bzang byi ba|{mgo'i skra byi ba'am bud pa/}
@@ -2609,7 +2627,7 @@ skyengs stabs|{kha skyengs shing ngo tsha ba'i tshul/}
 skyengs pa|{(tha mi dad pa) ngo tsha ba/ kha mi skyengs pa/ kha skyengs gdong dmar/ spyang ki kha ma skyengs tsam dang/ lu gu tshe ma zad tsam/ skyengs bzhin du cang mi smra bar yul yul por gyur/}
 skyed|{skyed pa'i skul tshig}
 skyed ka|{skyed kha dang 'dra/}
-skyed bkag skyed ka mtshams bcad pa|{dus sgo gtsang mtshams skyed bkag gis ma rtsa phyir bslog}
+skyed bkag|{skyed ka mtshams bcad pa/ dus sgo gtsang mtshams skyed bkag gis ma rtsa phyir bslog}
 skyed skrun|{'phel thabs dang je cher bzo thabs/ grub 'bras skyed skrun yong thabs byed/ sdod khang skyed skrun/ skyed kha/} 1) {ma rtsar 'khri ba'i 'phel cha'am 'phar ma/ dngul skyed/ 'bru skyed/ lo skyed/ zla skyed/ lnga skyed/ bcu skyed/ skyed lci'i bu lon/ skyed yang bu lon/ skyed med dngul bun/ skyed kha gcog pa/ skyed la skyed rgyag} 2) {je mang dang je bzang du song ba'i cha/ yon tan la skyed kha 'phel ba/ blo skyed/ sems la skyed kha gsar pa byung ba/}
 skyed khe|{skyed kha dang khe bzang/}
 skyed thog skyed brtsegs|{bu lon gyi ma rtsar ma zad skyed kha la'ang skyed kha brtsis pa/}
@@ -2640,7 +2658,8 @@ skyems 'dra|{dwags po skyems stong nas thon pa'i shog bu legs pa zhig gi 'dra/}
 skyems tshugs|{btung snod kyi bye brag cig}
 skyems tshul|{btung ba/}
 skyems rdze'u|{(rnying) chang blug sa'i rdza snod chung ngu/}
-skyems shog sngar bod kyi shog dngul par skrun gyi rgyu cha skyems stong nas thon pa'i shog bu spus legs shig skyer dkar|1) {kha dog dkar ser/} 2) {sngo sman zhig rma 'drub cing khams bde bar byed pa'i nus pa yod/}
+skyems shog|{sngar bod kyi shog dngul par skrun gyi rgyu cha skyems stong nas thon pa'i shog bu spus legs shig}
+skyer dkar|1) {kha dog dkar ser/} 2) {sngo sman zhig rma 'drub cing khams bde bar byed pa'i nus pa yod/}
 skyer skya|{mdog ser skya/}
 skyer kha|{shing skyer pa'i kha dog}
 skyer khanda|{skyer pa'i khanda'i bsdus ming/}
@@ -2649,7 +2668,7 @@ skyer pa|{shing sman gyi rigs shig ste/ me tog dang 'bras bu ro skyur la kha/ zh
 skyer pa'i khanda|{skyer pa'i bar shun las byas pa'i khanda ste/ ro kha/ zhu rjes bsil/ nus pas mig nad kyi rigs kun la phan/}
 skyer pa'i 'bras bu|{skyer pa nag po'i 'bras bu'i kha dog dmar la ro skyur ba/ 'khru ba gcod pa/}
 skyer pa'i 'bru|{skyer pa'i 'bras bu dang 'dra/}
-skyer pa'i me tog skyer pa dkar nag gnyis yod|{dkar po'i me tog gis khrag shor la phan/}
+skyer pa'i me tog|{skyer pa dkar nag gnyis yod/ dkar po'i me tog gis khrag shor la phan/}
 skyer ma|{dres ma yang zer/ lo ma mang po skyes pa'i rtswa ldum thag pa'i rgyu cha zhig}
 skyer tsher|{rtsi shing tsher ma can zhig skyer tsher rkang la zug pas rnag kyang gsog}
 skyer shun|{shing skyer pa'i bar shun te grang ba tsha 'dzag dang gnyan tshad la phan/}
@@ -2665,7 +2684,7 @@ skyel ba|{(tha dad pa) bskyal ba/ bskyal ba/ skyol//} 1) {sa gnas gzhan du gtong
 skyel ma|{srung skyob kyi lam grogs sam/ skyel mkhan/}
 skyel ring|{thag ring du skyel ba/}
 skyes|{yig rten dang/ lag rtags sogs bsam pa dkar ba mtshon byed du sprod pa'i dngos rigs/ phebs skyes/ 'byon skyes/ gnang skyes/ thag ring nas dngos rigs phran tsam zhig skyes su bskur/ snying nye bas dus dang dus su bza' btung gi skyes phul/}
-skyes kyi mchog skyes ni rdzong ba ste|{rang gi grod bshes lta bu thag ring du 'gro ba'am/ tshur 'ong ba'i tshe phan tshun yid dga' ba'i mtshon byed du ster ba'i rgyu dngos/}
+skyes kyi mchog|{skyes ni rdzong ba ste/ rang gi grod bshes lta bu thag ring du 'gro ba'am/ tshur 'ong ba'i tshe phan tshun yid dga' ba'i mtshon byed du ster ba'i rgyu dngos/}
 skyes kyi mtshan ma|{(rnying) dran rten/}
 skyes skar|1) {byis pa skyes dus kyi tshes grangs gang yin pa der 'khel ba'i skar ma/} 2) {skyes khyim dang don gcig}
 skyes khyim|{shar gling dbus ma'i tshangs thig steng du karda'i thog mar nyi ma skyes ma thag tu rang 'gros g.yon 'khor gyis gza' so so'i skyes skar steng du slebs te rlung 'gros kyis shar gling dbus ma'i tshangs thig thad du slebs pa dang lhan cig tu gza' rnams skyes pa'i rgyu skar/de la skyes skar yang zer/ nyi ma nabs so'i chu tshod 45/ zla ba tha skar chu tshod 0/ mig dmar mchu'i chu tshod 30/ lhag pa lha mtshams chu tshod 30/ phur bu me bzhi'i chu tshod 30/ pa sangs nabs so'i chu tshod 0/ spen pa snrubs kyi chu tshod 0/ skar 18/ sgra gcan nag pa'i chu tshod 0/ mjug ring chu smad chu tshod 0 steng du skyes pa'o/ 45 0 30 30 0 0 0 0 0}
@@ -2674,7 +2693,7 @@ skyes sgra can|{(mngon) ra'i ming/}
 skyes chang|{gzhan la lag rtags su 'bul rgyu'i chang/}
 skyes chen|1) {gzhan la sprod rgyu'i lag rtags chen po/} 2) {gzhan don sgrub 'dod kyi snying stobs phul du byung zhing skyo dub med pa theg pa chen po'i gang zag}
 skyes chen dam pa|{skyes bu mchog tu gyur pa/}
-#skyes mchog skyes bu mchog tu gyur pa|
+skyes mchog|{skyes bu mchog tu gyur pa/}
 skyes stobs|{skyes thob dang don gcig}
 skyes stobs blo rtsal|{rang bzhin du yod pa'i blo gros kyi nus pa/}
 skyes stobs shes rab|{rang bzhin du yod pa'i shes rab/}
@@ -2684,7 +2703,7 @@ skyes thob kyi mi dge ba|{skye ba sngon mi dge bar goms pas tshe 'dir mi dge ba 
 skyes thob lung ma bstan|{mi dge ba dang dge ba zag bcas kyi rnam smin rnams so/}
 skyes thob shes rab|{skye dus nas yod pa'i shes rab/}
 skyes bdag|{(mngon) lcags lug lo/}
-#skyes nag khyim pa pho mo ste skyes pa dang nag mo|
+skyes nag|{khyim pa pho mo ste skyes pa dang nag mo/}
 skyes nas 'da' ba|{gzugs su nye bar 'gro ba gsum gyi nang gses/ gzugs khams kyi lha gnas bcu drug gang yang rung bar dang por skyes pa'i rten de nyid la mya ngan las 'da' ba ste/ dge 'dun nyi shu'i nang gses shig}
 skyes nas 'da' ba gsum|{dge 'dun nyi shu las/ skyes nas mya ngan las 'da' ba la skyes tsam nas 'da' ba dang/ 'du byed dang bcas te 'da' ba dang/ 'du byed med par 'da' ba ste gsum mo/}
 skyes nas ma ning|{skyes ma thag nas mtshan bcas ma ning dang mtshan med ma ning gnyis gang rung ngam/ pho min mo min du gyur pa/}
@@ -2705,7 +2724,7 @@ skyes phran|1) {na tshod chung ba'am/ dar ma/} 2) {lag rtags chung ngu/}
 skyes bu|{mi/ skyes bu ngan pa/ skyes bu stobs ldan/ skyes bu che 'bring chung gsum/ skyes bu tha shal/ skyes bu blo mig dang ldan pa/}
 skyes bu skyes mchog|{(mngon) sangs rgyas kyi mtshan/}
 skyes bu khyu mchog|{(mngon) sangs rgyas kyi mtshan/}
-#skyes bu gang zag mi|
+skyes bu gang zag|{mi/}
 skyes bu gang zag rab rib can|1) {mig rab rib can gyi mi/} 2) {shes rig rmongs pa'i mi/}
 skyes bu cang shes bzang po|{shes rab can gyi mi bzang po/}
 skyes bu chung ngu|{skyes bu chung ba dang 'dra/}
@@ -2748,23 +2767,22 @@ skyes rabs so bzhi pa|{sngon byung ston pa'i rnam thar bstan pa'i gzhung zhig st
 skyes lan|{lag rtags kyi slog cha/}
 skyes shor|{zla grangs ma tshang bar phru gu skyes nas shi ba/}
 skyes lha|{mi so so tshes grangs gang la skyes pa'i dus 'khel ba'i skar lha dang skye sa'i yul lha/}
-#skyo bkag shing thal dang spyin chu bsres nas shing chas kyi gsang srubs 'gog byed lde gu'i ming|
+skyo bkag|{shing thal dang spyin chu bsres nas shing chas kyi gsang srubs 'gog byed lde gu'i ming/}
 sko glu|{sems sdug skye bzhin par len pa'i glu gzhas/}
-skyo ngag smre sngags sam sdug skad|{skyo ngag 'don pa/}
+skyo ngag|{smre sngags sam sdug skad/ skyo ngag 'don pa/}
 skyo ngal|{sems skyo ba dang/ lus ngal ba/}
 skyo sngogs|1) {(rnying) sngar khon pa bar skabs su zhi ba slar slong ba/ skyo sngogs byed pa/} 2) {kha mchu dang rtsod gleng/}
 skyo sngogs byed pa'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ dge slong gzhan dag gi rtsod pa zhi bar byas pa de skyo sngogs kyi sgo nas slar rtsod pa slong ba/}
 skyo chad de ba|{yi thang chad nas sun snang skyes pa'i rnam pa zhig yid skyo chod de ba zhig la lam du zhugs/}
 skyo ting nge ba|{yid skyo lhang lhang byung ba'i rnam pa zhig pha ma dang bral bas yid skyo ting nger lus/}
-skyo thar|1) {thug pa'i bye brag cig} 2) {sa ngang pa gser ldan dang spyin bsres pa'i skyo 'bur 'then byed kyi skyo ma/}
+skyo thang|1) {thug pa'i bye brag cig} 2) {sa ngang pa gser ldan dang spyin bsres pa'i skyo 'bur 'then byed kyi skyo ma/}
 skyo thang dmar mo|{ri bo zhig bod rang skyong ljongs kyi dpal mgon rdzong gi byang shar ngos su yod/ 'di'i mtho tshad rgya mtsho'i ngos nas spyi khre 5384 yod/}
 skyo dub|{sems skyo zhing lus dub pa/}
 skyo 'dur|{skyo ldur dang 'dra/}
 skyo ldur|{phye dang chu bsres pa'i skyo ma/}
 skyo snang|{yid sun pa'i snang ba/ skyo snang skye ba/ skyo snang yi chad/}
 skyo po|1) {sems sdug po dang yi mug pa/ bsam pa skyo po/ gdong la skyo gnyer sdud pa/} 2) {dman pa dang/ ngan pa/ gzugs po skyo po/ skyid sdug skyo po/ 'tsho ba skyo po/ mi tshang skyo po/ sha shed skyo po/}
-skyo ba|1. {(tha mi dad pa)} 1) {sems sdug 'byung ba'am/ mya ngan skye ba/ sems skyo ba/ yid skyo nas mig lta mi bzod pa/ sems sdug yid skyo/} 2) {yid sun pa dang/ zhen kha log pa/ ngal dub byung yang mi skyo ba/ byas nyes byung ba la skyo nas 'gyod sems skyes pa/ }2. {nges 'byung ngam/ yid 'byung gi sems/ skyo ba bsang ba/ sems la}
-#skyo ba skyes pa|
+skyo ba|1. {(tha mi dad pa)} 1) {sems sdug 'byung ba'am/ mya ngan skye ba/ sems skyo ba/ yid skyo nas mig lta mi bzod pa/ sems sdug yid skyo/} 2) {yid sun pa dang/ zhen kha log pa/ ngal dub byung yang mi skyo ba/ byas nyes byung ba la skyo nas 'gyod sems skyes pa/ }2. {nges 'byung ngam/ yid 'byung gi sems/ skyo ba bsang ba/ sems la skyo ba skyes pa/}
 skyo 'bur|1) {sa ngang pa gser ldan btsos ma la spyin bsres te ri mo 'bur dod 'bri ba'i skyo ma/} 2) {skyo mas bris pa'i ri mo/}
 skyo ma|1) {phye dang chu bsres nas bzos pa'i lde gu/} 2) {mig skyag} 3) {phra ma/} 4) {(rnying) rtsod pa'am/ kha mchu/}
 skyo ma snga sbyor|{khrims sar zhu gtug sngon la byed pa/}
@@ -2772,7 +2790,7 @@ skyo ma snga btsan|{snga dus khrims sar zhu gtug sngon la byed mkhan de bden pa 
 skyo ma byed pa|1) {phra ma byed pa/} 2) {phye rtsam gyis skyo ma g.yo ba/}
 skyo med|{(mngon) mtho ris/}
 skyo tsha|1) {thug pa'i bye brag cig} 2) {tshod ma/}
-#skyo tshig sems sdug pa'i skad cha|
+skyo tshig|{sems sdug pa'i skad cha/}
 skyo ra|{kha khyer ram khang pa'i mtha'i mu khyud/ rtsig pa'i skyo ra/ chu'i skyo ra/}
 skyo rogs|{sems skyo ba'i skabs rogs ram byed mkhan/}
 skyo log bag log gam|{gnyen log}
@@ -2785,7 +2803,7 @@ skyo bsangs|{skyo sang dang 'dra/}
 skyo lhang nge|{skyo ba'i blo skye tshul zhig sems skyo lhang nge ba zhig byung/}
 skyog pa|{(tha dad pa) bskyogs pa/ bskyog pa/ skyogs//} 1) {kha lo sgyur ba/ rta kha bskyogs pa/ mgo bo bskyogs nas mig gis mi lta/ mgrin pa skyogs shig} 2) {zur du g.yol ba/ sku phar skyog tsam gnang dang/}
 skyogs|1. {skyog pa'i skul tshig }2. 1) {gzar bu ste 'chu byed kyi yo byad cig chu skyogs/ dngul skyogs/ zangs skyogs/ bzhu skyogs/}2) {thabs tshul/ sna tshogs skyogs brgya/}
-#skyogs nag lcags kyi gzar bu|
+skyogs nag|{lcags kyi gzar bu/}
 skyong grogs|{rogs ram byed mkhan/}
 skyong ba|{(tha dad pa) bskyangs pa/ bskyang ba/ skyongs//} 1) {'tsho bar byed pa dang/ mgon byed pa/ 'tsho skyong/ gso skyong/ phru gu byams pas bskyangs/ mgon med rgan rgon rnams la gzigs shing skyong/ rtswa khar sgo phyugs skyong ba/ gnyen 'khor skyong ba/ drin gyis bskyangs pa/} 2) {srung ba dang/ skyob pa/ rgyun skyong/ srung skyong/ bdag skyong/ yul 'khor skyong/ thabs kyis bskyangs/} 3) {byed pa'am/ 'dzin pa/ srid skyong ba/ khyim tshang skyong ba/ las don tshul bzhin du bskyangs/ tshong las bskyangs/}
 skyong byed|{(mngon) pha/}
@@ -2802,7 +2820,7 @@ skyon bgrang|{skyon gyi grangs bgrangs te smod pa/}
 skyon 'gebs mdzes 'chos|{skyon sbas te 'dra chags po bzo ba/}
 skyon 'gel|{nyes med nyes 'gel/}
 skyon sgrog gtug bsher|{khrims la gtugs nas rtsod gleng byed pa/ byas nyes ther 'don gyis skyon sgrog gtug bsher byed pa/}
-#skyon sngog nyes skyon shod pa|
+skyon sngog|{nyes skyon shod pa/}
 skyon can bris bsub nang rul|{phan tshun nang skyon sbed res kyi ngan mthun/ phan tshun skyon can bris bsub nang rul ma yin par skul lcag gtong res byed dgos/}
 skyon cha|{skyon gyi rigs/ srog la thug pa'i skyon cha/}
 skyon brjod|{skyon yod pa brjod pa'am/ bton pa/}
@@ -2820,7 +2838,7 @@ skyon brus|{gzhan skyon bton pa'am/ bsngogs pa/}
 skyon dbags|{(rnying) skyon gyis 'go ba/}
 skyon sbed|{rang gzhan gyi skyon cha gsang nas 'jog pa/}
 skyon med|1) {skyon cha med pa/ skyon med skyon btsugs/} 2) {sangs rgyas shig gi mtshan/}
-#skyon med spus dag spus ka ha cang yag po|
+skyon med spus dag|{spus ka ha cang yag po/}
 skyon mtshang|{nyes skyon/ bsam sbyor ngan pa'i skyon mtshang 'bru ba/ sbas bskungs byas pa'i skyon mtshang rim gyis brtol/}
 skyon 'tshol|{skyon yod med rtog dpyod byed pa/ mi 'dris bzhin skyon 'tshol/ khyi 'dris bzhin dri 'tshol/}
 skyon 'dzin pa|1) {gzhan skyon sems la 'jog pa/} 2) {gzhan spyod skyon du lta ba/}
@@ -2870,7 +2888,8 @@ skra dkar|1) {rgas pa'i mgo skra/ mi skra dkar can/ na rgas skra dkar/} 2) {lo n
 skra rkang|{skra'i nyag ma/ skra rkang mang/}
 skra kha|{skya ga dang 'dra/}
 skra mkhan|1) {skra bzhar mkhan/ ming gi rnam grangs la mthar gnas pa dang/ mtho ris grags/ 'dren mkhan/ zla 'dzin bcas so/} 2) {skra sla mkhan/}
-skra 'khyig bud med kyi skra lhas ma sbrel byed rgyan cha zhig skra 'khyil|1) {mgo'i skra sgor sgor du 'khyil nas skyes pa/} 2) {gtsug 'khyil/}
+skra 'khyig|{bud med kyi skra lhas ma sbrel byed rgyan cha zhig}
+skra 'khyil|1) {mgo'i skra sgor sgor du 'khyil nas skyes pa/} 2) {gtsug 'khyil/}
 skra ga'u|{sngar bod kyi shod drung rim bzhi yan gyi spa lcog steng du rgyag rgyu'i go gnas kyi rtags shig dang/ mi drag mtho rim gyi g.yog po'i lcang lo'i steng du rgyag rgyu'i ga'u/}
 skra grangs|{skra yi grangs ka ste shin tu mang ba'i dpe/ bu lon skra grangs las mang/ rnyog gra rgya mtsho las zab/}
 skra sgre can|{skra rtsa srab pa'am skra tha re tho re las med mkhan/}
@@ -2900,7 +2919,7 @@ skra 'dzin|{sngar lha sar smon lam tshugs dus lha sa'i bud med rnams kyis skra'i
 skra rdzun|{skra brdzus dang 'dra/}
 skra brdzus|{skra'i tshab/}
 skra zhags|1) {skra lhas ma ring po mgor dkris chog pa zhig} 2) {(mngon) bud med kyi skra/}
-#skra gzhug skra lhas ma'i rtser gdags bya'i phod 'dzar|
+skra gzhug|{skra lhas ma'i rtser gdags bya'i phod 'dzar/}
 skra zings|{(rnying) nga rgyal che ba/}
 skra bzang|1) {sngo sman par pa ta'i ming gi rnam grangs shig} 2) {mgo skra yag po/}
 skra bzang zil pa|{'khri shing ral pa can sa nag hrul can dang tsher ma skye ba/ phan nus gtso cher rims dang dug tshad sel ba'i khrag sman zhig}
@@ -2944,13 +2963,12 @@ skru ba|1. {(tha dad pa) bskrus pa/ bskru ba/ skrus/ /slong ba/ zas bskrus te 't
 skru ma|{'tsho rten med pas gzhan nas slong mo byas nas 'tsho ba skyel mkhan/}
 skrug pa|{bskor nas bzhog par byed pa'i dkrug pa dang don gcig}
 skrun|{skrun pa'i skul tshig}
-skrun pa|{(tha dad pa) bskrun pa/ bskrun pa/ skrun/ /gsar du 'dzugs pa dang/ bzo ba/ chu bed skrun pa/ mthun rkyen skrun pa/ dpe cha par du}
-skrun|{'dzugs skrun/ gsar skrun/}
+skrun pa|{(tha dad pa) bskrun pa/ bskrun pa/ skrun/ /gsar du 'dzugs pa dang/ bzo ba/ chu bed skrun pa/ mthun rkyen skrun pa/ dpe cha par du skrun/ 'dzugs skrun/ gsar skrun/}
 skrus|{skru ba'i skul tshig}
 skrog pa|{(tha dad pa) bskrogs pa/ bskrog pa/ skrogs//} 1) {srub pa'am/ dkrug pa/ zho bskrogs te mar blangs/} 2) {dkrol ba/ da ma ru skrog bzhin du 'cham brgyab/}
 skrogs|{skrog pa'i skul tshig}
 skrod|{skrod pa'i skul tshig}
-skrog pa|{(tha dad pa) bskrod pa/ bskrad pa/ skrod/ /gnas nas spyugs pa dang 'don pa/ rgyal mtshams nas phyir skrod/ nyes can rnams gnas nas bskrad/}
+skrod pa|{(tha dad pa) bskrod pa/ bskrad pa/ skrod// gnas nas spyugs pa dang 'don pa/ rgyal mtshams nas phyir skrod/ nyes can rnams gnas nas bskrad/}
 skrod pa'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ zhe sdang gi sems kyis dge slong gzhan gnas khang nas phyi rol tu 'don pa/}
 brkam chags|1) {sred pa ste 'dod zhen/ mi brkam chags can la chog shes med/} 2) {ser sna/}
 brkam pa|{(tha mi dad pa) 'dod pa'am/ chags pa/ rgyu nor la brkam pa/ chang dang 'khrig pa spyod pa la brkam pa/}
@@ -2972,13 +2990,12 @@ brkos shul|{sa dang rdo shing sogs brkos pa'i shul/}
 brkyang bskum|{phar rkyong ba dang tshur skum pa/}
 brkyang nul|{(rnying) ar ga'i zhal ba/}
 brkyang ba|{rkyong ba'i ma 'ongs pa/}
-brkyangs khru|{ring thung 'jal byed kyi tshad cig}
-ste|{lag pa'i gung sor brkyangs pa'i rtse nas gru tshigs bar gyi ring tshad/}
+brkyangs khru|{ring thung 'jal byed kyi tshad cig ste/ lag pa'i gung sor brkyangs pa'i rtse nas gru tshigs bar gyi ring tshad/}
 brkyangs mkhyid|{khu tshur gyi mthe bong dang mthe'u chung brkyangs te 'jal ba'i tshad/}
 brkyangs nyal|{rkang lag brkyangs nas nyal ba/}
 brkyangs 'dom|{lag sor brkyangs te 'jal ba'i 'dom gyi tshad/}
 brkyangs pa|{rkyong ba'i 'das pa/}
-#brkyangs phyag lus thams cad sa la phab pa'i phyag mos gus chen pos brkyangs phyag 'tshal|
+brkyangs phyag|{lus thams cad sa la phab pa'i phyag mos gus chen pos brkyangs phyag 'tshal/}
 brkyangs shad|{rkang lag sogs brkyangs bsnar/}
 brkyangs sor lnga|{lag sor bzhi bskums pa'i steng mtheb tshigs mdzub tshigs la sbyar ba'i ring tshad/}
 bska ba|1) {ro'i bye brag a ru ra'i ro lta bu/} 2) {sla min gar po/ thug pa bska ba/}
@@ -3003,15 +3020,14 @@ bskal pa chen po grangs med pa gsum|{bskal chen grangs gnas drug cu'i mtha' ma s
 bskal pa gnyis|{sgron bskal te chos dar ba'i bskal pa dang/ mun bskal te chos mi dar ba'i bskal pa gnyis so/}
 bskal pa gnyis ldan|{rtsa ba bzhi las gnyis tsam rang gi ngang gis srung thub pa'i bskal pa/}
 bskal pa dang po|{snod bcud kyi 'jig rten chags nas ring po ma lon pa'i dus skabs/}
-bskal pa drug chags bskal dang|{gnas bskal/ bar bskal/ bskal chen/ 'jig}
-bskal|{stongs bskal te drug}
+bskal pa drug|{chags bskal dang/ gnas bskal/ bar bskal/ bskal chen/ 'jig bskal/ stongs bskal te drug}
 bskal pa bar ma|{chos mngon pa'i bshad srol ltar na bskal pa chung ba gnyis rer bskal pa bar ma gcig zer/ 'di la mi lo bye ba gcig dang sa ya drug bdun 'bum dgu khri brgyad stong tham pa yod/}
 bskal pa bar ma gsum|{bar gyi khug pa bco brgyad kyi bar du 'byung ba'i bskal pa ste mu ge'i bskal pa dang/ nad kyi bskal pa/ mtshon gyi bskal pa ste gsum/}
 bskal pa rtsod ldan|{tshe lo brgya pa'i dus su mi rnams phal cher rtsa ba bzhi las gcig tsam yang mi srung zhing phan tshun rtsod pa dang ldan pa'i bskal pa yin zhing tshe lo brgya pa'i dus kyang zer/}
 bskal pa rdzogs ldan|{bskal pa dang po'i mi rang bzhin gyis rtsa ba bzhi rdzogs par bsrung ba'am gzhi de la mi 'jug pa'i bskal pa/}
 bskal pa bzang po|{sangs rgyas stong rim par byon dang 'byon pa'i sgron me'i bskal pa/}
 bskal pa bzang po zhes bya ba'i mdo|{'phags pa bskal pa bzang po mdo sde zhes bya ba sangs rgyas stong gi rigs rus dang/ yab yum dang/ 'khor dang/ sku tshe'i tshad dang/ bstan pa'i gnas tshad dang/ byang chub mchog tu thugs bskyed tshul sogs rgyas par bstan pa'i mdo sde bam po nyer drug pa/ rgya gar gyi mkhan po bitya' ka ra sidha dang/ lo tsA ba bande dpal dbyangs kyis bsgyur cing phyis ska ba dpal brtsegs kyis zhus pa/}
-bskal pa ya thog bskal pa rdzogs ldan gyi dus zhes mi rnams tshe lo khri thub cing|{sa zhag dang/ 'bras sa lu sogs ma rmos pa'i lo tog la longs su spyad nas 'tsho ba'i dus skabs byung ba de'o/}
+bskal pa ya thog|{bskal pa rdzogs ldan gyi dus zhes mi rnams tshe lo khri thub cing/ sa zhag dang/ 'bras sa lu sogs ma rmos pa'i lo tog la longs su spyad nas 'tsho ba'i dus skabs byung ba de'o/}
 bskal pa shes|{(mngon) rtsis pa/}
 bskal pa gsum ldan|{rtsa ba bzhi las gsum tsam rang chas su srung ba'i bskal pa/}
 bskal pa'i mtha'|1) {tshad nges gzung med pa/} 2) {dus kyi mtha' ma ste bskal pa 'jig stongs kyi mtha'/}
@@ -3023,28 +3039,30 @@ bskal bzang rgya mtsho|{tA la'i bla ma sku phreng bdun pa 'di mdo khams lho rgyu
 bskal bzang sangs rgyas|{bskal pa bzang po'i dus 'dir byon dang 'byon pa'i sangs rgyas te/ rnam 'dren dang po 'khor ba 'jig nas rnam 'dren mos pa'i bar gyi sangs rgyas stong la bskal bzang sangs rgyas zhes bya'o/}
 bskal bzang bsil g.yab|{rgyal ba bskal bzang gi sku dus su dar zer ba'i zhwa mo/}
 bskal li|{lo mang por go chod pa'i li tho/}
-#bskal li'i re'u mig tshes zhag sum brgya don gcig gi longs spyod khyim drug spyi nor la bsnan bya'i ming|
+bskal li'i re'u mig|{tshes zhag sum brgya don gcig gi longs spyod khyim drug spyi nor la bsnan bya'i ming/}
 bsku mnye|1) {lus la byug pa bsku zhing phur phur gtong ba/} 2) {'bru mar sogs snum bsku ba ste 'byug pa dang/ mnye ba ste 'phur ba'i sgo nas rlung nad rengs 'khum bcos pa'i thabs shig}
 bsku ba|{skud pa'i ma 'ongs pa/}
 bskug pa|{skug pa'i ma 'ongs pa/}
 bskugs pa|{skud pa'i 'das pa/}
 bskung ba|{skung ba'i ma 'ongs pa/}
 bskungs pa|{skung ba'i 'das pa/}
-bskungs yig bsdus yig ste|{bkris zhes pa de bkra shes kyi bskungs yig yin pa lta bu/ bkris bkra shis}
+bskungs yig|{bsdus yig ste/ bkris zhes pa de bkra shes kyi bskungs yig yin pa lta bu/ bkris bkra shis}
 bskum pa|{skum pa'i ma 'ongs pa/}
 bskums khru|{ring thung 'jal byed kyi tshad cig ste/ lag sor bskums pa'i khu tshur gyi dkyil tshigs nas gru mo'i bar gyi ring tshad/}
 bskums mkhyid|{khu tshur gyi mthe bong brkyangs te 'jal ba'i tshad/}
 bskums 'dom|{lag sor bskums te 'jal ba'i 'dom gyi tshad/}
 bskums pa|{skum pa'i 'das pa/}
-bskums phyag lus kyi mal lnga sa la phab ste 'tshal ba'i phyag bskums sor lnga|{lag sor bzhi bskums pa'i steng mtheb rtse mdzub tshigs la sbyar ba'i ring tshad/}
+bskums phyag|{lus kyi mal lnga sa la phab ste 'tshal ba'i phyag}
+bskums sor lnga|{lag sor bzhi bskums pa'i steng mtheb rtse mdzub tshigs la sbyar ba'i ring tshad/}
 bskur ba|{skur ba'i 'das pa dang ma 'ongs pa/}
-bskur yig btang yig bskur gshom|{bskur rgyu'i gra sgrig gnyen nye dur kha chems bskur gshom gyis/}
+bskur yig|{btang yig}
+bskur gshom|{bskur rgyu'i gra sgrig gnyen nye dur kha chems bskur gshom gyis/}
 bskul ba|{skul ba'i 'das pa dang ma 'ongs pa/}
 bskul ba'i spang ba|{spang ltung sum cu'i nang gses/ gos nyo ba'i rin gyi rin po che zhal ta dang lan gsum gyi bar du mthong sar bsdad pa las lhag pa'i bskul mas gos blangs pa/}
 bskul ma|{skul lcag gtong ba'am/ byed du 'jug pa/ dran gso'i bskul ma btang/ yang yang bskul ma byas pa/}
 bskus pa|{skud pa'i 'das pa/}
 bsko ba|{sko ba'i ma 'ongs pa/}
-bsko gzhag las don gyi byed por bsko ba|{las 'dzin bsko gzhag byed pa/}
+bsko gzhag|{las don gyi byed por bsko ba/ las 'dzin bsko gzhag byed pa/}
 bsko yas|{sngar rgya gar gyi grangs gnas shig gi ming/}
 bskong 'gugs|{phar btang ba rnams tshur 'gugs pa/ sku tshab bskong 'gugs byed pa/ lung pa so sor btang ba'i las mi rnams bskong 'gut kyis tshogs 'du 'tshogs 'dug}
 bskong gtong|{tshur bskong ba dang/ phar gtong ba/ dmag sde bskong gtong/ las byed pa bskong gtong/}
@@ -3077,7 +3095,7 @@ bskyar ldab|{ldab skyor/ bskyar ldab thengs mang byas/}
 bskyar ba|{yang yang ldab pa'i don du go ba'i skyor ba'i 'das pa dang ma 'ongs pa/}
 bskyar ba'i sgra|{phrad rang dbang can gyi yang sgra/ yang}
 bskyar ma|{ldab pa dang/ yang yang bskor ba/ bskyar bshad/ yang bskyar/ shi nas bskyar du gson pa/}
-#bskyar tshig lab skyor byed pa'i gtam|
+bskyar tshig|{lab skyor byed pa'i gtam/}
 bskyar zlos|{skad cha sogs ldab skyor/}
 bskyar bzo|{sngar bzos nyams pa bskyar du bzo ba/}
 bskyar gso|{nyams so/ rnying shul bskyar gso/ skyon shor 'phrul chas bskyar gso/}
@@ -3116,10 +3134,11 @@ bskrus pa|{skru ba'i 'das pa/}
 bskrog pa|{skrog pa'i ma 'ongs pa/}
 bskrogs pa|{skrog pa'i 'das pa/ /kha//}
 kha|{bod yig gsal byed gnyis pa 'di'i nga ro 'don tshul la skye gnas mgrin pa dang/ byed pa mgrin pa/ nang gi rtsol ba mgrin pa phye ba dang/ phyi'i rtsol ba srog chen sgra med/ }1. 1) {ming gzhi'i ma ning yi ge zhig} 2) {ming sngon gyi cha shas shig kha dog kha 'thor ba/ kha sgyur ba/} 3) {rtags mtshungs 'dren skabs rjes 'jug ma ning gis drangs pa'i ming mtha' zhig dgun kha/ gter kha/ gsol kha/ 2} 1) {skye 'gro'i zas za ba dang smra ba'i sgo/ kha lkugs pa/ bong bu'i kha nas gser bskyug mi yong/ ming gi rnam grangs la ngag 'don dang/ gtam gyi 'byung gnas/ bdud rtsi'i rten/ mu kha/ smra ba'i sgo/ smra byed/ zhal/ za byed/ gsung byed bcas so/} 2) {snod kyi kha/ phor ba'i kha/ bum pa'i kha/ shel dam gyi kha gcod pa/} 3) {mdun phyogs/ khang pa phan tshun kha sprod pa/ kha phyogs/} 4) {nye 'gram/ mtsho kha/ gtsang po'i kha/} 5) {steng cha/ khri kha/ dpe cha cog tse'i kha la bting ba/} 6) {dus skabs/ phyogs la 'gro kha/ las ka byed khar bsam blo gzab gzab gtong dgos/} 7) {skad cha/ rdzun shod mkhan gyi kha la mnyan rgyu med/ gros bsdur byed mi tshang ma kha mthun pa/} 8) {phyugs kyi lo tshad/ g.yag kha rgan/ rta kha chung/} 9) {ras kyi 'jal tshad zheng dkyus 'dra ba zhig ras kha gang/ gos chen kha do/}
-#kha kyog kha'am mchu to 'khyog po|
+kha kyog|{kha'am mchu to 'khyog po/}
 kha klo|{klo yul gyi stod char sdod pa'i klo pa/}
-#kha dkar khog nag skad cha 'jam la bsam pa ngan pa|
-kha dkar gting nag kha dkar khog nag dang don gcig kha dkar po|1) {skad cha bkra shis pa/} 2) {mdog dkar rkyang/}
+kha dkar khog nag|{skad cha 'jam la bsam pa ngan pa/}
+kha dkar gting nag|{kha dkar khog nag dang don gcig}
+kha dkar po|1) {skad cha bkra shis pa/} 2) {mdog dkar rkyang/}
 kha dkris|{ske la dkri bya'i ras sam kha dkri byed/}
 kha bkag pa|1) {skad cha shod du ma bcug pa/ g.yo thabs kyis mi'i kha bkag pa/} 2) {bug sgo bkag pa/ bum pa'i kha bkag pa/} 3) {'gror ma bcug pa/ rta kha bkag pa/}
 kha bkug|1) {gos kyi mtha' nang du bkug pa'i tshem srub/} 2) {rta rgod po srab kha 'then kyang mi nyan par kha sgur brgyab pa/ rta drel sogs kha bkug brgyab pa/}
@@ -3128,7 +3147,8 @@ kha bkral|{logs su phye ba/ dngos rigs sde tshan ris mi mthun pa rnams so sor kh
 kha skad|1) {zer rgyun/} 2) {phal skad dang/ ngag}
 kha skong|1) {snon ma/} 2) {kha tshang byed dam/ grangs long byed/}
 kha skong gi chos bcu gsum|{bsnyen rdzogs kyi dge 'dun mngon gyur gyi nang gses/ kha skong gi chos la las gral du mi 'dug par 'greng ba dang/ yul de chad las sogs bya ba'i 'os su gyur pa dang/ lus dngos su ma 'dus par 'dun pa sogs phul ba dang/ bsnyen par ma rdzogs pa dang/ sdom pa nyams pa dang/ mtshams med byas pa dang/ ston pa'i bstan pa la yid mi ches pa'i sdig lta can dang/ spo mgu la sogs pa dman pa'i sa na gnas pa dang/ chos phyogs pa las lta ba tha dad pa'i chos min phyogs pa dang/ bsdam bya nyes byas yan chad kyis gos pa'i 'khrul bcas ma yin pa ste gzhi'i skabs nas 'byung ba bcu dang/ mtshams gzhan dang mtshan gzhan dang/ dkon mchog gzhan 'dzin pa ma yin pa ste zhu ba'i skabs nas 'byung ba gsum bcas bcu gsum mo/}
-kha skong sbyin sreg cho ga lhag chad kyi nyams pa skong ba'am gso ba'i phyir yi dam gang rung gi sgos blug pa'i sbyin sreg gam cho ga'i yan lag tshang bar blug pa'i las sbyor gyi sbyin sreg kha skom|{kha'i nang gi rlan skam pa'i gdung ba/ kha skom pa'i mi la chu'ang zhim/}
+kha skong sbyin sreg|{cho ga lhag chad kyi nyams pa skong ba'am gso ba'i phyir yi dam gang rung gi sgos blug pa'i sbyin sreg gam cho ga'i yan lag tshang bar blug pa'i las sbyor gyi sbyin sreg}
+kha skom|{kha'i nang gi rlan skam pa'i gdung ba/ kha skom pa'i mi la chu'ang zhim/}
 kha skyur|{ljang sprin te/ lha 'bri ba tsho'i logs skad cig}
 kha skyur ba|1) {tshos log pa/} 2) {ro myong tshul/ kham bu zos rkyen kha skyur ba/}
 kha skyengs|{ngo tsha ba/ rtsod lan 'debs ma nus par kha skyengs pa/}
@@ -3195,12 +3215,12 @@ kha rgyab gnyis med|{zas dang gos gnyis ka med pa/}
 kha rgyal ba|1) {kha gshags sam rtsod pa rgyal ba/} 2) {ngo 'phang mtho ba'am bgo mtho ba/}
 kha rgyu bro rgyu|{ro'am bro ba/ zas de sa zos pa bzhin kha rgyu bro rgyu gang yang mi 'dug skad cha de la kha rgyu bro rgyu mang po 'dug}
 kha rgyu gshin po|1) {ngag 'jam po'am mthun po/} 2) {kha la nyan po/}
-kha rgyug gzhan gyi skad cha'i rjes su 'gro ba|{rang gi lta ba med par gzhan gyi kha rgyug byed pa/}
+kha rgyug|{gzhan gyi skad cha'i rjes su 'gro ba/ rang gi lta ba med par gzhan gyi kha rgyug byed pa/}
 kha rgyud|{ngag rgyun nam bshad rgyun/}
 kha rgyun|1) {gtam rgyun nam bshad srol/} 2) {rkyal snod kyi kha sgrog ko rgyun/}
 kha sgo|1) {skad cha/ skad gsang mtho zhing kha sgo yangs po'i thog nas tshogs gtam btang ba/} 2) {bzhin ras sam gdong/ byis pa tshang ma kha sgo mdzes pa sha stag 'dug}
 kha sgyur ba|1) {mdog sgyur ba/ ras dkar po dmar por kha sgyur ba/ kha sgyur dngul chas/} 2) {kha phyogs sgyur ba/ shar phyogs su kha sgyur ba/} 3) {shod stangs sgyur ba/ skad cha shod stangs rtsa ba nas kha sgyur ba/}
-#kha sgrog rkyal pa'am khug ma sogs kyi kha sdom byed|
+kha sgrog|{rkyal pa'am khug ma sogs kyi kha sdom byed/}
 kha sgrob|{kha shob bam 'ud gtam/ gnas lugs dang mi mthun pa'i kha sgrob bshad pa/}
 kha sgrom|{'ud gtam/}
 kha brgya|{skad cha mang po/ mi brgya la kha brgya/}
@@ -3215,11 +3235,11 @@ kha mngar ba|{skad cha 'jam 'jam snyan snyan shod tshul/}
 kha mngal|{lce'i steng ro mi gsal bar gyur pa'i don te/ bad kan gyi nad rtags shig}
 kha lnga pa|{(mngon) seng ge /}
 kha snga ba|{skad cha shod snga ba/ gros 'go 'don mkhan kha snga ba/}
-kha cig la la'am 'ga' zhig kho tsho'i nang nas kha cig gis lan 'debs pa dang|{kha cig gis lan mi 'debs pa/}
+kha cig|{la la'am 'ga' zhig kho tsho'i nang nas kha cig gis lan 'debs pa dang/ kha cig gis lan mi 'debs pa/}
 kha col|{gang byung mang byung shod pa'i kha lang shor ba/}
 kha gcang po|1) {smra mkhas pa/} 2) {gtam snyan po/}
 kha gcig khog gnyis|{kha zhe mi mtshungs pa'i dpe/}
-kha gcig grag kun kha mthun pa|{tshang ma kha gcig grag red/}
+kha gcig grag|{kun kha mthun pa/ tshang ma kha gcig grag red/}
 kha gcig lce gnyis|{kha gcig nas skad cha mi mthun pa gnyis smra ba/}
 kha gcu ba|1) {kha phyogs gzhan du skyog pa/} 2) {kha lo sgyur ba/}
 kha gcus sna gcus|{kha dang sna g.yas g.yon du gcus pa ste gzhan gyi gtam sogs 'dod par mi 'bab pa'i rnam 'gyur zhig}
@@ -3249,18 +3269,18 @@ kha mchu|{gyod dam/ rtsod gleng ngam/ rtsod shad/ kha mchu'i dpang po/ sa khang 
 kha mchu bogs len|{gzhan gyi gyod don rang gis 'gan len pa/}
 kha mchu'i dug ro|{rtsod gleng gi rtsa ba rnying pa/}
 kha 'cham|{gros mthun pa/ nang la kha ma 'chams na phyi la don mi 'grub/}
-#kha 'chams phrugs gcig yid gcig mthun du gyur pa|
+kha 'chams phrugs gcig|{yid gcig mthun du gyur pa/}
 kha 'chal|{don med pa'i gtam/ kha 'chal ngag 'chal/ kha 'chal smra ba/}
 kha 'ching|{ras khug sogs kyi kha 'ching byed dam sdom byed/}
 kha 'chu ba|{rang bzhin 'khyog por 'gyur ba/}
 kha 'chol|{kha nas sgra dag po shod mi thub pa/ kho kha 'chol can yin gshis drags zhes brjod dgos par/ dwags zhes brjod kyi 'dug drags dwags}
 kha 'jam|{ngag 'jam/}
-#kha 'jam gting gnag skad cha 'jam la sems ngan pa|
+kha 'jam gting gnag|{skad cha 'jam la sems ngan pa/}
 kha 'jam gting rtsub|{kha 'jam gting gnag dang don gcig}
 kha 'jal ba|{ras sogs kyi zheng kha la brten nas de'i ring thung tshad 'jal ba/}
 kha rje|1) {rang gi bdag thob rgyu dngos yongs rdzogs/} 2) {bsod nams/}
 kha rje dbang thang|1) {bsod nams dang/ de la longs spyod pa'i bgo skal/} 2) {mi sger gyi rgyu nor longs spyod/ sger gyi kha rje dbang thang so sor dbang/}
-#kha rje'i khyu mchog bsod nams chen po|
+kha rje'i khyu mchog|{bsod nams chen po/}
 kha ljid po|{ngag sgo dam po'am skad cha mang po mi shod pa/}
 kha nyams lces dpyad|{nang rgyus nang gis brtag pa/ kha nyams lces dpyad byas pa'i sgo nas las don 'thus shor med par sgrub dgos/}
 kha nyin|{kha sang gi snga nyin/}
@@ -3276,10 +3296,10 @@ kha ta|1) {bslab bya/ kha tas blo 'gugs/ kha ta skul lcag mi nyan pa la kha ta b
 kha ta ba|{bslab bya byed pa po/}
 kha ta bslab bya|{gros 'debs slob ston/}
 kha ti kha ba|{mtsho sngon khongs gtogs rje tsong kha pa'i dngos slob byang bla mas btab pa ste/ rje tsong kha pas ma yum la bskur ba'i 'dra thang dngos ma gsung 'byon du grags pa dgon pa 'di na bzhugs/}
-#kha tig ro kha ba|
-#kha tog rgyun zas min pa'i dus nges med du bza' rgyu'i rigs|
+kha tig|{ro kha ba/}
+kha tog|{rgyun zas min pa'i dus nges med du bza' rgyu'i rigs/}
 kha ton|{ngag 'don nam rgyun klog gi chos/}
-kha TAM ga|{dbyug to'i rtser thod skam gsum brtsed steng lcags kyi rtse gsum can gyi phyag mtshan zhig}
+kha TAM ga|{dbyug to'i rtser thod skam gsum brtsegs steng lcags kyi rtse gsum can gyi phyag mtshan zhig}
 kha gtad gyong mnyam|{'thab zla gnyis ka gyong tshad mtshungs pa/}
 kha gtad pa|1) {phyogs mdun bstan pa/ the tshom med par shar phyogs su kha gtad nas phyin pa/} 2) {'gran zla byed po/ kha gtad dgra zlar langs pa/ kha gtad 'jal thabs/}
 kha gtam|1) {ngag rgyun nam gtam rgyud/} 2) {skad cha/} 3) {gtam dpe/}
@@ -3310,8 +3330,8 @@ kha thi'i ris can|{ri mo sgor sgor gyi dkyil du gru bzhi yod pa snga dus kyi don
 kha thug|1) {thad ka dang drang po/ lam kha thug tu song na thag nye/ gtam kha thug la bshad na go sla/ las don gang byung yang kha thug so sor byed dgos/} 2) {do bdag gnyis mos kyis bza' tshang byas pa/ kho gnyis kha thug nas lo mang po song/} 3) {stabs 'khel ba/ khyed rang 'dir phebs pa dang kha thug 'khel song/ kha thug gdong thug}
 kha thum|1) {snod spyad kyi kha thum/} 2) {(yul) gyon pa'i mtha' 'gril/ ras kha gang la kha thum brgyab pa/}
 kha ther ther|1) {dgod 'tsher 'tsher/} 2) {snod kyi kha rgya yangs pa/ sder ma kha ther ther zhig tu shing thog bsgrigs pa/ ja dam kha ther ther/}
-kha thog tshig thog gam ngag thog bsam 'char kha thog nas bshad pa|{gtam kha thog don gnas/}
-kha thog lag bzhag tshig thog don gnas kyi dpe|{las don gang yin yang kha thog lag bzhag cig byed dgos/}
+kha thog|{tshig thog gam ngag thog bsam 'char kha thog nas bshad pa/ gtam kha thog don gnas/}
+kha thog lag bzhag|{tshig thog don gnas kyi dpe/ las don gang yin yang kha thog lag bzhag cig byed dgos/}
 kha thogs|{kha btags nas thogs pa'am/ tshang ma gsod thub pa/}
 kha thon pa|{(yul) kha sos pa/}
 kha thor|{kha'i bad thor ram shu thor/}
@@ -3319,7 +3339,7 @@ kha mthun khog 'gal|{skad cha 'dra yang bsam blo tha dad pa/}
 kha mthun gros bsdur|{blo rtse gcig gyur gyi gros mol/}
 kha mthun zhe mthun|{kha zhe gnyis ka mthun pa/}
 kha 'thab pa|1) {khas rtsod pa/ kha 'thab kyis phar phyogs las rgyal ba/} 2) {byung song mgo gtug pa/}
-#kha 'thab rang dag byung song kha 'thabs nas mgo thug pa|
+kha 'thab rang dag|{byung song kha 'thabs nas mgo thug pa/}
 kha 'tham pa|1) {so 'grig ste kha gdangs btsum mi thub pa/} 2) {skad cha lab mi shes pa/ mi kha 'tham pa la skad cha mi 'dri/}
 kha 'then|{rta sogs kyi kha 'then pa/ lam du rta kha 'then nas skad cha shod pa/}
 kha 'thor dgu 'thor|{kha 'thor ya 'thor yang zer/ lhu'am sde tshan/ khyu grangs sogs gyar tshabs che ba/}
@@ -3330,14 +3350,14 @@ kha dan|{'gyur med gtan 'khel gyi tha tshig kha dan tshig la ma gnas na mtha' mj
 kha dam po|1) {gtam cher mi shod pa/} 2) {gsang tshig thub pa/} 3) {kha gcod 'grig po'am dam po/}
 kha dal spyod dal|{lus ngag gnyis ka dal ba/ kha dal bas gang byung shod/ lus khom ste gang byung byed/}
 kha di ra|{seng ldeng shing gi ming gi rnam grangs shig}
-#kha dig lce dig pa ste tshig gsal po smra mi thub pa|
+kha dig|{lce dig pa ste tshig gsal po smra mi thub pa/}
 kha dig lce rengs|{skad cha sgra dag sgros gtsang shod mi thub pa/}
-#kha dig dig sgra mi gsal ba'am gtam thon dka' ba'i ngag dig lkugs|
+kha dig dig|{sgra mi gsal ba'am gtam thon dka' ba'i ngag dig lkugs/}
 kha dug can|{(mngon)} 1) {sbrul/} 2) {dug sbrang/}
 kha dum pa|{gros mthun pa/ don gnad 'di la nga tsho tshang ma kha dum pa yin/}
 kha dul po|1) {ngag 'jam po/} 2) {rta sogs legs par thul ba'i lhing po/}
 kha deb tshad 'dzin|{yig rigs sogs rtsa ba 'dzin sa med par kha nas gang bshad la cha 'jog pa/ kha deb tshad 'dzin du ma gyur par zhib brtsad byed pa gal che/}
-kha dog sngo ser dkar dmar sogs mdog tu rung ba'i gzugs|{kha dog bkrag lhag ge ba/ kha dog gsal ba/ kha dog ngan pa/}
+kha dog|{sngo ser dkar dmar sogs mdog tu rung ba'i gzugs/ kha dog bkrag lhag ge ba/ kha dog gsal ba/ kha dog ngan pa/}
 kha dog gi zil gnon bzhi|{zil gyis gnon pa'i skye mched brgyad kyi nang gses/sngo ser dkar dmar zil gnon bzhi ste/ ting nge 'dzin gyis kha dog rang nyid 'od dang ldan pa dang gzhan so sor dmigs pas sprul bsgyur la dbang bas zil gyis gnon pa'o/}
 kha dog gi gzugs|{kha dog dang don gcig}
 kha dog chen po|{(mngon) gser/}
@@ -3355,10 +3375,10 @@ kha drog|1) {glo bur du bza' btung rnyed pa'i skal ba/} 2) {gnas skabs sam kha s
 kha gdangs pa|1) {kha phye ba/ kha gdangs na glo ba mthong ba/} 2) {skad cha bshad pa/ kha gdangs sa dang lag pa rkyong yul/}
 kha gdan|{'bol gdan gyi kha la gding rgyu'i rum sogs/}
 kha bde po|1) {skad cha shod mkhas po'am kha snyan po/} 2) {smra lce bde myur/ kha bde lce bde/ kha bde dgos khar zad/}
-kha mdog ngo gdong gi mdangs|{yun ring na nas kha mdog shor 'dug}
+kha mdog|{ngo gdong gi mdangs/ yun ring na nas kha mdog shor 'dug}
 kha 'dam|{sge'u gsher/}
 kha 'dar|{ha cang 'khyags ches nas kha 'thab 'thab byed pa/ dgun a rang da rang gi grang ngad ma bzod par kha 'dar ba/}
-#kha 'dig sgye snod sogs kyi kha sdom byed tha gu|
+kha 'dig|{sgye snod sogs kyi kha sdom byed tha gu/}
 kha 'dum|{mi mthun pa mthun par 'gyur ba/}
 kha 'debs|{gzhi rkang gi thog tu rgyag rgyu'i kha snon/ dngul kha 'debs brgyab pa/ ja la kha 'debs btab pa/}
 kha 'dogs pa|{(rnying) tshang ma gsod pa/}
@@ -3404,7 +3424,7 @@ kha spris|{zho dang 'o ma sogs kyi khar chags pa'i spris ma/}
 kha sprod|{thad kar gcig la gcig kha gtad nas yod pa/ sdod sa kha sprod byas nas bsdad pa/ khang pa kha sprod/ rta rgyug na rgyug mnyam dang/ gur rgyag na kha sprod/}
 kha sprod pa|1) {phan tshun ngo shes byed 'jug pa/} 2) {kha dang kha gtugs pa/}
 kha pho|1) {kha shob bam sgrob bshad/ 'ud che'i kha pho zlo ba/} 2) {ya sos ma mchu gnon pa'i rnam 'gyur/}
-#kha pho'i tshig pho bzo'am rdzig gtam|
+kha pho'i tshig|{pho bzo'am rdzig gtam/}
 kha phor|{'thung snod phor pa/}
 kha phyi|{kha btags spus zhan zhig}
 kha phyin pa|{(rnying) gros mthun pa/}
@@ -3425,7 +3445,7 @@ kha 'phrin|{ngag thog gi lan nam skad cha/ nga la kha 'phrin bskyal byung/}
 kha 'phrod po|1) {snod spyad kyi kha gcod 'grig po/} 2) {las ka dang gtam sogs mgo thug pa/}
 kha ba|1. {(tha mi dad pa) dri ma 'thul ba/ me tog gi dri bsung rgyang ring du kha ba/ }2. 1) {gangs/ kha ba sib sib (slowly, gently) 'bab pa/ rdo tshan gyi steng du kha ba bab pa/ ming gi rnam grangs la gangs dang/ char sku/ mchod bya bcas so/} 2) {ro drug gi ya gyal te dom mkhris lta bu'i rdzas gang khar reg pa'i tshe kha yi dri sbyang zhing yi ga med par gyur pa'i bro ba zhig}
 kha ba can|1) {gangs yod pa'i sa cha/} 2) {gangs can te bod yul gyi ming/}
-#kha ba char ldog hor zla dang po'i sgang tshad la kha ba char du 'gro ba'i dus tshigs|
+kha ba char ldog|{hor zla dang po'i sgang tshad la kha ba char du 'gro ba'i dus tshigs/}
 kha ba chung|{hor zla bcu pa'i sgang la kha ba 'bab pa'i mgo tshugs pa'i dus tshigs/}
 kha ba che|{hor zla bcu gcig pa'i dbugs thob nas kha ba che ba 'bab pa'i dus tshigs/}
 kha ba ri pa|1) {gangs ri'i khrod du sdod mkhan/} 2) {bod pa'i ming/}
@@ -3443,7 +3463,7 @@ kha bya|{(rnying) lo rgyus mkhan gyi ngag thog nas bshad pa'i gna' gtam/}
 kha byang|1) {ming byang ngam kha yig kha byang shog lhe/} 2) {za ba dang smra ba la goms pa/}
 kha byang lag byang|{goms 'dris che ba'i dpe/}
 kha byams tshig 'jam|{'jam po ngag kha byams tshig 'jam gyis sems gso byed pa/ kha bye ba/} 1) {rang bzhin du bye ba'am srub gas pa/} 2) {kha bral rgyab 'gal du song ba/} 3) {phru gu'i kha nas skad cha thog ma bshad pa/}
-#kha brag kha dbrag dang 'dra|
+kha brag|{kha dbrag dang 'dra/}
 kha bral ba|1) {so sor gyes pa/ bza' mi kha bral/ phan tshun kha bral du mi rung ba/} 2) {'thor ba'am zhig pa/ 'tshem kha bral ba bskyar du btsems/}
 kha blan pa|{(rnying) kha bsgyur ba/}
 kha blon|{yul dpon/}
@@ -3453,12 +3473,13 @@ kha dbrag|1) {rtsa ba gcig nas khag gnyis gsum du gyes pa/ chu kha dbrag lam kha
 kha 'bab bzhi|{gangs te se'i phyogs bzhi nas 'bab pa'i chu bo bzhi ste/ shar phyogs glang chen kha nas gang gA 'bab/ lho phyogs rma bya'i kha nas sindhu 'bab/ nub phyogs rta yi kha nas pakshu 'bab/ 'di la yar klungs gtsang po'ang zer/ byang phyogs seng ge'i kha nas si ta 'bab/}
 kha 'bar ba|1) {tshig rtsub bshad pa/ khong khro skyes nas kha 'bar ba/} 2) {glo bur phyug por 'gyur ba/ dud tshang kha 'bar ba/} 3) {smra mkhas shing shod rgyu mang ba/ kha 'bar g.yo gtam/}
 kha 'bar ma|{yi dwags kyi rgyal mo zhig}
-#kha 'bar ma'i glud chog yi dwags kyi rgyal mo kha 'bar ma la glud rdzongs bsngo ba'i cho ga zhig kha 'bug skad cha shod pa|
+kha 'bar ma'i glud chog|{yi dwags kyi rgyal mo kha 'bar ma la glud rdzongs bsngo ba'i cho ga zhig}
+kha 'bug|{skad cha shod pa/}
 kha 'bud|{me mda'i kha 'tshang/}
 kha 'bur|{shing bzo ba'i lag cha zhig}
 kha 'bus|{me tog sogs kha bye la khad pa'i mche ba/}
 kha 'bus pa|{me tog dang shing lo'i mche ba gsar du bzhad pa/}
-#kha 'bog rta drel la chag ster snod chag phad|
+kha 'bog|{rta drel la chag ster snod chag phad/}
 kha 'byams|{snying po med pa'i stong gtam/}
 kha 'byams pa|{lo mas 'bras sgrib lta bu'i spros bshad la shor ba/}
 kha 'byar|{phan tshun dam por 'grig pa/ pang leb gnyis kha 'byar nas 'phral ma thub pa/}
@@ -3466,7 +3487,7 @@ kha 'byed pa|1) {so sor kha 'phral ba/} 2) {kha gcod sel ba'am/ srub bar phye ba
 kha 'bras|{gdong gi rnam pa'am dbyibs/ byis pa 'di kha 'bras gtsang ma zhig 'dug}
 kha 'brid pa|1) {slu ba/ nya mo zas kyis kha brid nas bzung ba/} 2) {nyung du gtong ba/ mang drags na kha 'brid par byed dgos/}
 kha 'bru ba|{skad cha sngog pa/ bden rdzun ji 'dra 'dug snyam du tshod len gyis kha 'bru ba/ phu gu'i kha 'bru ba/}
-kha zad|{kha shob bam 'ur shob/ kha rbad shod mkhan/ dngos su lag len med par kha rbad kho na bshad/ kha sbug dog po/ skad cha shod mtsher chen po/}
+kha rbad|{kha shob bam 'ur shob/ kha rbad shod mkhan/ dngos su lag len med par kha rbad kho na bshad/ kha sbug dog po/ skad cha shod mtsher chen po/}
 kha sbub pa|1) {snod spyad kha zhabs slog pa/} 2) {kha sa la bstan pa/ nyal khri'i steng la kha sbub tu nyal ba/}
 kha sbon|{(rnying) kha ton/}
 kha sbyar|1) {kha dang kha sbyor ba'am 'o byed pa/} 2) {snod sogs kyi kha sbyar ba/} 3) {(mngon) ga'u/}
@@ -3497,25 +3518,25 @@ kha rtsang|{khar rtsang dang 'dra/}
 kha rtsar 'khril po|{kha la nyan po/ bzhon rta kha rtsar 'khril po/ gang bshad lag len byed pa'i las rogs kha rtsar 'khril po/}
 kha rtsal|{gtam shod pa'i nus rtsal/}
 kha rtsis|{yid 'dren bzhin du ngag thog nas drangs pa'i rtsis thabs/}
-#kha rtsub khog yag kha mi snyan yang sems bzang ba|
+kha rtsub khog yag|{kha mi snyan yang sems bzang ba/}
 kha rtsed|{kha nas rtsed mo shod pa/}
 kha rtsod|{rtsod gleng ngam kha 'dzing/ kha rtsod rdzogs rgyu med par rgyag pa/ don med kha rtsod shor nas sems 'khrugs pa/}
 kha tsha|1) {byis pa'i kha'i nang du byung ba'i thor pa/} 2) {nor phyugs kyi kha lce dang sug bzhi la phog pa'i phyugs kyi 'gos nad gdug pa can zhig}
 kha tsha dgos gal|{kha tsha dgos nges/ 'tsho ba'i nang nas lto gos gnyis kha tsha dgos gal che shos red/}
 kha tsha dgos gtugs|{kha tsha dgos gal dang don gcig}
-#kha tsha gting nag bshad bshad tsha la sems ngan pa|
+kha tsha gting nag|{bshad bshad tsha la sems ngan pa/}
 kha tsha dus gtugs|{shin tu gal gnad che ba'i dus tshod la nye bar slebs pa/}
 kha tsha po|1) {mi kha drag po'am kha rtsub po/} 2) {gal che ba'am lag thogs po/ dgos mkho kha tsha po/} 3) {ro kha tsha ba/ phru gu la kha tsha po'i zas ma sprod/} 4) {shugs drag po/ dmag kha tsha po zhig rgyag gi 'dug}
 kha tsha ba|{ro kha tsha ba/}
 kha tsha rmig tsha|{rmig pa kha dbrag can gyi dud 'gro'i rims nad cig thog mar phog skabs kha chu mang du thon rjes khar phog na kha rul ba dang/ lce 'chad pa/ rmig par phog na rmig pa rul te chad 'gro ba'i phyugs kyi 'gos nad che gras shig}
 kha tsha ra|{(yul) bod pa dang bal po 'dus pa las byung ba'i mi/}
-#kha tshag dkar yol sogs kyi kha cung zad chag pa|
+kha tshag|{dkar yol sogs kyi kha cung zad chag pa/}
 kha tshang|1) {gnag phyugs kyi mdun so brgyad po brjes pa'i lo bdun pa'i ming/} 2) {grangs tshang/ kha tshang cha tshang/ sgo ra kha tshang/}
 kha tshad|1) {kha zheng gi tshad/} 2) {kha shags 'gran pa/} 3) {zas kyi bro ba lta ba/ ja'i tshwa che chung kha tshad lta ba/}
 kha tshan|1) {gangs 'bab tshan/ klung la bab pa las ri mgor bab pa'i kha tshan che/} 2) {skad cha shod shugs/ bden rdzun gyi dbye ba ma phye gong du kha tshan chen po de 'dra bshad nas gang yong/} 3) {kha dang so'i ngar shugs/ khyi 'di kha tshan chen po yin pas spyang ki la 'thab thub yong/}
 kha tshar|1) {ras dang snam bu sogs kyi sne 'dzar/ gos chen gyi kha tshar ring nge ba/} 2) {bskong cha dang/ bsnan cha/ nor bu bdun thang la kha che sha kha ma'i kha tshar btab pa/}
 kha tshar sman|{sbyor sde byas pa'i gtso bo'i sman gyi steng du kha tshar gdab pa'i sman gzhan re gnyis dper na khyung lnga'i steng du mgron thal bsnan nas skran nad kyi sman du btang ba lta bu'o/}
-kha tshig kha nas bshad pa'i gtam|{snying gtam shod dgos pa las kha tshig tsam mi smra/}
+kha tshig|{kha nas bshad pa'i gtam/ snying gtam shod dgos pa las kha tshig tsam mi smra/}
 kha tshig pa|{mchu to bza' btung tsha mos tshig pa/}
 kha tshugs|{gsang gtam gzhan la mi shod pa'i kha tshod zin po/}
 kha tshub|{sbra gur gyi mthongs g.yogs/}
@@ -3536,7 +3557,7 @@ kha 'dzin|1) {'tsho 'dzin/ khyim gyi kha 'dzin/ gzhis kyi kha 'dzin/} 2) {phyogs
 kha 'dzin rogs dan|{phyogs 'dzin rogs ram/ nyam chung skyong 'os rigs la kha 'dzin rogs dan gang thub byed pa/}
 kha 'dzin gsum|{sug smel dang/ gur kum/ pi pi ling ste gsum/}
 kha 'dzum|{gad mo cung zad bgad pa/}
-kha rdzig ngo rdzig gtam rdzig po shod pa dang|{gdong rdzig po ston pa/}
+kha rdzig ngo rdzig|{gtam rdzig po shod pa dang/ gdong rdzig po ston pa/}
 kha zhan pa|1) {kha dbang chung ba'am skad cha nus med/} 2) {'khos ka dman pa'am dbang thang chung ba/}
 kha zhugs|{kha brnyogs lang shor/}
 kha zhun|{snum zhun sgron me'i yas snod/}
@@ -3545,7 +3566,7 @@ kha zheng|{zheng ngam rgya khyon/}
 kha zhen|1) {kha bshad tsam la zhen pa/} 2) {gting nas sha zhen med pa'i dga' khul/}
 kha gzhon pa|{sgo phyugs na so chung ba/}
 kha zas|1) {bza' bca' spyi/ kha zas za tshod ma zin pa/ kha zas bsod pa/ kha zas skya ba/ kha zas ro brgya dang ldan pa/ kha zas mi mthun pa zos pas khams ma snyoms pa las sdug bsngal byung ba/ ming gi rnam grangs la lto dang/ bzhes bya/ zas/ bza' bca' bcas so/} 2) {bzhes spro'am dkar spro/}
-kha zas spyod tshul nyer gcig nyes byas kyi sde tshan lnga pa zas za ba'i sde la|{zas legs par mi za ba dang/ zas kham ha cang che ba dang/ ha cang chung ba dang/ 'jig rten dang mthun pa'i kham ran pa min pa dang/ zas kha sgor ma slebs par kha gdangs pa dang/ za bzhin du gtam smra ba dang/ zas mi zhim par tsug tsug dang/ zas zhim par cag cag dang/ grang ba la hu hu dang/ tsha ba la phu phu'i sgra dang bcas pa dang/ lce phyir phyung ba dang/ 'bras sogs 'bru ma re re nas gud du phye ba dang/ zas la 'phya smod dang/ kham gcig mkhur g.yas g.yon du spo ba dang/ rkan sgra gtog pa dang/ dud 'gro ltar kham 'phro bcad pa dang/lag pa la zas chags pa bldag pa dang/ mdzub mos lhung bzed brad nas 'byog pa dang/ lag pa la zas chags pa sprugs pa dang/ zas dang bcas pa'i lhung bzed skyom skyom byed pa dang/ zas mchod rten gyi gzugs 'dra bar bcos pa'i tshul gyis za ba ste nyer gcig go /}
+kha zas spyod tshul nyer gcig|{nyes byas kyi sde tshan lnga pa zas za ba'i sde la/ zas legs par mi za ba dang/ zas kham ha cang che ba dang/ ha cang chung ba dang/ 'jig rten dang mthun pa'i kham ran pa min pa dang/ zas kha sgor ma slebs par kha gdangs pa dang/ za bzhin du gtam smra ba dang/ zas mi zhim par tsug tsug dang/ zas zhim par cag cag dang/ grang ba la hu hu dang/ tsha ba la phu phu'i sgra dang bcas pa dang/ lce phyir phyung ba dang/ 'bras sogs 'bru ma re re nas gud du phye ba dang/ zas la 'phya smod dang/ kham gcig mkhur g.yas g.yon du spo ba dang/ rkan sgra gtog pa dang/ dud 'gro ltar kham 'phro bcad pa dang/lag pa la zas chags pa bldag pa dang/ mdzub mos lhung bzed brad nas 'byog pa dang/ lag pa la zas chags pa sprugs pa dang/ zas dang bcas pa'i lhung bzed skyom skyom byed pa dang/ zas mchod rten gyi gzugs 'dra bar bcos pa'i tshul gyis za ba ste nyer gcig go /}
 kha zungs|{rwa rnyi'i rgyud thag}
 kha zur|1) {kha'i grwa/} 2) {gtam gyi tshig zur/}
 kha zer ba|{mi snyan par brjod pa'am smad ra gtong ba/}
@@ -3556,17 +3577,18 @@ kha bzas 'gab btang|{tshur yag po byas pa de phar sdug po lan 'jal ba'i dpe/}
 kha bzas lce thim|{rang gis bzas tshar ba'am bed spyad tshar ba'i don/ kha bzas lce thim gyi bu lon de gang ltar sel dgos/}
 kha bzed pa|{kha gyen du bslangs pa/}
 kha bzo 'pher po|{kha bde la gtam shod mkhas po/}
-kha 'og 'og dang don gcig kha ya|1) {gtam lan/ gtam dris kyang kha ya mi byed/} 2) {sne len/ sku mgron bos te kha ya gzab rgyas byas pa/} 3) {ya gyal/} 4) {'gran pa'i do zla/ ge sar nor bu dgra 'dul de/ gnam sngon po khebs pa'i kha ya red/ sgo khyi ji ltar btsan kyang/ gzig gi kha ya mi yong/}
+kha 'og|{'og dang don gcig}
+kha ya|1) {gtam lan/ gtam dris kyang kha ya mi byed/} 2) {sne len/ sku mgron bos te kha ya gzab rgyas byas pa/} 3) {ya gyal/} 4) {'gran pa'i do zla/ ge sar nor bu dgra 'dul de/ gnam sngon po khebs pa'i kha ya red/ sgo khyi ji ltar btsan kyang/ gzig gi kha ya mi yong/}
 kha ya ngo ya|{'grul pa'i sne len/ 'grul pa la kha ya ngo ya legs par byed pa/}
 kha yag ngo bstod|{kha mkhas po'i ngo bstod/}
-#kha yag ngo yag kha mkhas 'dra chags|
-#kha yag tshig yag bkra shis pa'i gtam mam skad cha snyan mo|
+kha yag ngo yag|{kha mkhas 'dra chags/}
+kha yag tshig yag|{bkra shis pa'i gtam mam skad cha snyan mo/}
 kha yang ba|1) {gtam mang ba/} 2) {kha brtan po ma yin pa/}
 kha yan pa|1) {nang gtam phyi gyar/ rang snang gang dran gyis kha yan pa/} 2) {bor stor ram/ kha 'thor ba/ dngos nor yo byad bar ma dor kha yan pa rnams rtsad gcod byed pa/}
 kha yar|1) {so so'am re re ba/ mi rigs kha yar/} 2) {thar thor/ 'bras bu kha yar/} 3) {kha shas dang/ 'ga' shas/ yo byad kha yar/}
-#kha yig ming byang ngam kha byang gi yi ge|
+kha yig|{ming byang ngam kha byang gi yi ge/}
 kha yu|{ri dwags kha sha mo/}
-kha yog ma nyes par nyes so zhes khag dkri ba|{ma nyes kha yog byung na bzod thabs med/}
+kha yog|{ma nyes par nyes so zhes khag dkri ba/ ma nyes kha yog byung na bzod thabs med/}
 kha yod lag med|{stong bshad ma gtogs don la med pa'am tshig thog tu don mi 'khyol ba/}
 kha yon|{kha kyog kyog}
 kha g.ya' ba|{za rkong ba ste lus la za 'phrug langs pa/}
@@ -3597,7 +3619,7 @@ kha rong dog po|{ri phan tshun bar gyi sa yul gu dog po/ kha rlangs/ kha'i dbugs
 kha brlang po|{tshig rtsub po/ gzhan sems sreg pa'i kha brlang po byed pa/}
 kha la rgya byin|{kha la thel tshe brgyab ste gtam smra ru ma bcug pa'am smra ba'i nus pa med par bzo ba/ rtsod gshags btab pas kha la rgya byin ltar lan gdab rgyu med par gyur/}
 kha la ca le ba|{gting la ma 'dres par kha la g.yengs pa/}
-#kha la yug khug rta'am char sdod bye'u|
+kha la yug|{khug rta'am char sdod bye'u/}
 kha lag|1) {bza' btung gi ming/} 2){kha dang lag pa/}
 kha lang|{byis pa'i kha'i nang du byung ba'i thor pa chung ngu zhig}
 kha lad pa|1) {kha ngan lang la shor ba/} 2) {zas za nyes shor ba/}
@@ -3614,9 +3636,9 @@ kha leb|{kha gcod/}
 kha lo|{kha phyogs kyi sgyur kha/ kha lor 'gro ba/ rta 'di kha lo bde po mi 'dug kha lo med pa rkyang dang 'dra/ sna lo med pa 'brong dang 'dra/}
 kha lo sgyur ba|1) {dbang sgyur ba/} 2) {kha phyogs sgyur ba/ chibs pa'i kha lo sgyur ba/ rlangs 'khor kha lo sgyur ba/} 3) {sangs rgyas shig}
 kha lo pa|{shing rta sogs kyi kha lo sgyur mkhan/ ming gi rnam grangs la kha lo sgyur ba dang/mgo 'dren/ sgyur byed/ mngag byed/ sna khrid/ g.yas sdod/ g.yon sdod bcas so/}
-#kha log ngo log rgol ba'i gtam dang bya spyod|
+kha log ngo log|{rgol ba'i gtam dang bya spyod/}
 kha log pa|1) {phar byas pa'i lan tshur ldog pa/ rang gi bya spyod nor bas mang tshogs kha log pa red/ khyi gyang khug la bkar na kha log mi rgyag ka med red/} 2) {mtshon gyi rno log pa/}
-kha log tshig log yi ma rangs pa'i tshig lan|{sems bzang gi kha ta la kha log tshig log rgyag mi rung/}
+kha log tshig log|{yi ma rangs pa'i tshig lan/ sems bzang gi kha ta la kha log tshig log rgyag mi rung/}
 kha sha|1) {ri dwags bye brag cig} 2) {ko ba mnyes ma'i skyi dkar/}
 kha shags|{kyal ka'i sgo nas shags 'gyed pa/ phyogs gnyis phan tshun kha shags rgyun mi 'chad par 'gyed pa/ gzu dpang gi mdun du su bden su rdzun gyi kha shags 'gyed pa/ mi tsho khag gnyis kyis gzhas tshig gis kha shags rgyag pa/}
 kha sha'i rwa|{srog chags sman gyi rigs shig ste/ ro lan tsha/ zhu rjes bsil/ nus pas glo ba sogs byang khog tu rnag khrag chu ser rgyas pa skem/ dug tshad sel/}
@@ -3671,25 +3693,26 @@ kha bslus pa|1) {rdzun gyis mgo skor btang ste rgyu nor khyer ba'am phrogs pa da
 kha ham che ba|{kha shed mkhrang ba'am kha shob tsha ba/}
 kha hub rgyag pa|{khas rngub pa/}
 kha hrag po|{kha dbang btsan pa/ kha hrag po shod mkhan de'i kha dbang du ma shor ba/}
-kha lhag byung song gi rtsis kha 'thab pa'i lhag ma'am|{nor zas bed spyad pa'i lhag ma/ tshong rtsis brgyab pa'i kha lhag 'tsho ba'i cha rkyen du bed gcod byas pa'i kha lhag}
+kha lhag|{byung song gi rtsis kha 'thab pa'i lhag ma'am/ nor zas bed spyad pa'i lhag ma/ tshong rtsis brgyab pa'i kha lhag 'tsho ba'i cha rkyen du bed gcod byas pa'i kha lhag}
 kha lhag 'khrol 'khyil|{rtsis mgo gtugs pa'i lhag ma'am/ bed spyad pa'i lhag 'phro/}
 khag|1) {sde tshan/ dgon sde khag yul khag lung pa khag las khungs khag} 2) {'gan/ lag bstar gyi khag 'khur ba/ 'thus tshang yong ba'i khag 'gan len pa/} 3) {nyes 'gan/ khyed rang la khag med/}
 khag dkri|{nyes 'gan g.yog pa/ phar tshur nga min kho yin gyi khag dkri byas/ gcig gis gcig la khag dkri bzhag pa/}
 khag dkri bsnyon 'dzugs|{byas nyes gzhan la g.yogs pa dang ham pa shod pa/ mi la khag dkri bsnyon 'dzugs kyis rang nyes sel thabs byed/}
 khag skur|1) {ma byas kyang byas song zhes pa'i nyes skyon 'dogs pa/} 2) {las ka'i 'gan dkri ba/}
-khag khag so so'am|{rang rang gcig pu/ las ka gcig pa ma red khag khag red/ sha rdza ma la btsos kyang sha khu khag khag}
+khag khag|{so so'am/ rang rang gcig pu/ las ka gcig pa ma red khag khag red/ sha rdza ma la btsos kyang sha khu khag khag}
 khag khag so so|{phan tshun 'brel ba med pa/ bzo zhing tshong gsum khag khag so so min par phan tshun 'brel ba dam zab yod/}
 khag 'khur|{'gan 'khur/ nga rang gis khag 'khur thub/}
-#khag 'khyag 'gan len|
+khag 'khyag|{'gan len/}
 khag 'khris|{'gan 'khel ba/}
 khag bgo|{sde tshan so sor bgo ba/ dpung sde khag bgos te btang ba/ las 'gan rnams sde tshan so sor khag bgos kyis sprad pa/}
 khag 'gan|1) {las ka'i khur 'gan/} 2) {nyes skyon gyi 'gan/}
 khag 'gel|{nyes pa ma byas par byas tshul gyi khag ngan g.yogs pa/}
 khag ngan pa|{nag nyes sam lan rtsa/ sha zhim po a pho spyang kis bzas/ khag ngan pa a lce wa mor bzhag}
 khag ngan sbir sgra|{nyes can yin pa'i skad grad/ gzugs med grib bzo byas nas khag ngan sbir sgra ci che sgrog pa/}
-khag gcig sde tshan gcig mi khag gcig lung pa khag gcig khag 'jog skyon 'gel ba'am snyad 'dogs pa|{rang nongs ngos len mi byed par gzhan la khag 'jog thabs byas/}
+khag gcig|{sde tshan gcig  mi khag gcig  lung pa khag gcig}
+khag 'jog|{skyon 'gel ba'am snyad 'dogs pa/ rang nongs ngos len mi byed par gzhan la khag 'jog thabs byas/}
 khag btags pa|1) {khag 'phangs pa/ kham bu za 'dod med pas skyur mo'i ro la khag btags/} 2) {nyes khag g.yogs pa'am snyad btags pa/ kho la ma byas byas tshul gyi khag btags pa red/}
-#khag theg 'gan len byed pa'i ming|
+khag theg|{'gan len byed pa'i ming/}
 khag theg pa|1) {'gan len pa po/} 2) {'gan len thub pa'am/ phod pa/}
 khag po|{las sla po min pa/ dka' las khag po/ bsam blo 'khor tshad lam la 'gro rgyu khag po 'dug}
 khag sbyong|{sdug sbyong/ khag sbyong gi dus tshod yol nas slar ldang ba'i go skabs med par gyur song/}
@@ -3700,8 +3723,7 @@ khag rub|{khag mang phyogs gcig tu sgril ba/ mi mang phyogs gcig tu khag rub kyi
 khang khungs|{khang pa'i 'dzin bdag su yin gyi khungs/ gzhung gi khang khungs/ sger gyi khang khungs/}
 khang khongs|{su yang rung ba zhig la bdag dbang thob pa'i khang pa'i gras/ gzhung la bdag pa'i khang khongs le lag khor yug sger la dbang ba'i khang khongs steng shod khe gtsang/}
 khang khyim|{khang pa'am khyim/}
-khang khral|{sngar khang pa glas nas sdod mkhan tshos}
-khang bdag la khang gla sprod rgyu'i khongs su ma gtogs pa'i ngal rtsol gyi khral|{sngar khang khral rgyug pa dang khang gla sprod pa khag khag red/}
+khang khral|{sngar khang pa glas nas sdod mkhan tshos khang bdag la khang gla sprod rgyu'i khongs su ma gtogs pa'i ngal rtsol gyi khral/ sngar khang khral rgyug pa dang khang gla sprod pa khag khag red/}
 khang gla|{sdod khang g.yar ba'i gla/ khang mig stong pa gzhan la khang glar gtong ba/ khang gla sprod pa/ khang gla bsdu ba/}
 khang sgrom|{khang pa'i phyi'i sgrom/}
 khang chen|1) {khang pa chen po/ khang chen thog brtsegs can/} 2) {gtsug lag khang/}
@@ -3711,9 +3733,9 @@ khang gnyer|{khang pa bdag gnyer byed po/}
 khang stong rkun ma|{don med rnam rtog gi dpe/ rnam rtog dgra ru langs na/ khang stong rkun mas khengs/}
 khang thog|1) {khang pa'i steng ngam rtse thog /}2) {khang pa'i thog 'gebs sam thog khebs/ ming gi rnam grangs la chu skyob dang/ ya phub/ yang thog bcas so/}
 khang thog chu 'gro|{khang steng gi chu 'gro'i wa kha/}
-#khang thog dar lcog khang pa'i thog tu btsugs pa'i dar lcog lda ldi dang bcas pa|
+khang thog dar lcog|{khang pa'i thog tu btsugs pa'i dar lcog lda ldi dang bcas pa/}
 khang thog pu shu|{khang pa'i nya rgyab/}
-khang bdag khang pa'i bdag po|{khang bdag gi thog khar mo bran gyi rdig sgra/}
+khang bdag|{khang pa'i bdag po/ khang bdag gi thog khar mo bran gyi rdig sgra/}
 khang pa|{mi'i sdod sa dang ca lag 'jog sa'i 'dzugs skrun dngos po/ khang tshon/ steng khang/ bar khang/ brang khang/ gzhung khang/ 'og khang/ khang pa rgyag pa/ grong khyer gyi dkyil du khang pa tsog tsog cig 'dug lo mang song ba'i khang pa hrul po/ ming gi rnam grangs la khang khyim dang/ khab/ khyim/ 'jug bya'i gnas/ rten gnas/ rten gzhi/ 'dug gnas/ 'dug sa/ gnas khang/ gnas gzhi/ phibs 'og bla gab can bcas so/}
 khang pa lcam gang ma|{zheng du lcam gang las med pa'i khang mig}
 khang pa'i lhag ma|{dge 'dun lhag ma bcu gsum las/ yo byad la chags pa las gyur pa gnyis kyi ya gyal/ gzhi srog chags mang zhing rtsod pa can 'jig rkyen yod pas mi rung ba gsum dang ldan pa'i sar rang don du dge 'dun las gnang ba ma thob bzhin srid du khru bco brgyad dang/ zheng du khru phyed dang bcu gcig gi tshad las lhag pa'i khang pa brtsigs pa'o/}
@@ -3722,12 +3744,13 @@ khang bu|{khang pa chung chung/}
 khang byi'u|{khang khyim du gnas pa'i byi'u mchil pa/}
 khang bye'u|{khang byi'u dang 'dra/}
 khang byel|{khang byi'u dang 'dra/}
-khang mig bcad brgyab pa'i khang chung|{khang pa 'di'i nang khang mig ga tshod 'dug}
+khang mig|{bcad brgyab pa'i khang chung/ khang pa 'di'i nang khang mig ga tshod 'dug}
 khang mo che|{khang pa chen po/}
 khang dmar|{rdzong zhig bod rang skyong ljongs kyi lho rgyud rgyal rtse dang gro mo'i bar du yod/ rdzong 'di'i lho ngos 'brug yul dang sa 'brel yin/}
 khang rmang|{khang pa'i gzhi rtsa'am rtsig pa'i rmang/ khang rmang gting ring po bting na brtan po yong/}
 khang rtsa|1) {khang pa'i rmang gzhi'am rtsig rmang/} 2) {khang pa'i 'khris sam 'gram/ khang par me skyon shor na/ khang rtsa'i rdzing chu skam yong/}
-khang rtsig khang pa'i rtsig pa|{khang rtseg khang pa brtsegs pa'am thog brtsegs can/}
+khang rtsig|{khang pa'i rtsig pa/}
+khang rtseg|{khang pa brtsegs pa'am thog brtsegs can/}
 khang tshan|{khams tshan dang 'dra/}
 khang mtshes|{grong pa khyim mtshes/}
 khang 'dzin|{khang gla sprad 'dzin/}
@@ -3761,7 +3784,7 @@ khab snyung gang 'gro|{'gro tshod dam g.yo thabs gang thub ci thub byed pa'i dpe
 khab snod|{'tshem spyad khab blug snod/}
 khab spang ba|{khyim spang ba/}
 khab be khob be|{lus las su mi rung ba'am las ji bzhin du byed mi thub pa'i tshul/ na nas nyal mal nang du khab be khob ber lus/ lus po khab khob tu gyur pa/}
-khab mig khab mgo'i i khung|{khab mig tu skud pa brgyus pa/}
+khab mig|{khab mgo'i i khung/ khab mig tu skud pa brgyus pa/}
 khab btsa'|{gser khab dang me btsa'/}
 khab btsun ma|{khyim bdag mo'am/ btsun mo/}
 khab btsun mo|{khab btsun ma dang 'dra/}
@@ -3785,8 +3808,9 @@ kham chu|{spar kha brgyad kyi ya gyal zhig}
 kham chung|{sangs rgyas kyi gsung yum 'bring po nyi khri lnga stong bon gyi tha snyad du bsgyur ba/}
 kham chen|{sangs rgyas kyi gsung yum rgyas pa bon lugs su bsgyur ba/}
 kham star|{shing 'bras kham bu dang star ga'i bsdus tshig}
-kham mdog kha dog gi bye brag cig kham sdong|{kham bu'i shing sdong/}
-kham nag kha dog gi bye brag cig ste|{mdog ser nag las nag po shas che ba zhig}
+kham mdog|{kha dog gi bye brag cig}
+kham sdong|{kham bu'i shing sdong/}
+kham nag|{kha dog gi bye brag cig ste/ mdog ser nag las nag po shas che ba zhig}
 kham pa|{kha dog gi bye brag cig ste/ mdog ser nag mdzo mo kham pa/}
 kham phor|{rdza phor/}
 kham 'phro|{khar zos pa'i zas rdog lhag ma/}
@@ -3795,10 +3819,10 @@ kham bu rdo len|{khams phyogs kyi byis pa'i rtsed mo zhig ste/ 'khyil chu'i nang
 kham bu ma chu|{bod rang skyong ljongs kyi lho rgyud na yod pa'i 'bab chu zhig de'i chu 'go blon po rgyal gdong nas byung zhing/ gro mo brgyud nas 'brug yul du 'bab/}
 kham mi khum mi|1) {sul mang ba'i rnam pa zhig kham khum sul mang ras gos gyon mi bde/} 2) {gnyer ma/ rgad po'i lus la kham khum gnyer ma mang/}
 kham dmar|{kha dog gi bye brag cig ste/ mdog ser nag las dmar shas che ba/}
-kham smug kha dog gi bye brag cig ste|{mdog ser nag}
+kham smug|{kha dog gi bye brag cig ste/ mdog ser nag}
 kham smyug ri mo|{kham bu dang smyug ma'i ri mo'i bsdus ming/}
 kham tshad|{zas kha gang gi tshod/}
-#kham tshig kham bu'i tshi gu'am nang rus sam nang snying|
+kham tshig|{kham bu'i tshi gu'am nang rus sam nang snying/}
 kham tshig gi nang snying|{kham tshig nang du yod pa'i son dkar po/}
 kham tshod|{kham tshad dang 'dra/}
 kham zas|{'dod pa'i khams kho na la yod pa ste/ sna lce lus gsum gyis kham du bcad cing mid nas za ba'i dri ro reg bya gsum gyi bdag nyid can/}
@@ -3833,18 +3857,20 @@ khams brtas|{lus kyi stobs rgyas pa/}
 khams tha ma|1) {gshis sam rang bzhin ngan shos/} 2) {'dod khams/}
 khams dang sa pa|{khams gsum dang de'i sas bsdus pa/}
 khams dwangs pa|1) {lus kyi khams bde ba/} 2) {gtsang ma'am/ dwangs gsal/}
-khams drug sa'i khams|{chu'i khams/ me'i khams/ rlung gi khams/ nam mkha'i khams/ rnam par shes pa'i khams bcas drug go /}
+khams drug|{sa'i khams/ chu'i khams/ me'i khams/ rlung gi khams/ nam mkha'i khams/ rnam par shes pa'i khams bcas drug go /}
 khams drug ldan|{nam mkha'/ rlung/ me/ chu/ sa/ ye shes kyi khams rnams ldan pa'i mi'i lus rten gsang sngags rdo rje theg pa sgrub pa'i snod du rung ba/}
 khams bde ba|{lus la nad med pa/ khams bde 'dri ba/}
 khams 'dri|{lus bde'am zhes 'dri ba/}
-khams rdig si khron zhing chen khongs dkar mdzes bod rigs rang skyong khul gyi sde dge dang dpal yul nas thon pa'i zangs rag gi rdig khams ldog pa|1) {lus kyi 'byung ba'i khams log pa/} 2) {zas kyi dang ga log pa/} 3) {mi'i rang bzhin nam gshis ka 'gyur ba/}
+khams rdig|{si khron zhing chen khongs dkar mdzes bod rigs rang skyong khul gyi sde dge dang dpal yul nas thon pa'i zangs rag gi rdig}
+khams ldog pa|1) {lus kyi 'byung ba'i khams log pa/} 2) {zas kyi dang ga log pa/} 3) {mi'i rang bzhin nam gshis ka 'gyur ba/}
 khams sna tshogs mkhyen pa'i stobs|{theg pa che chung rnam pa gsum gyi rigs dang ma nges pa dang rigs med pa lta bu dang/ skal ba dang bag chags shas che chung gi bye brag gis rigs lngar dbye bar mkhas pa'am/ yang na/ rten dbang po'i khams dang/ brten pa rnam shes kyi khams/ dmigs pa yul gyi khams la sogs pa khams kyi rab dbye rnam pa kun tu mkhyen pa/}
 khams pa|{khams kyi yul mi/}
 khams pa dbu se|{karma dus gsum mkhyen pa'i mtshan gzhan zhig}
 khams 'pho ba|1) {lus kyi khu ba 'chor ba/} 2) {'chi 'pho ba/}
 khams bar ma|{gzugs khams/}
 khams bris|{khams nas bris pa'i yig gzugs sam ri mo/}
-khams mi nyag khams yul gyi bye brag cig khams dmar po|{(mngon) khrag dang zla mtshan/}
+khams mi nyag|{khams yul gyi bye brag cig}
+khams dmar po|{(mngon) khrag dang zla mtshan/}
 khams rmya ba|{thang chad pa'am nyob pa/}
 khams smad|{khams yul gyi chu bo mang che ba byang nas lho phyogs su 'bab pas sngar bod kyi deb ther nang du gsang sngags chos rdzong gi shar rgyud nas yun nan zhing chen gyi nub rgyud bar la khams smad zer/}
 khams tshan|{dgon pa'i grwa tshang gi sde tshan zhig grwa pa yong khungs sa khul la gzhigs nas tshan khag so sor bgos shing/ khams tshan du ma las grwa tshang gcig grub/ sngar se 'bras dga' gsum la cha bzhag na/ se ra dgon par khams tshan sum cu dang/ 'bras spungs dgon par brgyad cu/ dga' ldan dgon par nyer drug bcas yod pa lta bu'o/}
@@ -3867,7 +3893,8 @@ khams gsum 'khor los sgyur ba|{(mngon) dus 'khor/}
 khams gsum na spyod pa|{khams gsum na gnas pa'i sems can/}
 khams gsum rnam rgyal|{(mngon) sgra gcan/}
 khams gsum pa|1) {gzugs med kyi khams/} 2) {lha dbang phyug chen mo'i bu rgan pa tshod bdag}
-khams gsum dbang 'dus spyan ras gzid spyan ras gzigs kyi bye brag cig khams gsum sa dgu|{'dod khams dang/ bsam gtan bzhi/ gzugs med bzhi rnams so/}
+khams gsum dbang 'dus spyan ras gzigs|{spyan ras gzigs kyi bye brag cig}
+khams gsum sa dgu|{'dod khams dang/ bsam gtan bzhi/ gzugs med bzhi rnams so/}
 khams gseng|{skyo dub bsang ba'am gseng bar byed pa/}
 khams gso|{lus stobs 'phel thabs byed pa/}
 khams bsil|1) {lus grang bas gdungs pa/} 2) {'byung ba grang ngad can/}
@@ -3875,7 +3902,7 @@ khar khor|{kha re kho re'i bsdus tshig}
 khar gong|{rdo dkar gong/}
 khar rje|{kha rje dang 'dra/}
 khar 'don pa|1) {ngag nas 'don pa/ blo na yod pa'i don khar 'don pa/} 2) {dngos po sogs steng du 'don pa/}
-khar phog snar phog 'dzems zon med pa'i tshig rtsub|{skad cha khar phog snar phog kho na shod pa/}
+khar phog snar phog|{'dzems zon med pa'i tshig rtsub/ skad cha khar phog snar phog kho na shod pa/}
 khar dbang|{kha rje dbang thang gi bsdus tshig}
 khar rtsang|{kha sang ste de ring gi snga nyin/}
 khar sang|{khar rtsang dang don gcig}
@@ -3897,13 +3924,14 @@ khal 'phyags|{(yul) sngar gzhung gi ar las dang/ smon lam tshogs shing sogs la k
 khal 'phyags rgyag pa|{khal ma gar yod btsan khral du skul ba/}
 khal ma|{do po 'gel sa'i phyugs sogs/}
 khal rdza|{'bru khal gcig shong ba'i rdza ma/}
-khal g.yag khal 'gel sa'i g.yag khas 'che ba|{rang gis khas len pa'am rang nyid ngo sprod pa/ skye bo dam pas khas 'che ba/ bsgrims te 'bad pas 'grub par bya/}
+khal g.yag|{khal 'gel sa'i g.yag}
+khas 'che ba|{rang gis khas len pa'am rang nyid ngo sprod pa/ skye bo dam pas khas 'che ba/ bsgrims te 'bad pas 'grub par bya/}
 khas 'ches pa'i dge slong|{sdom pa ma blangs pa'am/ yang na sdom pa ral te med par gyur na yang nga dge slong yin zhes pa lta bu/}
 khas brjod|{(mngon) glu dbyangs/}
 khas nyin|{kha sa'i snga nyin/}
 khas blangs kyis bsal ba|{bsal ba bzhi'i nang gses/ rang tshig snga phyi 'gal ba/ dper na/ bdag gi ma mo gsham yin no zhes pa lta bu'o/}
 khas blangs rgyab skyur|{khas len byas pa'i don ma brtsis pa/ las don sgrub rgyu khas blangs rgyab skyur byas na ma rabs khrel med red/}
-khas blangs thebs gcog khas len byas pa'i don lag tu mi len pa|{las rogs sgrub rgyu gtan 'khel byas kyang khas blangs thebs gcog byed pa/}
+khas blangs thebs gcog|{khas len byas pa'i don lag tu mi len pa/ las rogs sgrub rgyu gtan 'khel byas kyang khas blangs thebs gcog byed pa/}
 khas blangs pas zhi ba|{'dul ba las bshad pa'i rtsod pa zhi byed kyi chos bdun gyi gras/ ltung ba gleng ba na mthong sdom legs par byas pa'i sgo nas phyir bcos te rtsod pa zhi bar byed pa'o/}
 khas blangs lag bstar|{khas len byas pa'i don dngos su bsgrubs pa/ rang gis ji ltar bshad pa'i don rnams khas blangs lag bstar tshig thog don 'khel byas pa/}
 khas dman|{'khos kas dbul ba/}
@@ -3911,16 +3939,16 @@ khas zhan pa|{kha zhan pa dang 'dra/}
 khas gzhes nyin|{khas nyin dang gzhes nyin/}
 khas len|{bcol ba'i las dang du len pa/ khas len tshig brtsi/ khas len 'gan khur/}
 khas len pa|1) {dam bca' 'jog pa'am dang du len pa/} 2) {khas len pa po/}
-khas len sos theg khas len dam bca' byas pa|{rang gis ji ltar khas len sos theg byas pa'i don rnams 'al 'ol rgyang skyur byed mi nyan/}
+khas len sos theg|{khas len dam bca' byas pa/ rang gis ji ltar khas len sos theg byas pa'i don rnams 'al 'ol rgyang skyur byed mi nyan/}
 khas sa|{(yul) kha rtsang ste de ring gi nyin sngon ma/}
 khi 'u|{(yul) spu rtsid kyi khu lu/}
 khis mgo|{(yul) thab kyi thal ba 'don sa'i sgo/}
 khu|{sngar bod kyi rigs rus shig bod rgyal srong btsan sgam po'i dus su de'i sa skal du yar klungs thob pa dang/ yon rgyal rabs kyi deb ther du brgyad stong pa'i sde dpon thang po che zhes pa de yin par snang/ phyis bod kyi khri skor bcu gsum gyi gras su drangs/ khu ston brtson 'grus g.yung drung ni rigs 'di nyid las byung/}
-#khu khog kha zas sreg pa lcags sam zangs kyi khog snod chen po|
-khu khrag zungs bdun gyi phyi mo skyes pa'i khu ba dkar po dang|{bud med kyi zla mtshan dmar po gnyis so/}
+khu khog|{kha zas sreg pa lcags sam zangs kyi khog snod chen po/}
+khu khrag|{zungs bdun gyi phyi mo skyes pa'i khu ba dkar po dang/ bud med kyi zla mtshan dmar po gnyis so/}
 khu gu|1) {(yul) khug ma chung ngu/} 2) {(rnying) pha'i spun zla'am a khu/}
 khu ge|{(yul) khug ma chung ngu/}
-khu rdog 'brom gsum|{jo bo rje dpal ldan a ti sha'i slob ma'i gtso bo/ khu brtson 'grus g.yung drung dang/ rdog legs pa'i shes rab/ 'brom rgyal ba'i 'byung gnas bcas gsum mo/}
+khu rngog 'brom gsum|{jo bo rje dpal ldan a ti sha'i slob ma'i gtso bo/ khu brtson 'grus g.yung drung dang/ rngog legs pa'i shes rab/ 'brom rgyal ba'i 'byung gnas bcas gsum mo/}
 khu chu|{skyes pa'i thig le/}
 khu thu chi|{(sog) g.yog po/}
 khu gdus|{sman khu sogs bskol ba/ sman snyigs dor te khu gdus yun ring byos/}
@@ -3931,7 +3959,7 @@ khu nu|1) {khu bo dang nu bo zhes pa'i bsdus tshig} 2) {stod mnga' ris khul gyi 
 khu nu la|{ri chen zhig nub pha smir sa mtho'i shar ngos nas bzung zhin cang dang bod ljongs brgyud de mtsho sngon zhing chen du brgyugs pa'i ri bo zhig de'i ring tshad spyi le 2500 dang ri rtse mtho shos gangs dkar la zhes pa mtsho ngos las smi 7719 ? yod/}
 khu pa|{(rnying) 'chag pa/}
 khu 'phangs|{khu 'bangs dang 'dra/}
-#khu 'phrig dogs pa'am rnam rtog khang stong nang nas rku shor yong snyam pa'i khu 'phrig byed pa|
+khu 'phrig|{dogs pa'am rnam rtog khang stong nang nas rku shor yong snyam pa'i khu 'phrig byed pa/}
 khu ba|1) {zas sogs kyi khu ba/ shing 'bras li'i khu ba/ sha'i khu ba/ 'bras btsos pa'i khu ba/} 2) {pho'i thig le/ ming gi rnam grangs la skyes bu'i rtags dang/ khams dkar po/ thig le/ stobs ldan/ dwangs ma/ nus byed/ dbang por 'gro/ byang sems dkar po/ zla ba/ sa bon bcas so/}
 khu ba dkar ba|1) {'o ma sogs khu ba dkar po/} 2) {skyes pa'i thig le/} 3) {(mngon) gza' pa sangs/}
 khu ba dwangs ma|{khu ba'i snying po'am/ nying khu/}
@@ -3948,9 +3976,9 @@ khu ba'i yang khu|{khu ba'i dwangs ma'am nying khu/}
 khu ba'i slob ma|{(mngon) lha min/}
 khu ba'i gsang|{rgyab kyi sgal tshigs bcu dgu pa khu ba'i gsang ste/ der me btsa' bzhag na khu ba 'byams pa dang/ lugs pa sel/}
 khu bo|{pha'i spun a khu/}
-khu byug dpyid dus skad snyan sgrog pa'i bya zhig ming gi rnam grangs la ngag snyan dang|{lnga pa'i dbyangs ldan/ 'dab ma'i theg pa/ 'dod pa'i tA la/ na tshod gnas/ nags dga'/ dpyid kyi pho nya/ dbyangs snyan/ dbyangs snyan sgrog mig mdzes/ gzhan gyis rgyas/ gzhan gyis gsos/ gzhan la sems bcas so/}
+khu byug|{dpyid dus skad snyan sgrog pa'i bya zhig ming gi rnam grangs la ngag snyan dang/ lnga pa'i dbyangs ldan/ 'dab ma'i theg pa/ 'dod pa'i tA la/ na tshod gnas/ nags dga'/ dpyid kyi pho nya/ dbyangs snyan/ dbyangs snyan sgrog mig mdzes/ gzhan gyis rgyas/ gzhan gyis gsos/ gzhan la sems bcas so/}
 khu byug grag zla|1) {hor zla gsum pa/} 2) {glang khyim ste khyim bcu gnyis kyi ya gyal zhig}
-#khu byug rtsi thog sngo sman khu byug rtswa ljang mchog dman rigs gnyis kyi nang nas dman pa|
+khu byug rtsi thog|{sngo sman khu byug rtswa ljang mchog dman rigs gnyis kyi nang nas dman pa/}
 khu byug rtswa ljang|{sngo sman gyi rigs shig ste/ ro mngar la kha ba/ zhu rjes snyoms/ nus pas rtsa kha 'byed/ chu 'gags 'byin/}
 khu dbon|{a khu dang/ tsha bo/}
 khu 'bangs|{dbyibs ril po yin pa'i kha ba'i bye brag cig khu 'bangs kha ba'i sna 'dren yin/ dung gi khu 'bangs tha ra ra/}
@@ -3959,7 +3987,7 @@ khu tshan|{pha'i spun dang de'i tsha bo gnyis kyi bsdus ming/}
 khu tshur|{mur rdzog khu tshur bcangs pa/ khu tshur mi la bzhus/ ngu 'bod rang gis 'debs/}
 khu tshur gyis 'tsho|{(mngon) gser bzo ba/}
 khu yu|1) {a yu ste/ gnag phyugs dang ra lug la rwa co med pa'i yu bo yu mo spyi'i ming/} 2) {rwa co 'khyog po can/}
-#khu yug khu byug dang 'dra|
+khu yug|{khu byug dang 'dra/}
 khu ye|{phywa gyang khug cig ces 'bod sgra/ phywa khu ye/rnam thos sras kyis nor gyang stsol/}
 khu ra|{(yul) snum khur te snum khol nang btsos pa'i bag leb chung ngu/}
 khu lu|{gnag phyugs kyi rtsid pa min pa'i spu 'jam po dang khyi'i spu 'jam po/}
@@ -3968,13 +3996,14 @@ khu le|1) {nya ga'am srang gi mda'/} 2) {zo ba'am zo lag}
 khu le'i ri mo|{srang mda'i ngos kyi grangs tshad ri mo/}
 khu sim po|{sgra dma' ba'am zing long med pa/}
 khug|1. {'gugs pa'i skul tshig/}2. {khug kyog mtsho khug rma chu'i khug dgu/ 'gyur khug}
-khug kyog 'grim 'grul nyung ba'i yul|{khug kyog cig tu bu chung rtse/}
+khug kyog|{'grim 'grul nyung ba'i yul/ khug kyog cig tu bu chung rtse/}
 khug khra|{rgya lu chas gyon dus sked par gdags rgyu'i rgyan cha zhig/}
 khug 'khyog|{khug kyog dang 'dra/ khug chung/ tig ta'i ming gi rnam grangs/}
 khug rta|{char sdod byi'u'am/ kha la yug gam/ 'dag byi'u/ ming gi rnam grangs la sgra sgrog dang/ char dga'/ char sdod/ chu nyung/ thub pa'i bu/ sprin 'degs/ sprin la slong/ bzang mo bcas so/}
 khug rta'i glo ba|{srog chags sman gyi rigs shig ste/ ro mngar/ zhu rjes snyoms/ nus pas glo rnag skem/ glo rdol gso/}
 khug rna|{lho 'ur zhes 'byung ste na bun gyi ming yin zer yang nam mkha' dwangs pa'i tshe snga dro'i dus rgyang ring por bltas tshe du ba srab mo lta bu sngo phyur rer mthong ba de yin/}
-khug rna'i kha dog yan lag gi kha dog brgyad kyi nang gses shig khug sna|{khug rna dang 'dra/}
+khug rna'i kha dog|{yan lag gi kha dog brgyad kyi nang gses shig}
+khug sna|{khug rna dang 'dra/}
 khug pa|1. {(tha mi dad pa) khugs pa/ khug pa//} 1) {'khul ba/ mi 'di sngar dang mi 'dra bar sems yag po khugs 'dug} 2) {'byung ba/ khe bzang khug pa/ rin gyis khug pa/ gnyid khug pa/ }2. {phar rgyu tshur rgyu'i gug dbugs khug pa gcig rma chu'i khug pa re re la/ sde 'bum tsho re yi chags gnas yod/}
 khug pa'i grangs ka|{bcu ldab kyi 'gyur khyad yod pa'i grangs gnas che chung gnyis kyi che ba'i ming de chung ba'i ming gi mthar chen po zhes pa btags nas byung ba rnams dper na ther 'bum dang ther 'bum chen po/ chen po ther 'bum ther 'bum chen po}
 khug ma|{ras snam sogs kyis bzos pa'i snod khug rtsam khug dngul khug ras khug dngos po tsag tsig tshang ma khug ma 'di'i nang la blugs yod/}
@@ -4020,10 +4049,10 @@ khur 'gel ba|1) {do po 'khur 'jug pa/} 2) {las 'gan dkri ba/}
 khur rngan|{spom tshod kyis sprad pa'i khur gla/}
 khur lci ba|1) {khur po ljid po/} 2) {'gan khur ljid po/}
 khur chen|1) {khres po chen po/} 2) {'gan khur chen po/}
-#khur thag khur po 'khur byed kyi thag pa|
+khur thag|{khur po 'khur byed kyi thag pa/}
 khur gdang|{khur po'i gdang shing/}
 khur 'dren pa|1) {rdog khres dbor ba/} 2) {khur po 'khyer ba po/}
-khur nag sngo khur mong dkar nag gnyis kyi nang tshan|{me tog ser po 'char ba zhig}
+khur nag|{sngo khur mong dkar nag gnyis kyi nang tshan/ me tog ser po 'char ba zhig}
 khur po|{rdog khres/ rang gi khur po rang gis 'khur/ thugs khur che bzhes/ shing khur/ 'gan khur/ khur 'dor ba/ las don khur du len pa/ gzhung don khur gyis dub pa/ khur drags pa/}
 khur ba|{'khur ba'i 'das pa/}
 khur bor ba|1) {khres khur brlag pa/} 2) {'gan khur bskyur ba/}
@@ -4038,8 +4067,8 @@ khur tshad|{khres po che chung gi tshad/}
 khur tshod|{sngo khur mong las byas pa'i tshod ma ste nus pas tsha ba sel/}
 khur tshos|{mkhur tshos dang 'dra/}
 khur 'dzin|{'gan khur len pa/}
-khur bzod pa|1) {'gan khur chen po len phod pa/} 2) {'khyer thub pa/}
 khur bzhi|{phung po'i khur dang/ brtson 'grus kyi khur/ nyon mongs pa'i khur/ dam bca'i khur bcas bzhi'o/}
+khur bzod pa|1) {'gan khur chen po len phod pa/} 2) {'khyer thub pa/}
 khur la mi 'jigs|{(mngon) sa gzhi/}
 khur len pa|1) {khres khur tshur len pa/} 2) {las ka'i 'gan len pa/}
 khur shing|1) {rkang thang thag ring 'grul pa'i rdog khres 'khyer spyad cig} 2) {khur po'i gdang shing/}
@@ -4086,7 +4115,7 @@ khe tshong pa|{tshong zog sdeb nyo byas te phar sil tshong byed mkhan/}
 khe bzang|{skyed kha'am phan slebs bzang po/ khe bzang sprad pa/ khe bzang yong sgo/}
 khe ru ma|{gcig pu'am hrang hrang/ mi tshang khe ru ma/}
 khe las|{khe bzang can gyi las ka/ khe las bdag gnyer/ bzo tshong sogs khe las spel ba/}
-#khe log tshong log rin thang las brgal ba'i khe spogs kho na gnyer ba|
+khe log tshong log|{rin thang las brgal ba'i khe spogs kho na gnyer ba/}
 khe sang|{khe bzang dang 'dra/}
 khe slebs|{yong 'bab/}
 kheg pa|{(tha mi dad pa) khegs pa/ kheg pa// bkag nas 'gog pa/ chu bkag nas kheg bzhin pa red/ rtags khegs/}
@@ -4110,7 +4139,7 @@ kheb|{khebs dang 'dra/}
 khebs|1) {steng nas 'gebs byed kyi g.yog spyad/ g.yag khebs/ cog tse'i khebs/ sga khebs/ pang khebs/ char khebs/ gdung khebs/} 2) {kha gcod/ khebs 'gebs pa/ khebs g.yogs pa/ khebs blangs pa/}
 khebs gcod|{snod kyi khebs g.yogs/}
 khebs che ba|{khyab che ba/}
-#khebs thig g.yog spyad sdom byed kyi thag pa|
+khebs thig|{g.yog spyad sdom byed kyi thag pa/}
 khebs pa|{(tha mi dad pa) khyab pa/ gsol ja khebs song ngam/ gos kyis bkab nas khebs pa/ sa gzhi sbar mos bkab pas khebs dogs med/}
 khebs 'bubs pa|{g.yog pa dang 'gebs pa/}
 khebs ma|{rta drel sogs kyi sgal par g.yog byed/}
@@ -4118,8 +4147,7 @@ khe'u sus|{(rnying) rgyun zas ma yin pa'i kha zas bzang po/}
 kher rkya|{chig rkya/ kher rkya 'pher ba/}
 kher rkyang|{gcig pu'am chig rkyang/ mi kher rkyang 'gro ba/ khang pa kher rkyang/ grogs med kher rkyang du lus pa/}
 kher dgod|{rang nyid gcig pur dag mo dgod pa/}
-kher 'gro|{gcig pur rgyu ba/ pho rgod pos dpung gdang ma bsgrigs par/}
-kher 'gro srog dmar skyel ba'i rgyu|{rta rgod kher rgyug mi rgod kher 'gro/}
+kher 'gro|{gcig pur rgyu ba/ pho rgod pos dpung gdang ma bsgrigs par/ kher 'gro srog dmar skyel ba'i rgyu/ rta rgod kher rgyug mi rgod kher 'gro/}
 kher rgod|{kher dgod dang 'dra/}
 kher ma|{gcig pu/ rkyen med pa'i rgyu kher ma la 'bras bu ga nas yong/ mda' rgod kher 'phen/ dpung rgod kher ngom/}
 kher ya|{gcig pu/}
@@ -4127,7 +4155,7 @@ kher re ma|{chig rkyang ngam gcig pu/}
 kher lab|{grogs med chig lab/}
 khel ba|{'khel ba'i 'das pa/}
 kho|{nga dang khyod min pa'i mi de/ kho tsho tshang ma slebs 'dug}
-kho cag kho rang tsho|{kho cag dang nged cag mnyam du las don byed myong/}
+kho cag|{kho rang tsho/ kho cag dang nged cag mnyam du las don byed myong/}
 kho chu gong ma|{rma chu'i stod rgyud kyi chu lag cig mtsho sngon zhing chen khongs mgo log bod rigs rang skyong khul gyi dga' bde rdzong du yod/}
 kho chu 'gab ma|{rma chu'i stod rgyud kyi chu lag cig mtsho sngon zhing chen khongs mgo log bod rigs rang skyong khul gyi dga' bde rdzong du yod/}
 kho nyid|{kho pa rang nyid/}
@@ -4146,7 +4174,7 @@ kho lag|1) {lus po'am lus po'i yan lag /}2) {(rnying) chu zheng ngam rgya khyon/
 kho lag rdzogs pa|{'phel stobs yongs su rdzogs pa/ lus kyi kho lag rdzogs pa'i dar ma zhig}
 kho lag yangs pa|1) {rgya khyon che ba/} 2) {lus kyi stobs shugs che/}
 kho shed|{kho na re'am/ khos 'di skad zer bya ba/}
-khog 'gog pa'i skul tshig khog rgas|{gzugs khog rgas pa/}
+khog|{'gog pa'i skul tshig khog rgas/ gzugs khog rgas pa/}
 khog rgyong|{ngan slob/}
 khog brgyangs zing slong|{bsam ngan gyis gzhan sems bskul nas zing 'khrug slong ba/}
 khog gcig|1) {g.yag lug sogs kyi sha phyi sgrom cha tshang gcig lug sha khog gcig} 2) {nang don gcig pa'i dpe/ skad cha shod stangs mi 'dra yang/ nang don khog gcig red/}
@@ -4156,7 +4184,7 @@ khog chud|{shes rtogs/}
 khog ltir|{rdza sogs las bzos pa'i ja snod chang snod/}
 khog stong|{nang stong pa/ gzi brjid khog stong/}
 khog stod|{lus kyi stod/}
-khog sngom pa|{kha 'gril ba'am/ kha mthun pa/}
+khog sdom pa|{kha 'gril ba'am/ kha mthun pa/}
 khog mna'|{snying thag pa'i mna' 'am/ dam bca'/}
 khog pa|1) {lto ba'am/ nang dang sbug khog pa chen po/ khog pa drang po/ zas ngan gcig gis khog pa'i stod smad dkrug} 2) {sems/ kha 'o ma khog tsher ma/ pho khyo ga'i khog par mda' shong mdung shong/ khog par dran tshad kha nas shod pa/ gnas tshul khog par tshud pa/}
 khog pa 'grim|{khog pa 'khru ba ste bshal ba/ sbyong sman btung bas khog pa 'grim gyin 'dug}
@@ -4164,7 +4192,7 @@ khog pa rgyong ba|1) {dkrug 'dod kyis gzhan la ngan slob pa/} 2) {nang nas rgyon
 khog pa can|1) {mi sems rgyud ngang ring ba/} 2) {(mngon) rus sbal/}
 khog pa chung ngu|1) {khog pa chen po'i ldog phyogs te grod khog chung chung/} 2) {bzod sems med pa/}
 khog spun|{rum sogs kyi spun/}
-#khog phrug khog ma chung chung|
+khog phrug|{khog ma chung chung/}
 khog dbub stong thun gyi chings|{chings lnga'i nang tshan zhig ste/ dpe cha'i gzhung don khog sgrig gi sa bcad/}
 khog 'bubs|1) {gur sogs 'bubs pa/ nyi gdugs rtsibs mas khog 'bubs pa/} 2) {khog sgrig ste go rim sgrig pa/ dpe cha'i gzhung don spyi khog 'bubs pa/ khang pa'i phyi sgrom spyi khog 'bubs pa/}
 khog 'bubs drang srong kun tu dga' ba'i zlos gar|{rab byung bcu pa'i nang zur mkhar blo gros rgyal pos mdzad pa'i rig gnas spyi dang/ khyad par du gso ba rig pa rgya gar du dar tshul dang/ rim bzhin bod du dar tshul/ g.yu thog pa sogs gso rig gi bstan 'dzin rnams byon tshul sogs 'khod pa'i sman gyi chos 'byung zhig}
@@ -4185,7 +4213,7 @@ khog yangs|1) {blo rgya che ba/ brtan brling khog yangs/} 2) {rgya'am khad/ lung
 khog shing|{srog shing/}
 khog sob|{khog pa mkhregs po min pa/}
 khong|1. {'gengs pa'i skul tshig }2. 1) {sems/ gad mo khong nas rgod pa la rgyu mtshan yod 'gro/ kha tsam ma yin khong nas phyung ba'i snying gtam yin pas sems la zhog a tsi 'jigs skul yin nam/ khong nas sdang ba yin pa mi shes/} 2) {khog pa dang nang/ khong nang zug rngu sman gyis 'byin pa/ }3. {kho'i zhe sa/}
-#khong khrag khog pa'i nang gi khrag kha nas khong khrag bskyugs pa|
+khong khrag|{khog pa'i nang gi khrag kha nas khong khrag bskyugs pa/}
 khong khro|{zhe sdang ste/ dgra la sogs pa sems can pha rol po rnams la brdeg cing gsad pa la sogs pa gnod pa sna tshogs bya bar sems pa/ khong khro za ba/ khong khro tsha po/ khong khro zhi ba/ khong khro spong ba/ khong khro slong mkhan med na bzod pa su la sgom/}
 khong khro ba|{zhe sdang ba/}
 khong khro'i phra rgyas|{sems can dang/ sdug bsngal/ sdug bsngal gyi gzhi bcas la kun nas mnar ba'i sems kyi bag la nyal ba/}
@@ -4204,7 +4232,7 @@ khong stong|{(mngon) bu ga/}
 khong du chud pa'i le'u gsum|{ston pa mya ngan las 'das nas bstan pa'i gnas tshad lo lnga brgya phrag bcu'i dang po nas gsum pa'i bar rim bzhin dgra bcom pa'i le'u dang/ phyir mi 'ong ba'i le'u/ rgyun du zhugs pa'i le'u ste gsum/}
 khong nang|{khog pa'i nang/}
 khong nad|{khog nad/}
-#khong gnag zhe nag po'am sems ngan po|
+khong gnag|{zhe nag po'am sems ngan po/}
 khong pa'i drod|{khog nang gi me drod/}
 khong 'byin|{khog gam/ nang nas phyir 'don/}
 khong 'bras|{khong pa'i nang gi don snod la 'byung ba'i 'bras nad phyir mi mngon pa zhig}
@@ -4215,7 +4243,7 @@ khong yangs|1) {sems gu yangs pa/ khong yangs dkyel che/ khong yangs pa'i mi de 
 khong yus|{phan btags drin ngoms/}
 khong ral|{khong rul dang 'dra/}
 khong rul|1) {snying rul te bsam shes med pa/} 2) {nang rul/}
-khong lag khog pa'i nang du lag pa 'jug pa|{lung pa 'ga' zhig tu phyugs lug sogs la khong lag btang nas gsod srol yod/}
+khong lag|{khog pa'i nang du lag pa 'jug pa/ lung pa 'ga' zhig tu phyugs lug sogs la khong lag btang nas gsod srol yod/}
 khong shing|{srog shing ngam/ gtso bo'i don snying/ khrims kyi khong shing yo 'khyog mi bzo ba/}
 khong shor|1) {khog pa'i nang du song ba ste byis pas rde'u sogs mid nor byung lta bu/} 2) {phyugs la bya bcos byed skabs 'bras bu khong du shor te lus pa/}
 khong subs|{(rnying) kha snon/}
@@ -4237,14 +4265,15 @@ khob|{'gebs pa'i skul tshig}
 khob khrob|{shing bkog pa dang/ rna lpags 'dril ba'i sgra/}
 khob sha tsha po|{(yul) las ka 'phral 'phral la byed mi thub mkhan/}
 khom pa|1. {(tha mi dad pa) lcogs pa'am dal ba/ de ring khom gyi mi 'dug sdod mi khom/ }2. {dal ba/ 'gro khom med pa/}
-#khom 'bog ko bas bzos pa'i ca lag 'jug snod|
+khom 'bog|{ko bas bzos pa'i ca lag 'jug snod/}
 khom long|{lcogs pa'am long skabs/ sang nyin khom long byung na khyed rang phebs bsur bcar chog}
 khor|{dgar ba'i skul tshig}
 khor pha|{(rnying) khyim mi/}
 khor mo|1. {bar mtshams med pa'am/ rgyun mi 'chad pa/ mi rbas mang po'i bar du sdug bsngal khor mor myong ba/ grong khyer gyi mtha' 'khor du lcags ri khor mor bskor ba/ }2. {khor mo yug gi bsdus tshig}
 khor mo yug|1) {mtha' skor/ phyi rol nas lcags ri khor mo yug tu bskor ba/} 2) {rgyun bar ma chad pa/ nyin mtshan khor mo yug tu las grwa btsugs pa/ lo khor mo yug tu las ka byas/}
 khor zug|{(rnying) nye skor dang/mtha' skor/}
-khor yug khor mo yug gi bsdus tshig khor yug gi lcags ri|{khor yug ri dang don gcig}
+khor yug|{khor mo yug gi bsdus tshig}
+khor yug gi lcags ri|{khor yug ri dang don gcig}
 khor yug ri|{mngon pa las gsal ba ltar/ gling bzhi'i phyi rol na lcags las grub pa'i ri ste/ de'i phyi'i mtha' skor du dpag tshad sa ya phrag gsum dang drug 'bum nyis stong drug brgya nyi shu rtsa lnga yod zer/}
 khor sa|{lha'i gzhal yas khang gi bar khyams sam/ skor lam lta bu/ khor sa nang ma/ khor sa phyi ma/ khor sa bar ma/}
 khol|1. {bkol ba dang 'gel ba dang 'khol ba'i skul tshig }2. {zur dang logs/ gzhung chen po'i nang nas le'u gcig khol du 'don pa/ gces nor rnams mdzod khang nas khol du phyung ste bzhag pa/ gsung 'bum gyi nang nas khol bkar gyis par du bskrun pa/}
@@ -4266,7 +4295,8 @@ khwa ta|{bya pho rog las chung ba'i bya nag cig khwa ta thams cad mdog nag yin/}
 khya ge khyo ge|{drang po med pa'am kyog kyog ri mo khya ge khyo ge/ shing khyag khyog gis ka gdung bzo mi nyan/ tshig khya ge khyo ge la yid brtan med/}
 khya ma|{(yul) me shing ngam bud shing/}
 khya re khyo re|{lus gom tshugs mi thub pa'i rnam 'gyur/ nad pa cung drag ste khya re khyo rer 'gro ba/ phru gu khyar khyor du phyin pa/}
-khyag khyog khya ge khyo ge'i bsdus tshig khyag pa|1. {(tha dad pa) bzod pa'am yar 'degs thub pa/ bu lon de'i khag khyag pa ngas byed/ bong bus rnga mo'i khal mi khyag }2. {theg pa/ snying stobs chen po yod la khyag pa chen po'ang yod/}
+khyag khyog|{khya ge khyo ge'i bsdus tshig}
+khyag pa|1. {(tha dad pa) bzod pa'am yar 'degs thub pa/ bu lon de'i khag khyag pa ngas byed/ bong bus rnga mo'i khal mi khyag }2. {theg pa/ snying stobs chen po yod la khyag pa chen po'ang yod/}
 khyad|{khyad par dang don gcig}
 khyad ci|1) {khyad par ci ste/ dbye ba med/ de ring sang nyin gnyis la khyad ci yod/} 2) {khyad par med/ lto gos gnyis la khyad ci/}
 khyad chos|{khyad par gyi chos te gzhan dang mi 'dra ba'am gzhan las lhag pa'i yon tan/ khyad chos ston pa/ rdo khab len gyi khyad chos ni lcags len pa yin/ de ni khyad gzhi gang la yod pa'i khyad chos ston byed kyi tshig cig yin/}
@@ -4285,7 +4315,7 @@ khyad par can|1) {khyad par yod pa/} 2) {ngo mtshar can/ lam khyad par can/ khya
 khyad par can gyi gzugs can|{gzugs can gyi rgyan gyi nang tshan zhig ste/ dpe can don gyi dngos po dma' ba zhig dpe'i dngos po mtho ba zhig gi gzugs can du bkod pa des khyad du thon pa'i bya ba lhag par 'grub par ston pa'i rgyan zhig}
 khyad par can rab tu grags pa ma yin pa|{chos can ma grub pa dang don gcig tshad ma'i rig pa'i bsgrub bya ltar snang gi nang tshan zhig ste/ grangs can pas sangs rgyas pa la bdag ni sems pa can yin no/ zhes sgrub par cha mtshon na/ bsgrub bya'i chos can bdag ces pa de sangs rgyas pas khas ma blang pas khyad par can rab tu grags pa ma yin pa'i skyon du gyur nas bsgrub bya ltar snang du gyur to/}
 khyad par chos sku'i mandala|{chos dbyings skye med kyi mandala thog snang bzhi rtog tshogs kyi tshom bu bkod nas/ bla ma chos sku'i lha tshogs la 'bul ba/}
-khyad par brdzod pa'i rgyan|{don rgyan gyi gras shig ste/ brjod bya yon tan dang/ rigs/ bya ba/ rdzas/ rgyu rnams la rang rang gi mtshan nyid ma tshang yang/ tshang ba dang khyad med dngos po'i nus pa phul du byung ba ston pa'i rgyan zhig}
+khyad par brjod pa'i rgyan|{don rgyan gyi gras shig ste/ brjod bya yon tan dang/ rigs/ bya ba/ rdzas/ rgyu rnams la rang rang gi mtshan nyid ma tshang yang/ tshang ba dang khyad med dngos po'i nus pa phul du byung ba ston pa'i rgyan zhig}
 khyad par brjod pa'i rgyan lnga|{khyad par brjod pa'i rgyan gyi nang gses rnam grangs lnga ni/ yon tan ma tshang ba'i khyad par brjod pa/ rigs ma tshang ba'i khyad par brjod pa/ bya ba ma tshang ba'i khyad par brjod pa/ rdzas ma tshang ba'i khyad par brjod pa/ rgyu ma tshang ba'i khyad par brjod pa bcas so/}
 khyad par rtogs pa|{bzang ngan dang che chung sogs kyi dbye ba shes pa/ legs nyes kyi khyad par rtod pa'i blo gros med thabs med/}
 khyad par ltos pa ba'i rtags|{rang bzhin gyi rtags yang dag gi bye brag cig ste/ rang rjod byed kyi sgras sgrub byed rang gi khyad par ram khyad chos dngos shugs gang rung gis rjod par byed pa/dung sgra chos can/ mi rtag ste/ rtsol byung yin pa'i phyir/ zhes pa lta bu rang nyid rtsol ba la ltos dgos pa'i khyad par gyi rtags kyis bsgrub pa'o/}
@@ -4293,7 +4323,7 @@ khyad par dag pa ba'i rtags|{rang bzhin gyi rtags yang dag gi nang gses/ rang rj
 khyad par du 'gro ba|{gong nas gong du 'gro ba/}
 khyad par du gdags pa|{ming ngam tha snyad dmigs bsal du gdags pa/}
 khyad par du 'phags pa|{gzhan las mchog tu gyur pa/ khyad par du 'phags pa bla na med pa/}
-khyad par du 'don pa|{gzhan las lhag par nus shugs 'don pa/}
+khyad par 'don pa|{gzhan las lhag par nus shugs 'don pa/}
 khyad par gnas|{(mngon) byang chub ljon shing/}
 khyad par 'phags bstod|{ston pa thub pa'i dbang po la bstod pa rgya gar gyi slob dpon mtho btsun grub rjes mdzad pa/}
 khyad par ba|{mi 'dra ba/}
@@ -4311,7 +4341,7 @@ khyad gzhi|{khyad chos gang dang ldan pa'i gzhi/}
 khyad gzhi tha dad la khyad chos mtshungs dang mi mtshungs gnyis kha'i bsdus brjod|{bsdus brjod kyi rgyan gyi nang tshan zhig ste/ dpe'i khyad gzhi khyad chos kyi rang bzhin ji 'dra ba brjod pa des/ dpe don gnyis kyi khyad gzhi tha dad la khyad chos mtshungs pa dang mi mthungs pa'i gnas tshul gang yin shugs kyis bsdus te brjod pa'i rgyan zhig}
 khyad gzhi tha dad la khyad chos mtshungs pa'i bsdus brjod|{bsdus brjod kyi rgyan gyi nang tshan zhig ste/ dpe'i khyad gzhi dang khyad chos kyi gnas lugs brjod pa des/ dpe don gnyis kyi khyad gzhi ngo bo tha dad la khyad chos mtshungs pa shugs kyis bsdus te brjod pa'i rgyan zhig}
 khyad gsod|{khyad du gsod pa'i bsdus tshig}
-khyad khongs|{gang zhig gi khyab pa'i sa khongs sam khyab yul/ stobs shugs khyab khongs/}
+khyab khongs|{gang zhig gi khyab pa'i sa khongs sam khyab yul/ stobs shugs khyab khongs/}
 khyab 'grems|{kun la khebs par 'grems pa/}
 khyab 'gro|{(mngon)} 1) {dri/} 2) {g.yog po/}
 khyab bsgrags|{mi mang po'i mthong thos go yul du bkram pa'am bstan pa/ khyab bsgrags yi ge/}
@@ -4329,8 +4359,7 @@ khyab 'jug pa|{sngar rgya gar gyi grub mtha' smra ba zhig yin pa des khyab 'jug 
 khyab 'jug gzer|{(rA hu le ne) khyab 'jug gi nad/}
 khyab mnyam|{chos gnyis phan tshun yin na yin mnyam dang/ min na min mnyam ste/ 'dus byas dang mi rtag pa lta bu'o/}
 khyab stobs|{(mngon) lha brgya sbyin/}
-khyab mtha'|{rtags gsal dang mtshan mtshon}
-sogs phan tshun khyab pa yod med kyi gnas la mtha' dpyad bkod pa ste|{yod med dang/ yin min gyi mtha' gcod pa/ dper na/ byas pa yin na mi rtag pa yin pas khyab/ du ba yod na me yod pas khyab ces pa lta bu'o/}
+khyab mtha'|{rtags gsal dang mtshan mtshon sogs phan tshun khyab pa yod med kyi gnas la mtha' dpyad bkod pa ste/ yod med dang/ yin min gyi mtha' gcod pa/ dper na/ byas pa yin na mi rtag pa yin pas khyab/ du ba yod na me yod pas khyab ces pa lta bu'o/}
 khyab gdal|1) {rgya khyab tu dar ba/ khyab gdal gting phyin/} 2) {sems can rnams kyi rgyud la thog ma nas gnas pa'i bde bar gshegs pa'i snying po/}
 khyab bdag|{(mngon) sangs rgyas/}
 khyab ldan|{(mngon) bshang ba/}
@@ -4366,8 +4395,7 @@ khyab byed dang 'gal ba'i rang bzhin dmigs pa|{'gal ba'i rang bzhin dmigs pa bzh
 khyab byed dang 'gal ba'i rang bzhin dmid pa'i thal 'gyur|{lhan cig mi gnas 'gal gyi 'gal ba'i khyab bya dmigs pa'i thal 'gyur gsum gyi nang gses/ 'gal ba'i rang bzhin rtad su bkod pa'i thal 'gyur gang zhig bzlog na rang bzhin dang 'gal ba'i khyab bya dmigs pa'i rang rgyud 'phen pa ste/ dper na/ tsan dan gyi me tshad ma'i stobs kyis nges pa'i shar gzhir chos can/ tsan dan gyi me tshad ma'i stobs kyis nges pa ma yin par thal/ grang reg yod pa'i phyir/ zhes pa'i thal 'gyur gyis/ de chos can/ grang reg med de/ tsan dan gyi me tshad ma'i stobs kyis nges pa'i phyir/ zhes bzlog pa gzhan rigs 'phen pa'i thal 'gyur ro/}
 khyab byed du 'jug pa|{rtags kyis gsal ba la khyab pa ste/ rtags de bsgrub bya'i chos kyi mthun phyogs sam/ mi mthun phyogs gang rung dang gnyis ka la khyab par yod pa'o/}
 khyab byed ma dmigs pa'i rtags|{snang rung gi 'brel zla ma dmigs pa'i rtags kyi nang gses/ bdag gcig gi 'brel ba la brten nas 'gog byed khyab byed ma dmigs pa'i rtags kyis dgag bya khyab bya bkag pa/ dper na/ brag rdzong pha gi na chos can/ shing sha pa med de/ shing med pa'i phyir/ zhes pa lta bu'o/}
-khyab byed ma dmigs pa'i thal 'gyur|{gzhan rigs 'phen pa'i thal 'gyur bcu bzhi'i nang gses/ khyab byed ma dmigs pa rtags su}
-bkod pa'i thal 'gyur gang zhig bzlog na rang bzhin gyi gtan tshigs 'phen pa ste|{dper na/ sha pa ldan pa'i shar gzhir chos can/ sha pa med par thal/ shing med pa'i phyir/ zhes pa'i thal 'gyur gyis/ de chos can/ shing yod de sha pa yod pa'i phyir/ zhes bzlog pa gzhan rigs 'phen pa'i thal 'gyur ro/}
+khyab byed ma dmigs pa'i thal 'gyur|{gzhan rigs 'phen pa'i thal 'gyur bcu bzhi'i nang gses/ khyab byed ma dmigs pa rtags su bkod pa'i thal 'gyur gang zhig  bzlog na rang bzhin gyi gtan tshigs 'phen pa ste/ dper na/ sha pa ldan pa'i shar gzhir chos can/ sha pa med par thal/ shing med pa'i phyir/ zhes pa'i thal 'gyur gyis/ de chos can/ shing yod de sha pa yod pa'i phyir/ zhes bzlog pa gzhan rigs 'phen pa'i thal 'gyur ro/}
 khyab byed rlung|{lus kyi rtsa ba'i rlung lnga'i ya gyal zhig ste/ snying la gnas shing/ khrag sogs dwangs ma lus kun la khyab par byed pa dang/ rkang lag 'degs 'jog sogs lus kyi sgul skyod byed pa'i rlung/}
 khyam khyom|{khyam me khyom me'i bsdus tshig}
 khyam me khyom me|{snod bcud 'gul stangs/ sa 'gul rkyen gyis snod bcud khyam khyom du g.yo/}
@@ -4383,7 +4411,7 @@ khyi kha rdo len|{las don gang zhig yin rung de la kha gtad 'jal mkhan re dgos p
 khyi khar rus bzung|{gtsigs cher brtsis te blos gtong mi bra ba/}
 khyi 'khyar|{khyi 'khyams te/ bdag po med pa'i khyi/}
 khyi gu|{khyi'i phru gu/}
-khyi 'gog khyis 'cha' ba'am rmug tu mi 'jug pa|{mi gcig gis khyi 'gog rgyu dang/ shing gcig gis me 'bar rgyu khag}
+khyi 'gog|{khyis 'cha' ba'am rmug tu mi 'jug pa/ mi gcig gis khyi 'gog rgyu dang/ shing gcig gis me 'bar rgyu khag}
 khyi 'gyed|{khyi rbad pa'am skul ba/}
 khyi rgan|1) {khyi lo lon pa/ khyi rgan sha la rgyugs na/ khyi phrug rang dgar rgyug} 2) {gzhan la gshe ba'i ngan tshig}
 khyi rgan rgya bo|{khyi rgan 'gram pa'i spu mdog rgya bo/}
@@ -4393,7 +4421,7 @@ khyi rngo|{za phrug langs nas spu byi ba'i khyi nad cig}
 khyi nyar 'khrol 'dzin|{sngar smon lam tshugs dus lha sa'i mi tsho'i khyim du khyi nyar chog pa tshogs chen zhal ngor dgongs pa zhus pa'i 'khrol 'dzin/}
 khyi nyal rgyug slong|{don med gzhan la snyad rko'i gtam dpe/ bdag la bka' bkyon khyi nyal rgyug slong gi tshul du gnang byung/}
 khyi thu po|{khyi rgod po'am ngar po/}
-#khyi dug rgyu ba'i dug gi nang tshan khyi smyon gyi sos rmugs pa'i dug nad lus la zhen pa|
+khyi dug|{rgyu ba'i dug gi nang tshan khyi smyon gyi sos rmugs pa'i dug nad lus la zhen pa/}
 khyi ldom|{bdag po med pa'i khyi/}
 khyi spyang|{khyi spyang tsha zhes khyi'i rigs shig ste/ spyang ki dang 'dra zhing/ rang gshis drag po/ rdzi rno ba zhig}
 khyi spyang kha 'gril|{khyi spyang kha mthun yang zer/ mi ngan kha 'gril gyi dpe/}
@@ -4402,21 +4430,23 @@ khyi spyang lag sbrel|{mi ngan kha mthun gyi dpe/}
 khyi sprang|{khyi dang sprang po/}
 khyi phag gi brtul zhugs|{sngar rgya gar gyi grub mtha' smra ba zhig gi brtul zhugs/}
 khyi phur|{khyi 'dogs sa'i phur pa/}
-#khyi phrug khyi'i phru gu|
+khyi phrug|{khyi'i phru gu/}
 khyi 'bigs|{(mngon) srog chags gzugs mo'am byi thur can/}
 khyi rbad pa|{gzhan 'dzin pa'am rmug pa'i phyir khyi skul ba/ cho cho byas nas khyi rbad pa/ ri dwags rngon la khyi rbad bzhin/ khyed kyis bskul der lan de bslogs/}
 khyi mig bzhi|{mig gnyis kyi thod du spu mdog ser po'i thig le gnyis yod pa'i khyi/}
-khyi me tog sngo zhig khyi mo tshang ma|{khyi mo sbrum ldan dang phru gu 'khrid rgyu yod pa'i khyi mo/ khyi mo tshang ma'i sgo 'gram nas/ seng dkar mo yin yang dogs zon dgos/}
+khyi me tog|{sngo zhig}
+khyi mo tshang ma|{khyi mo sbrum ldan dang phru gu 'khrid rgyu yod pa'i khyi mo/ khyi mo tshang ma'i sgo 'gram nas/ seng dkar mo yin yang dogs zon dgos/}
 khyi smyon|{sems smyo nad kyis zin pa'i khyi/ khyi smyon yin yang bdag po ngo shes/}
-khyi zug khyis skad rgyag pa|{'grul pa slebs na khyi zug yong/}
+khyi zug|{khyis skad rgyag pa/ 'grul pa slebs na khyi zug yong/}
 khyi zla|{hor zla dgu pa/}
-khyi gzig gzig gi rigs shig khyi yan|{bdag po med pa'i khyi 'khyams/}
+khyi gzig|{gzig gi rigs shig}
+khyi yan|{bdag po med pa'i khyi 'khyams/}
 khyi ra|{rngon/ mi tshe gcig la khyi ra brgyab nas 'tsho ba skyel ba/ ri 'go lon nas khyi ra/}
 khyi ra ba|{rngon pa/}
 khyi ro|1) {khyi'i ro/} 2) {(yul) khyi la gshe ba'i tshig}
 khyi las lod|{khyi las ngan pa ste/ ha cang tha shal gyi dpe/}
 khyi lo|{lo skor bcu gnyis kyi ya gyal zhig khyi lo pa/}
-#khyi shig 'ju ba|
+khyi shig|{'ju ba/}
 khyi shing|{shing sman gyi rigs shig ste/ ro mngar/ zhu rjes snyoms/ nus pas glo nad sel/ lud pa gyen du 'dren/}
 khyi shing dman pa|{shing gi bye brag}
 khyi gsar|{khyi lo chung/ lung chung sbug na khyi gsar btsan/}
@@ -4465,7 +4495,7 @@ khyim gnas skyed ma|{(mngon) a ma/}
 khyim pa|{mi skya bo/ khyim pa pho mo/ khyim par 'bebs pa/}
 khyim pa skya bo|{mi skya/}
 khyim pa brtag pa'i dpyad|{khyim pa'i mtshan nyid brtag dpyad byed pa'i thabs/}
-#khyim pa mi nag mi skya|
+khyim pa mi nag|{mi skya/}
 khyim pa mo|1) {khyim pa bud med/} 2) {(mngon) mna' ma/}
 khyim pa sun 'byin pa|{'jig rten pa rnams zhe khrel bar byed pa/}
 khyim pa'i cha lugs|{mi skya bo'i chas gos gyon stangs/}
@@ -4496,14 +4526,15 @@ khyim mtshes|{grong rogs/ khyim mtshes rgyal khab/ thag ring gi gnyen las mdza' 
 khyim 'tsho|1) {khyim tshang la 'tsho skyong byed pa/} 2) {khyim dang 'tsho ba'i bsdus ming/}
 khyim 'dzin|{khyim so 'dzin mkhan/}
 khyim 'dzin ma|{chung ma'am/ khyim bdag mo/}
-khyim zhag nyi ma khyim rer 'pho ba'i yun tshad sum cur bgos pa'i cha shas gcig khyim zhag dkyil 'khor|{khyim lo gcig gam khyim zhag sum brgya drug cu tham pa/}
-khyim zhag dus kyi rtag longs|{khyim zhag gcig gi dus longs te/yul longs dus tshod bzhi dang chu srang sum cu'am nyin zhag gi chu tshod drug cu dang/ chu srang nga gnyis/ dbugs bzhi/ dbud gcig dus mda' mkha' ri yid kyi char byas pa'i cha shas sum khri lnga stong brgya phrag gcig dang bzhi yin/ 4 30 ( 1 ) 1 60 1 60 52 4 35104 1470156 1 01464}
+khyim zhag|{nyi ma khyim rer 'pho ba'i yun tshad sum cur bgos pa'i cha shas gcig}
+khyim zhag dkyil 'khor|{khyim lo gcig gam khyim zhag sum brgya drug cu tham pa/}
+khyim zhag dus kyi rtag longs|{khyim zhag gcig gi dus longs te/yul longs dus tshod bzhi dang chu srang sum cu'am nyin zhag gi chu tshod drug cu dang/ chu srang nga gnyis/ dbugs bzhi/ dbud gcig dus mda' mkha' ri yid kyi char byas pa'i cha shas sum khri lnga stong brgya phrag gcig dang bzhi yin/} 4 30 1.  1 60, 1 60 52 4, 35104/1470156, 1.01464
 khyim gzhis|{gtan du gnas sa'i gzhis/ khyim gzhis chags pa/}
-khyim zla|1) {bza' zla/} 2) {khyim zhag sum cu tshang ba'i dus te/ nyi mas rang 'gros kyis yul gyi chu tshod mda' yon zla ba bgrod pa'i yun tshad de la khyim zla zhes bya'o/ 1 620 135 1/12}
-khyim zla'i dus kyi rtag longs|{gza'i rang 'khor bzhi song zin pa'i 'phro na gza' gnas su gnyis dang/ chu tshod nyer drug chu srang nyer gcig dbugs gcig dbugs gcig ri ro'i cha bcu/ ri mkha' ri'i tsha lnga brgya don gsum/ 'dod cha gnyis bcas so/ 30 4+7+2=30 26 21 1 10/67/ 573/707/1/13/ }30.{43922}
+khyim zla|1) {bza' zla/} 2) {khyim zhag sum cu tshang ba'i dus te/ nyi mas rang 'gros kyis yul gyi chu tshod mda' yon zla ba bgrod pa'i yun tshad de la khyim zla zhes bya'o/} 1,620 135 1/12}
+khyim zla'i dus kyi rtag longs|{gza'i rang 'khor bzhi song zin pa'i 'phro na gza' gnas su gnyis dang/ chu tshod nyer drug chu srang nyer gcig dbugs gcig dbugs gcig ri ro'i cha bcu/ ri mkha' ri'i tsha lnga brgya don gsum/ 'dod cha gnyis bcas so/} 30, 4x7+2=30 26 21 1, 10/67, 573/707, 2/13, 30.43922
 khyim gza'|{nyi ma khyim so sor slebs nyin gyi res gza'/ de la khyim 'pho'i gza' yang zer/}
 khyim las|{mi tshang gi phyi nang las ka/}
-khyim lo|{nyi ma rang 'gros kyis rgyu skar 'khor lo rdzogs par spyod pa la brten nas sa la dus bzhi 'khor tshul gyi khyim bcu gnyis rdzogs par 'char ba la khyim lo zhes btags pa'o/ khyim lo gcig la khyim zhag sum brgya dang drug cu tham pa/ nyin zhag sum brgya drug cu re lnga dang mig klu me skyon gyi cha 4975/ skyon ston lo 'pho'i thad la ltos/ 360 365 4975/18382(=}365.270645) 356.{258675}
+khyim lo|{nyi ma rang 'gros kyis rgyu skar 'khor lo rdzogs par spyod pa la brten nas sa la dus bzhi 'khor tshul gyi khyim bcu gnyis rdzogs par 'char ba la khyim lo zhes btags pa'o/ khyim lo gcig la khyim zhag sum brgya dang drug cu tham pa/ nyin zhag sum brgya drug cu re lnga dang mig klu me skyon gyi cha 4975/ skyon ston lo 'pho'i thad la ltos/} 360, 365 4975/18382(=365.270645) 356.258675
 khyim sa|{khyim chags sa'am yod sa/}
 khyim sun 'byin pa|{khyim pa sun 'byin pa dang don gcig}
 khyim sun 'byin pa'i lhag ma|{dge 'dun lhag ma bcu gsum las/ bsgo ba las gyur pa'i lhag ma bzhi'i nang gses/ bslab pa dang 'gal ba'i ngan spyod kyis khyim pa rnams sun 'byin par byas te/ ma dad pa byed pa'i tshe dge slong de dge 'dun gyi gnas nas bskrad pa na skrod byed dge 'dun la bskur ba 'debs pa lan gsum gyi bar du bzlog kyang mi nyan pa'o/}
@@ -4543,7 +4574,7 @@ khyu yi bdag|{(mngon) glang po mchog khyu g.yag 'bras bu ma phyung ba'i pha g.ya
 khyug ge ba|{myur stabs su g.yo tshul zhig thag ring nas me 'od dmar khyug ge ba mthong byung/}
 khyug pa|{myur po/ sems khral byas te khyug gis 'gro ba/ mi de las ka byed dus bde cag khyug pa la/}
 khyug tsam|{hril tsam mam yud tsam/ khyod rang 'dir khyug tsam phebs rogs gnang/ 'di gar khyug tsam yong nas yang bskyar gzhan du phyin song/}
-khyugs se khyug shin tu myur ba'i tshul|{mun nag gi nang du glog 'od khyugs se khyug}
+khyugs se khyug|{shin tu myur ba'i tshul/ mun nag gi nang du glog 'od khyugs se khyug}
 khyung|1) {sngar gyi bshad srol bya chen zhig khyung mkha' lding snyi la 'dzin thabs med/ stag dmar yag thag pas btags thabs med/} 2) {sngar bod kyi yab 'bangs rus drug gi gras shig}
 khyung dkar|{gnag phyugs mdzo/}
 khung skyugs|{khyung gis sbrul zos pa las byung bar grags pa'i rin po che g.yu rnying las chung mthing mdangs chags pa zhig ste/ nus pas dug nad dang/ mchin nad/ mdze nad sogs 'joms/}
@@ -4603,8 +4634,9 @@ khyo bo|{khyim bdag ming gi rnam grangs la khyo pho bo dang/ dga' grogs/ dga' ba
 khyo mang|{(mngon) smad 'tshong ma/}
 khyo med ma|{khyo ga med pa'am/ mag pa med pa'i bud med/}
 khyo mo|{khyo ga yod pa'i bud med/}
-khyo shug bza' mi'am bza' tshang ngam bza' tsho|{khyo shug gnyis 'grogs nas phyin song/ khyo shug tu bsdu ba/}
-khyog 'gyog pa'i skul tshig khyog pa|{(tha mi dad pa) theg thub pa'am 'degs thub pa/ dka' ngal ci tsam byung yang khyog pa/ gang mi khyog par do'i snon pa/}
+khyo shug|{bza' mi'am bza' tshang ngam bza' tsho/ khyo shug gnyis 'grogs nas phyin song/ khyo shug tu bsdu ba/}
+khyog|{'gyog pa'i skul tshig}
+khyog pa|{(tha mi dad pa) theg thub pa'am 'degs thub pa/ dka' ngal ci tsam byung yang khyog pa/ gang mi khyog par do'i snon pa/}
 khyog po|{theg pa'am khur thub pa/ las 'gan khyog po 'dug}
 khyogs|1) {'gyogs khri'am/ 'gyogs byams/ khyogs kyis bteg pa/ khyogs 'degs pa/} 2) {las khri/}
 khyogs khri|{'do li'am phebs byams/}
@@ -4628,14 +4660,14 @@ khyor ba|{lag thal ya gcig cung zad 'khums pa'i ming ste/ de dang srang do gnyis
 khyos ma|1) {zas kyi lhag ma/} 2) {rngan pa'am lag rtags/ nga la khyos ma rnams bskur te sngon la brdzangs/ khyos ma bzang po/}
 khra|{bye'u sogs gsod mkhan bya zhig ming gi rnam grangs la bya khra dang/ g.yo/ ba/ ri bong za bcas so/}
 khra kyi le|{khra lham me/ skar ma khra kyi ler shar 'dug}
-#khra bkyag ja dkar gyi stegs|
+khra bkyag|{ja dkar gyi stegs/}
 khra khra|{tshos gzhi sna tshogs 'dres pa/ ras khra khra/ khyi khra khra/ khra khra pa khra/}
 khra khro|{spro thung ba'am ngang thung ba/ khra khro can dang mnyam du rtsed mo ma rtse/}
 khra gling|{(yul) sge'u khung khra ma nyis sbyar ram gsum sbyar gyi gling/}
 khra rgya|{bya khra 'dzin byed kyi rnyi/}
 khra bcad|{khang pa la shing gi khra ma bsgrigs pa'i yol bcad/}
 khra chil le ba|{bkrag mdangs che ba/ mda' gri mdung gzhu dang bcas khra chil le ba'i ngang nas g.yul du bskyod do/}
-#khra chung mig lta byed mig khra chung mig la sdul mi 'gro|
+khra chung mig|{lta byed mig  khra chung mig la rdul mi 'gro/}
 khra chem chem|{ha cang bkra ba'i tshon mdangs 'phro stangs/ stag gzig gi spu ris khra chem chem/ rin chen mdzes rgyan gyi 'od mdangs khra chem chem/}
 khra chem me|{'od bkrag 'tsher stangs shig nam mkha' g.ya' dag la rgyu skar khra chem mer shar 'dug}
 khra chod|{shing gi khra ma'i bcad/}
@@ -4651,8 +4683,8 @@ khra sbo|{(mngon) khra zla'am dbo zla ste/ hor zla gnyis pa/}
 khra ma|1) {rgya gram lta bu'i ri mo ste/ skar khung gi khra ma/} 2) {yi ge'i khra ma/ kha mchu thag chod pa'i bcad mtshams khra ma/} 3) {btab nas zhag drug cu song mtshams smin yong ba'i nas dang khre/} 4) {khya ma dang 'dra/}
 khra ma nyis sgrom|{sge'u khung khra ma gling nyis bsgrid/}
 khra man|{ri mo sngo dmar dkar gsum yod pa'i gzi ste dkar khra man yang zer/}
-khra mig khra ma'i dra mig khra me re|{kha dog sna tshogs kyi bkrag mdangs}
-snang tshul|{phyogs nas 'dus pa'i mi tshogs rnams kyis gos khra me re gyon pa/ lus rtsal thang mis khra me rer gang 'dug}
+khra mig|{khra ma'i dra mig}
+khra me re|{kha dog sna tshogs kyi bkrag mdangs snang tshul/ phyogs nas 'dus pa'i mi tshogs rnams kyis gos khra me re gyon pa/ lus rtsal thang mis khra me rer gang 'dug}
 khra mer mer|{kha dog sna tshogs kyi rang mdangs snang tshul/ glog zhu tshon mdog mang po khra mer mer bkra ba/ ri ldebs rnams ra lug gis khra mer mer du gang 'dug}
 khra zla|{(mngon) hor zla gnyis pa/}
 khra yol|{sge khung khra ma can gyi yol ba/}
@@ -4662,24 +4694,27 @@ khra ru|{sge'u khung gi shel khra bsgar sa'i ru/}
 khra la|{mtsho sngon zhing chen khongs yus hru'u bod rigs rang skyong khul gyi khri 'du rdzong gi ba yan ha la ri'i la zhig}
 khra lam me|{mig lam du lhang nger gsal ba'am mdzes pa/ ma 'ongs pa'i gnas tshul khra lam mer mthong ba/ me long la gzugs brnyan shar ba ltar khra lam me bar yod/}
 khra lam lam|{ha cang gsal ba'i tshon mdangs sna tshogs 'char stangs/ rma bya'i sgro mdangs khra lam lam/ 'ja' tshon gyi mdangs ris shin tu khra lam lam 'dug}
-khra shig shig 'od bkrag 'tsher ba'i rnam pa zhig stag lpags kyi ri mo khra shig shig 'dug khra shel|{sge'u khung gi khra ma'i shel/}
+khra shig shig|{'od bkrag 'tsher ba'i rnam pa zhig stag lpags kyi ri mo khra shig shig 'dug}
+khra shel|{sge'u khung gi khra ma'i shel/}
 khra sing sing|1) {bar gseng dang re'u mig gi bu ga gsal ba/ skar khung khra ma'i bar stong khra sing sing mthong gi 'dug} 2) {dmar rjen du thon pa/ nags der sdong skam khra sing sing mang/ rus pa khra sing sing la khyi'ang mi 'khor/}
-#khra slog dpyad khra dang du mi len pa|
+khra slog|{dpyad khra dang du mi len pa/}
 khra hor|{bya khra hor pa/}
-khra hrig hrig mig 'bur tshugs su lta tshul|{stag gzig gi mig khra hrig hrig lta ba/}
+khra hrig hrig|{mig 'bur tshugs su lta tshul/ stag gzig gi mig khra hrig hrig lta ba/}
 khra lham me|{'od sna tshogs 'phro stangs sam/ 'char tshul/ mtshan mo glog zhu'i 'od mdangs khra lham mer gsal/ sngar gyi gnas tshul khra lham mer dran pa/}
-khrag lus kyi khrag zungs khrag nad khrag snying khrag khrag gi dwangs ma|{khrag dron las grub pa/ dkar na zho/ dmar na khrag ming gi rnam grangs la khyab gnas dang/ mdog dmar/ mi ltung/rma skyes/ rma las 'bab pa/ mtshon bsnun skyes/ lus skyes/ sha yi sa bon/ shar 'gyur byed bcas so/}
+khrag|{lus kyi khrag zungs khrag nad khrag snying khrag khrag gi dwangs ma/ khrag dron las grub pa/ dkar na zho/ dmar na khrag ming gi rnam grangs la khyab gnas dang/ mdog dmar/ mi ltung/rma skyes/ rma las 'bab pa/ mtshon bsnun skyes/ lus skyes/ sha yi sa bon/ shar 'gyur byed bcas so/}
 khrag rkang|{sngo sman gyi nang tshan ser po khrag rkang dang myang rtsi spras kyang zer te/ ro kha la bska/ zhu rjes bsil/ nus pas chu gsher 'then/ rgyu tshad 'joms/ rims tshad sel/}
 khrag skem|{khrag gcod byed sman mchog cig}
 khrag skyug|1) {khrag skyug pa'i nad/} 2) {(mngon) chu phag lo/}
 khrag skyes|{(mngon) lus kyi sha/}
 khrag skran|{kha zas kyi dwangs ma ma zhu ba don snod kyi nang du khrag ngan rgyas shing/ de 'dril te skran du gyur pa/}
 khrag skran hrem po|{mngal du khrag skran chags pa zhig ste/ nad rtags su mngal du bu chags pa ltar hrem ste mkhregs por chags shing ldang dub byed pa zhig}
-#khrag khrig ther 'bum chen po bcu tham pa|
+khrag khrig|{ther 'bum chen po bcu tham pa/}
 khrag khrig snang ba|{(mngon) smig rgyu/}
-khrag khrug khrag gi khrug gi'i bsdus tshig khrag khrog khrag ge khrog ge'i bsdus tshig khrag khrog pa|{sngo sman gyi nang tshan khang phug pa'am dar ya kan te/ nus pas byang khog nang gi rnag khrag skem/ rkang 'bam 'joms/}
+khrag khrug|{khrag gi khrug gi'i bsdus tshig}
+khrag khrog|{khrag ge khrog ge'i bsdus tshig}
+khrag khrog pa|{sngo sman gyi nang tshan khang phug pa'am dar ya kan te/ nus pas byang khog nang gi rnag khrag skem/ rkang 'bam 'joms/}
 khrag mkhris|{khrag nad dang/ mkhris pa'i nad gnyis mnyam du 'dom pa'i nad/}
-#khrag 'khrug lus kyi khrag 'khrug pa'i nad|
+khrag 'khrug|{lus kyi khrag 'khrug pa'i nad/}
 khrag gi khrug gi|{zing nger 'dzings pa'am/ 'dres nas 'khrugs pa'i tshul/ dpe cha rnams khrag gi khrug gi byas te bsngogs 'dug gong 'og 'dzings shing khrag khrug tu 'khrugs pa/}
 khrag gi so nad|{so nad bye brag cig}
 khrag ge khrog ge|{sgrig bkod 'khrugs pa'i zang ngi zing ngi'i snang tshul/ sgam g.yugs te ca lag rnams khrag ge khrog ger gyur 'dug}
@@ -4710,7 +4745,7 @@ khrag rtsa|{lus rtsa'i bye brag cig}
 khrag tshabs|{bud med kyi zla mtshan rgyun ldan bzhin ma bab par rlung gis ngan khrag lus la gtor nas byer ba'i nad de/ nang gses su dbye na glo ba'i khrag tshabs dang/ snying gi khrag tshabs/ mchin pa'i khrag tshabs/ mtsher pa'i khrag tshabs/ mkhris pa'i khrag tshabs/ mkhal ma'i khrag tshabs/ rgyu ma'i khrag tshabs/ 'o tshabs/ nu tshabs/ khrag tshabs gor pa bcas rigs bcu mchis so/}
 khrag tshabs gor pa|{mo nad khrag tshabs bcu'i nang tshan lus lci zhing 'gro mi thub pa dang/ rgyu smad du 'dril snyam sems pa 'byung ba zhig}
 khrag 'tshab|{bsad pa'am rmas pa'i lan len pa/}
-#khrag 'dzag khrag thigs rgyag pa|
+khrag 'dzag|{khrag thigs rgyag pa/}
 khrag 'dzin|{(mngon) pags pa/}
 khrag zhag khrag dang zhag tshi'i bsdus tshig khrag rul|{rnag}
 khrag ro|1) {khrag gi snyigs ma'am ro to/} 2) {khrag nad kyi nad ro/}
@@ -4736,14 +4771,14 @@ khrab lcibs|{khrab kyi nang gdan nam nang gos/}
 khrab chas|{drag chas go khrab/}
 khrab byang|{khrab kyi byang bu/}
 khrab ma|1) {khrab gyon pa'i dmag mi/} 2) {(rnying) lus la gyon byed pa'i khrab/}
-#khrab rmog lus skyob dang mgo skyob gnyis|
+khrab rmog|{lus skyob dang mgo skyob gnyis/}
 khram|{rtsis kyi khram kha sogs ri mo'i bye brag cig khye bos khram brgyab pa/ bcu khram/}
 khram kha|1) {rgya gram gyi ri mo ste khram bam/ rtsis kyi khram kha/} 2) {'dre gdon 'gugs byed kyi shing byang/}
 khram kha'i shing|{khram ris btab pa'i shing ste 'dre gdon 'gugs byed kyi shing byang/}
 khram khram|{thang mar rdal ba'am 'grems tshul/ lci ba rlon pa thang la khram khram du bkram nas nyi mar bskams pa/}
 khram khrum|1) {rdung btags zhib mor ma byas pa'i rags dum/ sman hrob khram khrum du rdung ba/} 2) {khram mi khrum mi'i bsdus tshig}
-khram rgyag mi ro bya gtor byed skabs sha lpags sbrags mar dum bur dra ba|{mi bsad pas ma chog par ro thog la khram brgyab 'dug}
-khram nag g.yo khram tsha po|{mi khram pa khram nag}
+khram rgyag|{mi ro bya gtor byed skabs sha lpags sbrags mar dum bur dra ba/ mi bsad pas ma chog par ro thog la khram brgyab 'dug}
+khram nag|{g.yo khram tsha po/ mi khram pa khram nag}
 khram pa|{g.yo sgyu can/}
 khram bam|{rgya gram gyi ri mo/}
 khram mi khrum mi|{ngal dub kyis lus 'khyor tshul zhig thag ring du phyin nas gzugs po khram mi khrum mir gyur 'dug}
@@ -4764,7 +4799,7 @@ khral khrol|{khral le khrol le'i bsdus tshig}
 khral 'khri|{rang thog tu bab pa'i khral 'ul gyi 'gan/}
 khral rgyug pa|1) {khral sgrub pa'am 'u lag tu 'gro ba/} 2) {rkang 'gro lag 'don gyi khral gang zhig 'khri ba de dod ma yin par dngos su rgyug dgos mkhan/}
 khral mngon sla bcos|{khral yin bsams te rang 'gan legs par mi sgrub pa/}
-#khral chag khral 'bab yang du phyin pa|
+khral chag|{khral 'bab yang du phyin pa/}
 khral 'jal|{'bru dngul sogs kyi khral sgrub pa/}
 khral rten sa zhing|{khral 'ul rgyug rgyu'i dmid rten/}
 khral 'ded pa|1) {khral 'ul rgyug par skul 'ded byed pa/} 2) {khral 'ul skul 'ded byed mkhan/}
@@ -4781,7 +4816,7 @@ khral tshad|{khral 'bab kyi tshad gzhi/ khral tshad spor gcog}
 khral zhing|{khral 'ul sgrub rten gyi sa zhing/}
 khral zla khral rogs|{khral 'ul rgyug mkhan nang khul gyi mi/}
 khral 'ul|{khral dang 'u lag khral 'ul 'gel dkri/ khral 'ul sgrub 'jal/}
-#khral g.yog khral pa'i g.yog po|
+khral g.yog|{khral pa'i g.yog po/}
 khral g.yol|{khral rgyug rgyu byol ba/}
 khral rigs|{khral 'ul sna tshogs/ khral rigs yang cha byed pa/ khral rigs rtsa chag gtong ba/}
 khral rigs sgrub khungs|{khral rigs sgrub 'jal byed yul mnga' bdag}
@@ -4800,7 +4835,7 @@ khri bgrangs mtsho|{mtsho sngon zhing chen khongs mtsho nub sog rigs bod rigs ha
 khri rgyab drug 'gyogs|{bya khyung dang/ klu mo/ chu srin/ bu chung/ krisha ? na sA ra/ glang chen bcas kyis bteg pa'i sangs rgyas byang sems kyi khri'i rgyab yol/ bya khyung steng la bris yod pa dang/ klu mo sogs lnga po de g.yas g.yon gnyis su bris yod/}
 khri sgyogs|1) {byams khri/} 2) {me sgyogs/}
 khri sgra dpung bcan|{dpung zhes pa spungs yang snang/ khri btsan nam dang sman bza' khri dkar gnyis kyi sras sngar bod rgyal nyer drug pa ste btsan lnga'i ya gyal zhig}
-#khri lcog khri mdun du rgyag pa'i lcog tse mthon po|
+khri lcog|{khri mdun du rgyag pa'i lcog tse mthon po/}
 khri chen|{sngar bod rje chos rgyal gyi gdung las brgyud cing/ chos srid gnyis ka'i go gnas kyi lhag zhabs tsam skyong ba la khri chen gyi mtshan gyis gzengs su bstod pa e lha rgya ri khri chen/ sa skya bdag chen nam khri chen/ gra phyi smin grol gling khri chen lta bu/}
 khri gnyan|{khri snyan dang 'dra/}
 khri gnyan gzungs bcan|{sngar bod rgyal nyer dgu pa/ lha tho tho ri gnyan btsan gyi bu yin/ rgyal po de'i skabs su bod kyi zhing sa dang 'brog sa 'brel mthud dang/ mtsho dang mtshe'u yur bur 'brel sbyor byas nas de'i chu zhing kha la 'dren pa'i srol btsugs/}
@@ -4821,7 +4856,7 @@ khri lde gtsug brtan|{sngar bod rgyal so bdun pa ste/ ming gzhan khri lde gtsug 
 khri lde yum brtan|{'di ni glang dar ma'i btsun mo chen ma'i bu dod yin te/ glang dar bkrongs rting yum gyis mi gzhan pa'i bu chung zhig btsal nas rang gi bur byas/ gzhan gyis de la blo mi thub kyang/ yum gyi bka' brtan du bcug pas khri lde yum brtan du ming chags/ phyis btsun mo chun ma'i bu gnam lde 'od srungs dang ma 'chams par 'khrug long byung ste gnyis ka'i rgyal sa shor/de nas bzung ste gnya' khri btsan po'i gdung rgyud kyis bod spyi la dbang bsgyur ma thub bo/}
 khri lde srong btsan|{khri srong lde'u btsan gyi sras gsum pa mu tig btsan po yin zhes pa dang/ yang sras bzhi pa'o zhes pa dang/ yang dbon sras khri ral pa can yin zhes pa sogs bzhed tshul sna tshogs 'dug go /}
 khri pa|{dbu bzhugs mkhan/ dga' ldan khri pa/ mkhan po khri pa/ bka' blon khri pa/}
-#khri phrag stong phrag bcu'i grangs|
+khri phrag|{stong phrag bcu'i grangs/}
 khri 'phang|{khri'i dpangs tshad/}
 khri sbrel ma|{khri nyis gshibs sam/ khri nyis bsgrid/}
 khri mu|{bod rang skyong ljongs lho kha kron chus khongs mtsho sna rdzong gi sa cha zhig 'gro ba bzang mo zhes pa'i sgrung nang bdud mo ha shang gi pha yul ni 'di'i rgyud na yod/}
@@ -4845,7 +4880,8 @@ khri srong lde brtsan|{(rnying) khri srong lde btsan dang 'dra/}
 khri srong lde'u btsan|{khri srong lde btsan dang 'dra/}
 khri srong rtsan|{(rnying) srong btsan sgam po dang don gcig}
 khrig khrig|1) {brtan brtan/ khyod rang khrig khrig yin nam/} 2) {'tshams po'am/ cha snyoms po/ mang nyung khrig khrig cig byung 'dug} 3) {legs pa'i ldog phyogs/ mi de khrig khrig cig 'dug} 4) {lham gyi sgra/}
-khrig gcig sdeb gcig khrig snyoms|{cha snyoms/}
+khrig gcig|{sdeb gcig}
+khrig snyoms|{cha snyoms/}
 khrig pa gang|{(yul) phyur bur gang ba/}
 khrigs|{gral dang/ star/ khrigs su chags pa/}
 khrigs khrigs med|{(yul) ha lam yid ches pa'am re ba byed pa dang dogs zon byed pa sod ston pa/ da lo lo yag 'byung bar khrigs khrigs med/ 'gro dang mi 'gro khrigs khrid med/}
@@ -4858,7 +4894,7 @@ khrid chen brgyad|{'gro mgon gtsang pa rgya ras kyi gdams ngag ste/ bla ma sku g
 khrid ston|{lam khrid slob ston/}
 khrid 'debs|{dpe cha sogs kyi go don slob pa'am brda sprod pa/ slob phrug rnams la dpe cha'i tshig don kha gsal go bde'i khrid 'debs byed pa/}
 khrid pa|{'khrid pa'i 'das pa/}
-#khrid yig slob khrid byed rgyu'i yi ge'am dpe cha|
+khrid yig|{slob khrid byed rgyu'i yi ge'am dpe cha/}
 khrid bshad|{dpe cha'i tshig don dang lag rtsal sogs ngag thog nas 'grel bshad brgyab pa/}
 khrims|{lha chos sam mi chos dang mthun pa'i lugs/ bca' khrims/ bka' khrims/ tshul khrims/ chos khrims/ rgyal khrims/ khrims gtong ba/ bka' brtsi khrims bkur/ khrims la gnas pa/ khrims la thug pa/ khrims la gtugs pa/ khrims la sbyor ba/ nag can gte po khrims kyis bkums pa/ dbang cha dang 'os 'gan tshang ma khrims kyis bcas/ khrims 'og la ma non pa'i mi dang/ sga 'og la ma shong ba'i rta/}
 khrims kyi kha lo pa|{(mngon) blon po/}
@@ -4874,7 +4910,7 @@ khrims gcod yul|1) {khrims ra/} 2) {nyes can gyi mi/}
 khrims gcod las mkhan|{khrims gcod kyi las ka lag len star ba'i mi/}
 khrims chad|{khrims dang 'gal ba'i nyes chad/}
 khrims chas|{khrims gcod gtong skabs kyi yo byad/}
-khrims chen drug mi srog mi gcod pa|{gzhan nor mi rku ba/ rdzun mi shod pa/ log g.yem mi spyod pa/ chang mi 'thung ba ste gtan khrims lnga dang/ kheng mi ldog pa bcas sngar bod rje srong btsan sgam pos bcas pa'i khrims chen drug ces su grags/}
+khrims chen drug|{mi srog mi gcod pa/ gzhan nor mi rku ba/ rdzun mi shod pa/ log g.yem mi spyod pa/ chang mi 'thung ba ste gtan khrims lnga dang/ kheng mi ldog pa bcas sngar bod rje srong btsan sgam pos bcas pa'i khrims chen drug ces su grags/}
 khrims chen bdun|{mi srog mi gcod pa/ gzhan nor mi rku ba/ rdzun mi shod pa/ log g.yem mi spyod pa/ chang mi 'thung ba ste gtan khrims lnga dang/ kheng mi ldog pa/ bang so mi 'dru ba gnyis bcas sngar bod rje srong btsan sgam pos bcas pa'i khrims bdun zhes su grags/}
 khrims 'jags|{khrims ji ltar bsgrags pa ltar gnas pa/}
 khrims 'jal|{nyes chad 'jal ba/}
@@ -4887,12 +4923,12 @@ khrims dung|1) {khrims gcod drag po gtong skabs 'bud pa'i dung/} 2) {khrims sar 
 khrims deb|{khrims lugs kyi yig cha/}
 khrims drag po|1) {khrims lci po/} 2) {lus srog la chad 'bebs kyi khrims/}
 khrims dral|{khrims bshig pa'am/ khrims rgya dbral ba/}
-khrims bdag bka' khrims kyi bdag po|{khrims bdag gong sa/}
+khrims bdag|{bka' khrims kyi bdag po/ khrims bdag gong sa/}
 khrims ldan|{tshul ldan nam/ khrims mthun/}
 khrims sdom pa|{khrims bzo ba/}
 khrims gnas|1) {khrims la gnas pa/} 2) {khrims gcod sa'i gnas sam yul/}
 khrims dpon|{zhal lce gcod pa po/}
-#khrims phog khrims kyis nyes pa lus dang rgyu thog tu phog pa|
+khrims phog|{khrims kyis nyes pa lus dang rgyu thog tu phog pa/}
 khrims sbyor|{khrims la sbyor ba ste khrims sar skyel ba/}
 khrims mun|{(rnying)} 1) {khrims gcod ra ba/} 2) {btson khang/}
 khrims med|{lugs srol med pa/ khong gang zag khyad par can zhig tu mi 'dzin pa'i khrims med/}
@@ -4903,13 +4939,13 @@ khrims rtsa|{khrims lugs/ khrims rtsa brag ri las nan pa/ khrims gzhug mda' mo l
 khrims brtsi|{bka' khrims dang len/}
 khrims 'dzin pa|1) {yul khrims 'dzin mkhan/} 2) {chos khrims 'dzin mkhan/}
 khrims bzo|{sgrigs khrims gsar bzo/}
-#khrims yig rgyal khab kyi khrims lugs gtan la phab pa'i yig rigs|
+khrims yig|{rgyal khab kyi khrims lugs gtan la phab pa'i yig rigs/}
 khrims yig dwangs shel me long|{rab byung bcu gcig pa'i lcags bya lor sde srid sangs rgyas rgya mtshos brtsams pa zhig 1681}
-khrims yig drug khri rtse 'bum bzher gyi khrims dang|{'bum gser thog sha ba can gyi khrims/ rgyal khams dper blangs kyi khrims/ mdo lon zhu bcad kyi khrims/ dbang chen bcad kyi spyi khrims/ khab so nang pa'i khrims te srong btsan sgam pos bod du lag len bstar ba'i rtsa ba'i bka' khrims drug}
+khrims yig drug|{khri rtse 'bum bzher gyi khrims dang/ 'bum gser thog sha ba can gyi khrims/ rgyal khams dper blangs kyi khrims/ mdo lon zhu bcad kyi khrims/ dbang chen bcad kyi spyi khrims/ khab so nang pa'i khrims te srong btsan sgam pos bod du lag len bstar ba'i rtsa ba'i bka' khrims drug}
 khrims yig gsum|{srong btsan sgam po'i skabs lag len bstar ba'i bden rdzun dbye 'byed kyi zhal lce khag gsum ste mdo lon zhu bcad kyi khrims dang/ dbang chen bcad kyi spyi khrims/ khab so nang pa'i khrims bcas so/}
 khrims ra|1) {btson khang/} 2) {khrims gcod sa/}
 khrims lugs|{khrims kyi lugs srol/}
-#khrims bshig khrims la ma brtsis par gtor ba|
+khrims bshig|{khrims la ma brtsis par gtor ba/}
 khrims sa|{khrims khang/ khrims sa gong ma/}
 khrims sa bar gcod|{khrims khang nas thag gcod dgos nges kyi gyod don de 'og nas khrims 'gal gyis thag gcod byas pa/}
 khrims sa tshod longs|{khrims la mthong chung byed pa/}
@@ -4923,7 +4959,7 @@ khri'u shing|{rkub stegs/}
 khris|{rkang dang nyag ma/ ska rags khris gcig}
 khris skud|{gyon pa'i mthar gtong rgyu'i skud pa bslas ma/}
 khru|1) {gru mo'i sne nas mtheb chung rtsa ba'i tshigs bar gyi cha shas de la bskums khru gang dang/ gru mo'i sne nas gung mdzub kyi rtse mo bar gyi cha shas de la brkyangs khru gang zhes zer bas/ snga ma la sor nyi shu dang/ phyi ma la sor nyer bzhi mchis so/} 2) {'dul ba las gsal ba ltar na rang gi lus kyi spyi gtsug nas rkang mthil gyi bar dum bu bdun du btang ba'i dum bu gnyis kyi ring tshad cig}
-#khru gang khor yug khru gang gru bzhi pa|
+khru gang khor yug|{khru gang gru bzhi pa/}
 khru 'jal|{khru tshad len pa/}
 khru thil|{(rgya) cha sgam sgrog tse sogs kyi logs ngos dngos po 'jug snod/}
 khru slog pa|{phru slog pa dang 'dra/}
@@ -4942,13 +4978,13 @@ khrum khrum|{zas skam po ldad pa'i sgra'i khyad par/}
 khrums|{rgyu skar khrums stod dang khrums smad gnyis kyi spyi ming/}
 khrums stod|{rgyu skar nyi shu rtsa brgyad kyi nang tshan zhig ming gi rnam grangs la bya mchu dang/ ra yi lha mo/ gnas me bcas so/}
 khrums smad|{rgyu skar nyi shu rtsa brgyad kyi nang tshan zhig ming gi rnam grangs la autta ra dang/ bha dra pA/ ze'u 'ching bcas so/}
-khrums zhag log zhag nyer bzhi dang bya zhag bzhi bcu rdzogs rjes su khrums zhag bcu gnyis brtsi ste|{bya zhag rdzogs rjes gtsang gi khrums zhag brtsi zhes pa ltar ro/}
+khrums zhag|{log zhag nyer bzhi dang bya zhag bzhi bcu rdzogs rjes su khrums zhag bcu gnyis brtsi ste/ bya zhag rdzogs rjes gtsang gi khrums zhag brtsi zhes pa ltar ro/}
 khrums zla|{hor zla bdun pa'i bcu drug nas brgyad pa'i bco lnga'i bar du khrums stod zla ba zer/}
 khru'u rtse|{(rgya) stong skud las btags pa'i dar rigs shig}
 khrus|1. {'khrud pa'i skul tshig }2. {khrus kyi ming/ gzugs po la khrus rgyag pa/}
 khrus kyi brtul zhugs|{(mngon) drang srong/}
 khrus khang|{khrus byed sa'i khang pa/}
-khrus khang|{(mngon) zhum bu'am byi la/}
+khrus mkhan|{(mngon) zhum bu'am byi la/}
 khrus chal|{'dag rdzas sam/ khrus rdzas/}
 khrus chu|1) {gzugs po 'khrud byed kyi chu/} 2) {lha rten la khrus gsol byas pa'i chu/}
 khrus dar|{lha rten la khrus gsol byed skabs sku phyi bar byed pa'i dar gos/}
@@ -4959,12 +4995,12 @@ khrus byed pa'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ tsha ba
 khrus ma|{khrud ma dang 'dra/}
 khrus rtsi|{'dag rdzas/}
 khrus rtswa|{(mngon) dag byed rdzas rtswa ku sha/}
-#khrus rdzas 'dag rdzas|
+khrus rdzas|{'dag rdzas/}
 khrus rdzing|{khrus rgyag sa'i chu rdzing/}
 khrus gzhong|1) {lus 'khrud sa'i gzhong pa/} 2) {khrus gsol skabs kyi 'bab gzhong/}
 khrus ras|{khrus rgyag skabs 'byid byed dang gyon rgyu'i ras/}
 khrus bshal|{chus dri ma bshal ba/}
-khrus bsum byed pa|{bya rgyud kyi spyod pa ste/ phyi'i khrus yan lag lnga khrus/ nang gi khrus rtsa ltung dag par byed pa/ gsang pa'i khrus mtshan rtog dag par byed pa'o/}
+khrus gsum byed pa|{bya rgyud kyi spyod pa ste/ phyi'i khrus yan lag lnga khrus/ nang gi khrus rtsa ltung dag par byed pa/ gsang pa'i khrus mtshan rtog dag par byed pa'o/}
 khrus gsol|{sku khrus 'bul pa/}
 khre|{son btab nas nyin zhag drug cu song mtshams smin thub pa'i 'bru'i bye brag cig}
 khre rgod|{zhing skyes khre yi rigs te/ nus pas 'khru ba gcod/ dug nad sel/}
@@ -4987,7 +5023,7 @@ khrel dogs|{gzhan zhe khrel ba'i dogs pa/}
 khrel gdong|{ngo tsha ba'i rnam 'gyur gyi gdong/}
 khel 'debs pa|{gzhan skyon gyi rnam grangs ra sprod pa/ sngar gyi byas nyes la khrel 'debs pa dang bcas phyin chad led bcos dgos pa'i bslab bya gtong ba/}
 khrel ba|1. {(tha mi dad pa) gzhan rgyu mtshan du byas nas nyes spyod la 'dzem pa/ nyes spyod la khrel ba/ mi 'os pa'i che thabs de skye bo khrel ba'i rgyu ru 'gyur/ }2. {nyes spyod la 'dzem pa'i shes pa/}
-#khrel bag khrel gzhung dang bag yod|
+khrel bag|{khrel gzhung dang bag yod/}
 khrel bor|{zhe khrel dogs la mi lta ba/}
 khrel med|{gzhan rgyu mtshan du byas te nyes pa la 'dzem pa med par 'jug pa spyod ngan la gzhan gyis khrel dogs mi byed pa/ nye nyon nyi shu'i nang gses shig}
 khrel med lugs med|{khrel ngo tsha med pa dang/ lugs srol la med pa/ khrel med lugs med kyi spyod ngan/}
@@ -5021,7 +5057,7 @@ khro gtum|1) {khong khro drag po/ zhe sdang gi khro gtum mi bzod pa 'bar ba/} 2)
 khro thab|{khro las bzos pa'i me thab/ rdo sol 'bud sa'i khro thab/}
 khro 'dar|{khong khro langs nas lus 'dar ba/}
 khro ldan|{(mngon) dpa' bo/}
-#khro nag lcags rigs khro nag po|
+khro nag|{lcags rigs khro nag po/}
 khro phu bka' brgyud|{'gro mgon phag mo gru pa'i slob ma rin po che rgyal tsha dang de'i slob ma khro phu lo tsA ba byams pa dpal bcas nas brgyud pa'i bka' brgyud/}
 khro phu dgon pa|{phag gru'i yang slob byams pa dpal gyis phyag btab pa'i dgon pa gtsang shab gzhung gi shar rgyud du yod/}
 khro phu lo tsA ba byams pa dpal|{rin po che rgyal tsha dang kun ldan ras pa sku mched kyi dbon po 'di rab byung gsum pa'i chu sprul lor 'khrungs/ dgung lo nyi shu pa nas zhang dge ba las sgra rig pa mthar phyin sbyangs te lo tsA ba grags can du gyur/ nyer bzhi pa la bal yul du byon/ kha che pan chen buddhashri las mdo sngags kyi gdams pa mang du gsan/ snga rting du mi tra dzo ge dang/ shAkyashribhadra/ buddhashri sogs pandita du ma khro phur spyan drangs/ yul 'khor rnams su 'chad nyan mdzad/ khro phu dgon par byams chen khru brgyad cu pa bzhengs/ sras sems pa chen po byung/ de'i yang slob tu bu ston rin po che byon/ rab byung bzhi pa'i shing bya la 'das/ de'i slob ma dag las rim par brgyud pa rnams la khro phu bka' brgyud ces grags/}
@@ -5029,7 +5065,7 @@ khro ba|1. {(tha mi dad pa) khros pa/ khro ba// sdang ba/ dgra la khros pa/ shin
 khro ba'i rgod pa|{khong khro'i sems rgod dam tshig pa za ba'i rkyen gyis sems g.yeng ba/}
 khro bas 'gog pa|{'gog pa'i rgyan gyi nang gses shig ste/ dgag bya mi 'dod pa'i bya ba'i dngos po byung zin pa zhig 'gog byed ko long gi khro tshig brjod pa'i sgo nas 'gog par byed pa'i rgyan zhig}
 khro bo|1) {drag po/} 2) {khro ba po/} 3) {drag po'i rnam 'gyur can gyi lha spyi/} 4) {(mngon) }1. {shing glang lo/ }2. {nang gi srung 'khor gyi phyogs bcur bzhugs nas sgrub pa po la srung ba'i khro bo bcu yod pas grangs bcu mtshon/}
-khro bo bcu gcig gnod mdzes dang|{gshin rje gshed/ gzhan gyis mi thub pa/ rta mgrin/ bdud rtsi 'khyil ba/ 'dod rgyal/ dbyug sngon can/ stobs po che/ mi g.yo ba/ gtsug tor 'khor bsgyur/ rdo rje sa 'og rnams so/}
+khro bo bcu gcig|{gnod mdzes dang/ gshin rje gshed/ gzhan gyis mi thub pa/ rta mgrin/ bdud rtsi 'khyil ba/ 'dod rgyal/ dbyug sngon can/ stobs po che/ mi g.yo ba/ gtsug tor 'khor bsgyur/ rdo rje sa 'og rnams so/}
 khro bo rnam par rgyal ba'i rtog pa gsang ba'i rgyud|{rgyud kyi bye brag cig khyon le'u bcu yod cing/ bod yig gi sgyur yig yod kyang/ sgyur pa po'i mtshan bkod med/ slar rgya yig gzhir bzung nas bsgyur bcos byas pa zhig}
 khro bo'i rgyal po|{lha drag po'i gtso bo/}
 khro bo'i sngags|{lha drag po'i gzungs sngags/}
@@ -5037,14 +5073,15 @@ khro bo'i rdo rje|{rdo rje bye brag cig}
 khro bo'i bzhad pa brgyad|{sdigs pa'i gad mo/ ha ha/ dgyes pa'i gad mo/ he he/ sgeg pa'i gad mo/ hi hi/ zil gyis gnon pa'i gad mo/ ho ho ste brgyad/}
 khro bo'i bzhugs stangs|{zhabs gcig brkyangs gcig bskums kyi bzhugs stangs/}
 khro mi thang|{(rnying) khro mi dgos/}
-#khro mig khong khro ba'i mig me ltar 'bar ba'i khro mig gis dgra la lta ba|
+khro mig|{khong khro ba'i mig  me ltar 'bar ba'i khro mig gis dgra la lta ba/}
 khro mo|1) {bud med khong khro can/} 2) {(mngon) shing 'brug lo/} 3) {lha mo khro mo/}
 khro tshub|{khong khro'i rnam 'gyur rlung tshub lta bu'i gzugs su bkod pa/ khro tshub langs pa'i rnam 'gyur ci yang ston/}
 khro zangs|1){khro dang zangs mnyam bsres kyis lugs brgyab pa'i snod spyad/} 2){lcags rigs khro'i nang gses shig}
 khro la|1){si khron zhing chen khongs dkar mdzes bod rigs rang skyong khul gyi sde dge rdzong gi ri zhig} 2) {la zhig bod rang skyong ljongs kyi kong po nyang phu dang ar rtsa mtsho'i bar du yod cing/ de'i mtho tshad rgya mtsho'i ngos nas smi 5494 yod/}
 khro lo lo|{sgra'i khyad par zhig dA ma ru dkrol nas sgra khro lo lo grag}
 khro sems|{khong khro'i sems/}
-khrog khrog nang nas grangs pa'i sgra grag stangs shig lto ba spos pas khog na sgra khrog khrog tu grag khrog chung|1) {sngo sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas rtsa tshad sel/ rma gso/ khrag shor gcod/} 2) {mes cher ma tshig pa'am tshos tsam pa/}
+khrog khrog|{nang nas grangs pa'i sgra grag stangs shig  lto ba spos pas khog na sgra khrog khrog tu grag}
+khrog chung|1) {sngo sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas rtsa tshad sel/ rma gso/ khrag shor gcod/} 2) {mes cher ma tshig pa'am tshos tsam pa/}
 khrog chen|{sngo sman zhig}
 khrog po|1) {mes tshig po'am tshos po/ bag leb khrog po/} 2) {rna ba de tsam mi gsal ba/ am cog khrog po/}
 khrog sman|1) {sa 'og nas bton rjes dngos po gzhan dang ma 'dres shing/ phye mar ma btags pa'i sman hrob/} 2) {sngo sman min pa'i sman rigs/}
@@ -5083,7 +5120,7 @@ khrom gseb|{khrom gyi nang ngam khrod/}
 khroms|{'grems pa'i skul tshig}
 khrol|{'grel ba dnag 'grol ba'i skul tshig}
 khrol khrol|{dA ma ru sogs kyi sgra khrol stangs shig}
-#khrol rgyag zhing kha thengs gnyis pa'i rmon pa rgyag pa|
+khrol rgyag|{zhing kha thengs gnyis pa'i rmon pa rgyag pa/}
 khrol ba|{(rnying) shes pa'am rtogs pa/}
 khrol bu|1) {'tshag byed kyi yo byad khrol ma chung chung/} 2) {dngos rdzas rdog po chung ngu'i rnam pa/ sman rdzas rnams khrol bur brdungs nas gdus/}
 khrol ma|{tshags ma/ spyir btang rgyun bus bzos pa'i tshags ma der zer/}
@@ -5092,7 +5129,7 @@ khrol le ba|{dA ma ru sogs kyi sgra grag tshul zhig}
 khrol lo lo|{khro lo lo dang 'dra/}
 khros pa|{khro ba'i 'das pa/}
 khros ma|{lha drag mo/}
-#khros tshig khros pa'i tshig rtsub bam tshig gnag po|
+khros tshig|{khros pa'i tshig rtsub bam tshig gnag po/}
 mkhan|{byed po/ shing mkhan/ lam mkhan/ 'gro mkhan/ yong mkhan/ shes mkhan/}
 mkhan brgyud|1) {rab byung gi sdom brgyud/} 2) {dgon pa'i mkhan po rim byung/}
 mkhan chung|1) {sngar bod kyi sa gnas srid gzhung gi sku drag ser mo ba'i go sa'i ming zhig} 2) {mkhan pa'i rigs me tog ser po 'char ba zhig ste/ nus pas glo nad sel/ lums byas na yan lag zha rengs 'dul/}
@@ -5103,7 +5140,7 @@ mkhan drung tA bla ma|{sngar bod sa gnas srid gzhung skabs/ yig tshang las khung
 mkhan drung sbrel po|{mkhan drung mnyam sbrel te sngar bod sa gnas srid gzhung gi yig tshang las khungs su mkhan drung zhes ser mo ba rim bzhi bzhi yod pa de dag mnyam sbrel la zer/}
 mkhan ldum|{rtswa ldum mkhan pa/}
 mkhan sde che chung|{sngar bod sa gnas srid gzhung gi sku drag ser mo ba'i go sa'i rim pa zhig}
-#mkhan nag rtswa mkhan pa nag po|
+mkhan nag|{rtswa mkhan pa nag po/}
 mkhan nang|{sngar bod sa gnas srid gzhung gis sa mtshams srung 'dzin du btang ba'i rtse drung la mkhan po dang/ shod drung la nang so zer/}
 mkhan pa|{ldum bu'i sman gyi rigs shig ste/ ro mngar la kha/ zhu rjes bsil/ nus pas khrag gcod/ lums byas na yan lag gi skrangs pa 'joms/}
 mkhan pa chig skyes|{rkang re rer skyes pa'i rtswa mkhan pa/}
@@ -5112,7 +5149,7 @@ mkhan po mngon gyur|{bsnyen par rdzogs pa'i mngon gyur bcu'i ya gyal zhig ste/ s
 mkhan po bo dhi sa twa|{bod rgyal khri srong lde btsan gyi dus su bod du phebs pa'i rgya gar gyi mkhan po zhi ba 'tsho/}
 mkhan bu|{mkhan po'i slob ma/}
 mkhan mo|{so thar sdom pa ster ba'i dge slong ma'am dge slong ma'i gtso bo/}
-#mkhan myug rtswa mkhan pa'i myu gu|
+mkhan myug|{rtswa mkhan pa'i myu gu/}
 mkhan tshab|{tA la'i bla ma'i mdzod pa spyi khyab mkhan po dngos su ma bskos pa'i bar la de'i las 'gan 'khur mkhan de la mkhan tshab zer/}
 mkhan zur|{dgon pa so so'i mkhan po 'phos nas zur du sdod mkhan/}
 mkhan rabs|{mkhan po rim byung/}
@@ -5125,17 +5162,18 @@ mkha' skyes|{(mngon)} 1) {me stag lo/} 2) {me stag}
 mkha' khyab|{nam mkhar khyab pa'am nam mkha' khebs pa ste rgya che ba'i dpe/ mkha' khyab slob ma/}
 mkha' khyab ting nge 'dzin|{phyogs kyi ris med par yongs su khyab pa'i ting nge 'dzin no/}
 mkha' gos can|{(mngon) sprin pa/}
-mkha' glog nam mkha'i glog mkha' bgrod|{(mngon) bya/}
+mkha' glog|{nam mkha'i glog}
+mkha' bgrod|{(mngon) bya/}
 mkha' 'grul|{gnam gru nam mkhar 'phur 'gro bar zer/}
 mkha' 'gro|{(mngon)} 1) {bya rigs/} 2) {lha/} 3) {mkha' 'gro ma/}
 mkha' 'gro skyes|{(mngon) srin po/}
-mkha' 'gro snying thog slob dpon pad ma dngos kyis mkha' 'gro ye shes mtsho rgyal la bstan pa dang|{pad ma las 'brel rtsal gyis gter nas bton pa'i rnying ma'i gdams ngag cig}
+mkha' 'gro snying thog|{slob dpon pad ma dngos kyis mkha' 'gro ye shes mtsho rgyal la bstan pa dang/ pad ma las 'brel rtsal gyis gter nas bton pa'i rnying ma'i gdams ngag cig}
 mkha' 'gro gtad rgya'i rgya mdud|{sde srid sangs rgyas rgya mtsho'i dngos slob 'phyongs rgyas ngag dbang dpal bzang gis mdzad pa'i man ngag rgyud kyi lhan thabs kyi gsang sman rnams lhug par bkrol ba'i lde mig lta bu'i le tshan zhig}
 mkha' 'gro sde lnga|{shar rdo rje mkha' 'gro/ lho rin chen mkha' 'gro/ nub pad ma mkha' 'gro/ byang las kyi mkha' 'gro/ dbus sangs rgyas mkha' 'gro bcas so/}
 mkha' 'gro ma|{(dAkini:)} 1) {thun min dngos grub brnyes pa'i rnal 'byor ma/} 2) {dag pa'i zhing khams sogs su skyes pa'i lha mo/}
 mkha' 'gro ye shes mtsho rgyal|{slob dpon pad ma'i gsang yum zhig}
-mkha' 'gro la phug sngo sman gyi nang tshan chu ma rtsi'i rigs shig ste|{ro skyur la bska/ zhu rjes drod/ nus pas chu 'gags 'bigs/ skyug pa gcod/ chu ser dang dmu chu sbyong/}
-#mkha' 'gro'i brda yig rnying ma'i gter yig la mkha' 'gro'i brda yig zer|
+mkha' 'gro la phug|{sngo sman gyi nang tshan chu ma rtsi'i rigs shig ste/ ro skyur la bska/ zhu rjes drod/ nus pas chu 'gags 'bigs/ skyug pa gcod/ chu ser dang dmu chu sbyong/}
+mkha' 'gro'i brda yig|{rnying ma'i gter yig la mkha' 'gro'i brda yig zer/}
 mkha' 'gro'i dbang|1) {sgrol ma'i gtso mo/} 2) {(mngon) }1. {bde mchog }2. {bya khyung/}
 mkha' mnyam|1) {nam mkha' mtha' yas pa dang mnyam pa ste/ rgya che ba'i dpe/} 2) {(mngon) sangs rgyas spyi/}
 mkha' steng 'gro|{(mngon) gza' bkra shis te mig dmar/}
@@ -5158,7 +5196,7 @@ mkha' sprin can|{(mngon) gro bzhin zla ba ste hor zla bdun pa/}
 mkha' 'phring|{(rnying) phor shubs/}
 mkha' dbyings|{mkha' klong ngam nam mkha'i mthongs/}
 mkha' 'bab|{bar snang nas 'bab pa'i mi rgyu kha char sogs/}
-mkha' dmag nam mkhar dmag 'thab byed pa'i dmag dpung ste|{spyir mkha' 'grul dpung sde dang/ sa ngos nas mkha' dmag rogs skyor byed pa'i dpung sde sna tshogs yod/}
+mkha' dmag|{nam mkhar dmag 'thab byed pa'i dmag dpung ste/ spyir mkha' 'grul dpung sde dang/ sa ngos nas mkha' dmag rogs skyor byed pa'i dpung sde sna tshogs yod/}
 mkha' yi snye ma|{(mngon) rgyal mtshan/}
 mkha' g.yugs|{gnam nas sa la mi rgyu sogs g.yugs pa/}
 mkha' rlangs|{bar snang du yod pa'i rlan gyi rlangs pa/}
@@ -5182,9 +5220,9 @@ mkhar rgya|{mkhar ru'i rgya ma ste mkhar rgya'i 'degs khal gcig la rgya ma brgya
 mkhar rgya'i spor|{mkhar 'degs sam mkhar khal gcig gi brgyad cu'i cha gcig}
 mkhar sngon|{sa ming zhig nang sog la yod/ deng sang ming la hu'u ho ha'o the zer/}
 mkhar rje|1) {rdzong gi sde pa ste rdzong dpon/} 2) {bsod nams/}
-mkhar nyag mkhar gyi nya ga ste mkhar rgya'i khal gcig gi nyi shu tham pa'i cha gcig yin zhing|{nya ga gang rer ha lam rgya ma'i srang bzhi re tsam zhig yin/}
+mkhar nyag|{mkhar gyi nya ga ste mkhar rgya'i khal gcig gi nyi shu tham pa'i cha gcig yin zhing/ nya ga gang rer ha lam rgya ma'i srang bzhi re tsam zhig yin/}
 mkhar nyal|{(mngon)} 1) {bya/} 2) {lha/}
-#mkhar lhag rdzong mkhar gyi rgyab phyogs|
+mkhar ltag|{rdzong mkhar gyi rgyab phyogs/}
 mkhar 'degs|{mkhar ru'i 'degs khal ste/ mkhar 'degs kyi khal gcig la ha lam rgya ma brgyad tsam zhig yin/}
 mkhar spe'u|1) {lcags ri'i phyogs mtshams su mtho tsam du brtsigs pa'i khang pa ste lcog kyang zer/} 2) {(rnying) shing gi sdong bu/}
 mkhar bu|{(rnying)} 1) {btsan rdzong chung ba/} 2) {mkhar chung ba/}
@@ -5205,7 +5243,8 @@ mkhal grum|{grum bu'i nad mkhal mar 'bab pa zhig ste/ nad rtags su sked pa man c
 mkhal 'grams|{mkhal nad rigs brgyad kyi nang tshan zhig}
 mkhal sngon la|{bod rang skyong ljongs kyi a mdo rdzong khongs su yod/}
 mkhal gcong|{lus smad grang zhing rked pa kha 'khor nas rgyun ring du na ba'i mkhal nad cig}
-mkhal mdog mkhal ma'i mdog ste dmar smug mkhal nad grang ba|{mkhal grang dang don gcig}
+mkhal mdog|{mkhal ma'i mdog ste dmar smug}
+mkhal nad grang ba|{mkhal grang dang don gcig}
 mkhal nad brgyad|{lus brdabs 'grams shor ba dang rlan grang gi gnas su las mang byas pa sogs las byung ba'i mkhal nad brgyad de/ mkhal rlung dang/ mkhal gcong/ mkhal nad 'or lhung/ mkhal tshad/ mkhal nad chu shor/ mkhal 'grams/ mkhal grum/ mkhal nad da rgan bcas so/}
 mkhal nad chu shor|{mkhal nad rigs brgyad kyi nang tshan zhig ste/ mkhal rtsa mi bde zhing zag chu khrag tu 'byung ba'i nad cig}
 mkhal nad da rgan|{mkhal nad rigs brgyad kyi nang tshan zhig ste/ mkhal ma'i thad kyi sgal tshigs phyir 'bur por gyur te rgur por 'gyur ba'i nad cig}
@@ -5213,7 +5252,7 @@ mkhal nad 'or lhung|{mkhal rked na zhing lus la za 'phrug 'byung ba dang/ 'gro '
 mkhal 'bras|{dri chu sri zhing rked pa kha 'khor nas na ba sogs 'byung ba'i 'bras nad mkhal mar babs pa zhig}
 mkhal ma|{mi lus kyi byang khog smad kyi char sta zur g.yas g.yon gnyis kyi gong thad du gnas shing don lnga'i ya gyal zhig ste/ de'i byed las ni lus kyi chu khams kyi dwangs ma rnams lus la skyel zhing snyigs ma rnams rgyu grog rtsa'i brgyud lgang par skyel ba yin no/}
 mkhal ma zho sha|{shing sman gyi rigs shig ste/ 'bras bu mkhal dbyibs dang 'dra ba/ ro mngar la tsha ba/zhu rjes cung bsil/ nus pas mkhal gcong dang/ mkhal tshad sel/}
-mkhal ma'i rtsa nag sgal tshigs bcu bzhi pa'i thad nas g.yas g.yon du tshon gang re dang|{phun gang re gzhal ba'i gnas su yod pa'i mkhal rtsa/}
+mkhal ma'i rtsa nag|{sgal tshigs bcu bzhi pa'i thad nas g.yas g.yon du tshon gang re dang/ phun gang re gzhal ba'i gnas su yod pa'i mkhal rtsa/}
 mkhal ma'i rlung tshabs|{mo nad rlung tshabs rigs drug gi nang tshan tshabs nad mkhal mar byer ba zhig ste/ nad rtags su rked tshigs kha 'khor nas na zhing lhag par du grang na sdug tu 'gro ba zhig}
 mkhal ma'i gsang|{rgyab kyi sgal tshigs bcu bzhi pa mkhal ma dang 'brel ba'i me btsa'i gsang ste/ der me btsa' bzhag na mkhal ma'i grang ba la phan/}
 mkhal dmar la|{bod rang skyong ljongs kyi a mdo rdzong khongs su yod/}
@@ -5229,9 +5268,9 @@ mkhas grub dge legs dpal bzang|{pan chen er te ni'i sku phreng brgyud rim du 'dr
 mkhas grub rgya mtsho|{tA la'i bla ma sku phreng bcu gcig pa 'di rab byung bcu bzhi pa'i sa khyi lor khams mgar thar du 'khrungs/ chu stag lor gser bum dkrugs te tA la'i bla ma'i yang srid du ngos 'dzin gyis gser khri'i thog tu gdan 'dren zhus/ shing yos lor 'jam dbyangs gong ma zhan phung gi bka' 'brel rgyal srid chos srid bzhes/ lo de nyid du 'das/}
 mkhas grub rje|{mkhas grub dge legs dpal bzang dang don gcig}
 mkhas grub nor bzang rgya mtsho|{rtsis rig mkhas pa zhig des rab byung brgyad pa'i sa khyi lor rtsis gzhung dri med 'od rgyan mdzad/ rtse thang bsam gtan gling du thur grib brtags/}
-#mkhas mchog rab tu byang chub pa|
+mkhas mchog|{rab tu byang chub pa/}
 mkhas thal|{mkhas tshul thal ches pa/ mkhas thal shor bas mthar khungs ma 'khyol ba/}
-mkhas mdog mkhas pa min na'ang yin khul|{mkhas min mkhas mdog ston pa sngo lo 'phyar ba'i rgyu red/}
+mkhas mdog|{mkhas pa min na'ang yin khul/ mkhas min mkhas mdog ston pa sngo lo 'phyar ba'i rgyu red/}
 mkhas 'dod|{yon tan la mkhas par byed 'dod pa/ yon tan la mkhas 'dod kha sbyang tsam gyis blo skyed mi thon/}
 mkhas gnas|{(mngon) dgon pa/}
 mkhas pa|1. {(tha mi dad pa) rab tu shes pa'am legs par rtogs pa/ bod yig la mkhas pa/ lag rtsal la mkhas shing las ka byed rgyur yid gzhungs pa/ thabs la mkhas shing sgrub phod pa/ }2. 1) {shes rab can/ mkhas pa slob pa'i dus na sdug bde bar sdod la mkhas mi srid/ ming gi rnam grangs la kun rig dang/ kun shes/ go ba can/ grangs can/ grags pa thob/ nyes pa shes/ snyan ngag mkhan/ brtan po/ thos ldan/ dam pa/ dus yig can/ dran pa'i dbang/ rnam par dwangs/ rnam gsal/ pandi ta/ spyod ldan/ blo gros can/ blo ldan/ blo bzang/ mig can/ mdzangs pa/ rig ldan/ rig pa can/ rig pa'i dpa' bo/ ring du mthong/ shes ldan/ shes rab can/ sems shes/ gsal sgo bcas so/} 2) {(mngon) gza' lhag pa/ }3. {grims po'am grung po/ thabs shes mkhas pa/ lag pa mkhas pa/ shing bzo ba mkhas pa/ }4. {legs par lobs pa dang/ byang chub pa'am thub pa/ 'tsho ba skyel mkhas pa/ 'gro gron gtong mkhas pa/ ri mo 'bri mkhas pa/ za mkhas spyod mkhas/}
@@ -5279,8 +5318,7 @@ mkhyen mkhyen|{mkhyen par mdzod dam thugs rjes gzigs zhes re ba zhu ba'i tshig k
 mkhyen rgya|{shes rgya'am shes tshad/ mkhyen rgya can/}
 mkhyen lnga pa|{(mngon) sangs rgyas spyi/}
 mkhyen ldan|1) {shes rab can/} 2) {sangs rgyas shig gi mtshan/}
-mkhyen pa|1. {(tha mi dad pa) shes pa'am rtogs pa'i zhe sa/ thams cad mkhyen pa/ rnam pa thams cad mkhyen cing gzigs pa/ gnas lugs zhib cha mkhyen par mdzad du gsol/ rgyal pham ji yong gi gnad 'gag mkhyen par gsol/ }2. {shes rab/ mkhyen pa thogs pa mi mnga' ba/ mkhyen pa dang gzigs pa mtha' yas pa/ mkhyen pa yongs su dag pa/}
-#mkhyen pa'i klong du chub pa|
+mkhyen pa|1. {(tha mi dad pa) shes pa'am rtogs pa'i zhe sa/ thams cad mkhyen pa/ rnam pa thams cad mkhyen cing gzigs pa/ gnas lugs zhib cha mkhyen par mdzad du gsol/ rgyal pham ji yong gi gnad 'gag mkhyen par gsol/ }2. {shes rab/ mkhyen pa thogs pa mi mnga' ba/ mkhyen pa dang gzigs pa mtha' yas pa/ mkhyen pa yongs su dag pa/ mkhyen pa'i klong du chub pa/}
 mkhyen pa lnga|{ye shes lnga dang don gcig}
 mkhyen pa gnyis|{ji lta ba mkhyen pa dang/ ji snyed pa mkhyen pa gnyis so/}
 mkhyen pa bzhi|{khams mkhyen pa dang/ rang bzhin mkhyen pa/ bsam pa mkhyen pa/ bag la nyal mkhyen pa bcas bzhi'o/}
@@ -5303,7 +5341,8 @@ mkhrang ba|1. {sra la mkhregs pa/ }2. {mkhrang po dang 'dra/}
 mkhrig dkar|{rta dre'u sogs rkang lag gi mkhrig ma man chad spu mdog dkar po can/}
 mkhrig ma|{lag mgo dang lag ngar gnyis kyi bar du 'brel ba'i tshigs/ lag rtsar lta dus sman pa'i mdzub mos nad pa'i mkhrig ma gnon pa/}
 mkhris skran|{snod kyi mkhris thum nang chags pa'i skran nad cig}
-mkhris khrag nad kyi bye brag cig mkhris glang|{mkhris pa glang 'thab kyi nad/}
+mkhris khrag|{nad kyi bye brag cig}
+mkhris glang|{mkhris pa glang 'thab kyi nad/}
 mkhris chen bzhi|{mi'i mkhris pa dang/ dom gyi mkhris pa/ bya rgod kyi mkhris pa/ nya'i mkhris pa bcas te bzhi'o/}
 mkhris nad|{mkhris pa'i nad kyi bsdus tshig}
 mkhris pa|1) {nyes pa'i mkhris pa ste lus kyi drod khams kyi cha shas yongs/} 2) {snod kyi mkhris pa ste mchin 'dabs kyi mkhris thum/}
@@ -5312,7 +5351,7 @@ mkhris pa lnga|{lus kyi rtsa ba'i mkhris pa lnga ste/ mkhris pa 'ju byed dang/ m
 mkhris pa can|{spro thung ba'i mi/}
 mkhris pa thang las lhag pa|{me drod mkhris pa rang gi ldang tshad/ skyes pa'i gsang sgro gang dang/ bud med la dngos bstan ma gsungs na'ang shud bstan de ltar go dgos pas de las lhag par gyur pa'i don/}
 mkhris pa mig ser|{snod mkhris kha lud de rtsa mig tu byer nas mig sprin ser por 'gyur ba zhig}
-mkhris pa rtsa rgyug rims nad mkhris par babs pa dang|{zas spyod sogs rkyen gzhan gyis snod mkhris rtsar brgyugs nas bzhin mig pags pa rnams ser por 'gyur ba'i nad cig}
+mkhris pa rtsa rgyug|{rims nad mkhris par babs pa dang/ zas spyod sogs rkyen gzhan gyis snod mkhris rtsar brgyugs nas bzhin mig pags pa rnams ser por 'gyur ba'i nad cig}
 mkhris pa sha ser|{snod mkhris kha lud de rtsa mig tu byer nas sha mdog ser por 'gyur ba zhig}
 mkhris pa gsha' ring|{ru thung zur nas mar lag ngar rgyab ngos nas thur du 'gro ba'i rtsa dang po snod mkhris dang 'brel ba'i gtar rtsa zhig ste/ de gtar na mkhris nad yun lon dang/ mkhris rims mgo nad sogs la phan/}
 mkhris pa'i nad|{lus kyi drod khams rgyas pa'i tsha ba'i nad la nyes pa'i mkhris pa dang/ mchin 'dabs mkhris thum skyon du gyur pa'i mkhris pa gnyis/}
@@ -5321,17 +5360,18 @@ mkhris tshabs|{mngal nad cig}
 mkhris zad|{mkhris pa'i ldang tshad gsang sgro gang yin pas de'i cha shas zad par gyur nas/ lus drod nyams shing/ pags mdog nag por 'gyur ba'i nad cig}
 mkhris rims|{rims nad mkhris pa la babs pa'i nad de/ mgo na ba dang/ tsha ba rgyas pa/ gshang gci pags mig rnams ser por 'gyur ba zhig}
 mkhris gsang|{rgyab kyi sgal tshigs gnyis pa dang bcu pa mkhris pa dang 'brel ba'i me btsa'i gsang ste/ de la me btsa' bzhag na mkhris pa grang mkhris la phan/}
-mkhregs 'dred 'bol zug gyong po dang thug na 'jigs nas g.yol|{mnyen po dang phrad na brnyas bcos byed pa'i dpe/ gang ltar btsan rgyal ring lugs pa mkhregs 'dred 'bol zug gi spyod ngan byed mkhan zhig red/}
+mkhregs 'dred 'bol zug|{gyong po dang thug na 'jigs nas g.yol/ mnyen po dang phrad na brnyas bcos byed pa'i dpe/ gang ltar btsan rgyal ring lugs pa mkhregs 'dred 'bol zug gi spyod ngan byed mkhan zhig red/}
 mkhregs pa|{mkhregs po dang 'dra/}
 mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mkhar mkhregs po/ klad rnying mkhregs po/}
 'khang skad|{khros pa dang/ sdang ba'i skad cha/}
 'khang sgra|{sdang tshig smra ba'i sgra/}
 'khang ba|{(tha mi dad pa) 'khangs pa/ 'khang ba/ /mi dga' ba dang/ sdang ba dang/ khros pa/ rang gis ma byung bar gzhan la 'khang ba/ rang nyid mun khang du bsdad nas nyi ma'i 'od la 'khang ba/ re 'khang byed pa/}
-'khang tshig ma rangs pa'am ma mgu ba'i tshig 'khang ra|{khros pa'i nyams dang/ ma 'dod pa'i rnam 'gyur/}
+'khang tshig|{ma rangs pa'am ma mgu ba'i tshig}
+'khang ra|{khros pa'i nyams dang/ ma 'dod pa'i rnam 'gyur/}
 'khangs pa|{'khang ba'i 'das pa/}
 'khan pa|{mkhan pa'i 'bri tshul gzhan zhig}
 'khams pa|{(tha mi dad pa) dran med du brgyal ba/ glo bur 'jigs nas 'khams pa/}
-#'khar rgyug lag rten dbyug pa|
+'khar rgyug|{lag rten dbyug pa/}
 'khar rnga|{'khar ba las bzos pa'i rol mo'i bye brag cig rnga dang 'khar rnga rdung ba/}
 'khar rnge'u|{'khar rnga chung chung/}
 'khar chu|{'khar ba zhun ma/}
@@ -5340,18 +5380,18 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khar ba|1. {(tha mi dad pa) thogs pa/ gyon pa lcags gzer la 'khar ba/ zas mid par 'khar ba/ }2. 1) {dbyug pa/ sba 'khar/ phyag 'khar/ lag na 'khar ba thogs pa/ lus 'khar ba la brten nas langs dgos pa/} 2) {li ste/ zangs gtso bor byas pa'i lcags rid 'dres ma zhig ming gi rnam grangs la zangs skyes dang bsil skyes so/}
 'khar ba om btsugs|{'khar ba'i rtse mor lag gnyis brtsegs pa'i steng du og ma bzhag pa/}
 'khar ba'i me long|{li las bzos pa'i me long/}
-#'khar dbyug lag 'khar|
+'khar dbyug|{lag 'khar/}
 'khar gzhong|{li las bzos pa'i gzhong pa/}
 'khar zangs|1) {li las bzos pa'i chu blug snod/} 2) {'khar ba dang zangs/}
 'khar bzo ba|{li'i yo byad bzo mkhan/}
 'khar gsil|{(}<{khakkhir}:>{) ? rab byung la gnod 'tshe bsrung ba'i phyir du ston pas gnang ba'i sil snyan bcu gnyis dang ldan pa'i 'khar ba ste/ rgyu lcags dang shing gnyis las grub pa ste/ rim pa gsum breng chags su yod pa'i stod smad gnyis lcags dang bar ma shing yin la/ stod smad kyi lcags brgyad bzhog byas shing/ 'og ma la rgya mdud yod pa/ dum bu steng ma la 'khor lo dang lcags kyu yod cing/ rwa bzhi'am/ gnyis su nges pa/ de la sil snyan bcu gnyis/ steng dang nang la mchod rten yod pa/ rwa'i bar stong pa/ rwa'i dpang mtho gang sor bzhi dang rwa man chad lus tshad dang mnyam pa'o/}
 'khar gsil gsil ba|{dge slong gi yo byad 'khar gsil dkrol ba/}
 'khal 'khol|{'khal le 'khol le'i bsdus tshig}
-#'khal 'thag rgyu spun 'khal zhing ras snam sod 'thag pa|
+'khal 'thag|{rgyu spun 'khal zhing ras snam sod 'thag pa/}
 'khal ba|{(tha dad pa) bkal ba/ bkal ba/ 'khol// skud pa sgrim pa'am bzo ba/ skud pa bkal te thad btags pa/ bal 'khal ba/}
 'khal le 'khol le|{sems rab tu dga' ba'am bya ba zhig byed 'dod nas tshugs dka' ba lta bu'i rnam pa/ khyed mjal 'dod nas nga'i sems 'khal le 'khol le byed kyi 'dug}
-#'khu ldog mi dga' ba'am phrag dog the'u rang lhar bsten na 'khu ldog cho 'phrul je cher 'gro|
-'khu 'phrig dogs pa'am rnam rtog bshan pa 'khris su slebs pa mthong yang|{bshas lug la rang nyid da lta gsod do snyam pa'i 'khu 'phrig gi 'du shes med/}
+'khu ldog|{mi dga' ba'am phrag dog  the'u rang lhar bsten na 'khu ldog cho 'phrul je cher 'gro/}
+'khu 'phrig|{dogs pa'am rnam rtog bshan pa 'khris su slebs pa mthong yang/ bshas lug la rang nyid da lta gsod do snyam pa'i 'khu 'phrig gi 'du shes med/}
 'khu ba|1. {(tha mi dad pa)} 1) {sdang ba dang 'tshe ba dang/ snying ring ba dang rgol ba/ dgra la 'khu ba/ mes rgyal la 'khu ba/} 2) {(rnying) ldog pa/ }2. {ser sna/}
 'khu bsam|1) {sdang ba'i bsam pa/} 2) {log lta/}
 'khugs pa|{khug pa'i da lta ba'i 'bri tshul gzhan zhig}
@@ -5360,7 +5400,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khum pa|{(tha mi dad pa) 'khums pa/ 'khum pa//} 1) {tshur 'dus pa'am zhum pa/ lus 'khum pa/ ngag 'khum pa/ yid 'khum pa/ dpa' 'khums pa/ 'gran bsdur byed skabs 'khum tshul rtsa ba nas ma ston/ ko ba ma brgyangs par 'khum pa/} 2) {shes pa'am rtogs pa/ sems kyis 'khums pa/ bshad tshul de nga'i sems la 'khums kyang yid brtan mi byed/}
 'khums pa|{'khum pa'i 'das pa/}
 'khur gor|{'bru rigs kyi phye brdzis nas bsred pa dang btsos pa'i zas dbyibs sgor mo zhig a mdo'i skad du go re zer/}
-#'khur thag 'khyer byed dam sdom byed kyi thag pa|
+'khur thag|{'khyer byed dam sdom byed kyi thag pa/}
 'khur ba|1. {(tha dad pa) khur ba/ 'khur ba/ khur// 'khyer ba/ las 'gan khur ba/ khres po rgyab tu khur ba/ }2. {bag zan zhig ste yul 'gar go re zer/}
 'khur shed|{theg shugs/ bong bu las g.yag 'khur shed che/}
 'khur bsam|{'gan 'khur legs sgrub kyi bsam pa/}
@@ -5386,7 +5426,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khon pa bsdum pa'i gso sbyong|{mthun pa'i gso sbyong las dus ma nges pa'i gso sbyong gi gras shig ste/ dge 'dun dbye ba bsdum pa zhes rtsod pa zhi bar bya ba'i phyir gso sbyong byed pa'o/ de la rtsod pa bzlog pa'i gso sbyong zhes kyang zer/}
 'khon 'bar|{'khon nad cher langs pa/ 'gal zla phan tshun 'khon 'bar gyi 'khrug gzhi ha cang che ba/}
 'khon med dbyen med|{phan tshun zhe 'gras pa dang/ dam sel gang yang med pa/ grong pa khyim mtshes 'khon med dbyen med dam gtsang bkra shis lugs legs sha stag red/}
-#'khon tshig sngar 'khon zhe 'dzin gyi gtam|
+'khon tshig|{sngar 'khon zhe 'dzin gyi gtam/}
 'khon 'dzin|1) {'khon du 'dzin pa ste/ sngar byung gnod 'tshe rnams sems kyi gting du 'jog pa/} 2) {nye nyon nyi shu'i nang gses shig ste/ khong khro ba'i char gtod pa gnod pa'i bsam pa rgyun mi gtong zhing mi bzod par byed pa zhig 'khon 'dzin zhe nad/gzhan gnod dam por 'dzin pa'i gting nad/}
 'khon zhugs|{sdang sems chags pa/}
 'khon bzod|{khro ba'am sdang sems bzod thub pa/}
@@ -5404,7 +5444,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khor kha|1) {rgya tshad dam zheng/} 2) {rang gnas su slebs kha/}
 'khor khyams|{khang pa'i nye skor gyi phyi khyams/}
 'khor rgya|{rgya khyon/}
-'khor sgyur gyi 'khor lo'i khyad chos drug myur du 'gro ba dang|{gzhan du 'gro ba/ ma rgyal ba las rgyal bar byed pa/ rgyal ba rnal du 'god pa/ mtho ba la 'phar ba/ dma' ba la 'bab pa/}
+'khor sgyur gyi 'khor lo'i khyad chos drug|{myur du 'gro ba dang/ gzhan du 'gro ba/ ma rgyal ba las rgyal bar byed pa/ rgyal ba rnal du 'god pa/ mtho ba la 'phar ba/ dma' ba la 'bab pa/}
 'khor sgyur gyi nye ba'i rin chen bdun|{ral gri rin po che dang/ pags pa rin po che/ khyim rin po che/ tshal rin po che/ gos rin po che/ lham rin po che/ mal cha rin po che ste bdun/}
 'khor sgyur lnga|{'khor los sgyur ba'i rgyal po lnga ste/ nga las nu dang/ mdzes pa/ nye mdzes/ mdzes ldan/ nye mdzes ldan te lnga/}
 'khor lnga sde bzang po|{ston pa shAkya thub pas gnas wa ra Na sir dus chu stod zla ba'i tshes bzhi nas brtsams te/ chos bden pa bzhi'i 'khor lo bskor ba na/ thog mar ye shes khong chud kyis bsnyen par rdzogs nas dgra bcom thob pa'i 'khor lnga ste/ kun shes koondi n.ya dang/ rta thul/ rlangs pa/ ming chen/ bzang ldan rnams so/}
@@ -5450,16 +5490,17 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khor ma|{snye ma rdung byed shing lcug bstar ba 'khor mig can/}
 'khor mo|{khol mo ste g.yog mo/}
 'khor 'tshem|{'khor lo'i 'tshem bu/}
-'khor zhag gnas skabs kyi dgongs zhu|{kho las khungs nas 'khor zhag zhus te phyin song/}
+'khor zhag|{gnas skabs kyi dgongs zhu/ kho las khungs nas 'khor zhag zhus te phyin song/}
 'khor bzhi|{dge slong pha ma gnyis dang/ dge bsnyen pha ma gnyis te bzhi/}
-#'khor zug khor zug dang 'dra|
+'khor zug|{khor zug dang 'dra/}
 'khor zlum|{gnyen 'khor 'khor pa rnams mthun thabs byed pa/}
-#'khor yug khor yug dang 'dra|
+'khor yug|{khor yug dang 'dra/}
 'khor yun|{skor ba thengs gcig 'khor ba'i dus yun/}
 'khor yul|{(rnying) yul mi dang 'khor g.yog}
-#'khor g.yag sgo sge'u khung gi 'khor gtan g.yag shing|
+'khor g.yag|{sgo sge'u khung gi 'khor gtan g.yag shing/}
 'khor g.yab|{khang pa'i mdun phyogs 'khor mor bskor ba'i g.yab/}
-'khor g.yog gnyen grogs dang bran g.yog 'khor res|{re mos/}
+'khor g.yog|{gnyen grogs dang bran g.yog}
+'khor res|{re mos/}
 'khor ro ro|{sgor 'khyil 'khyil/ mi mang po 'khor ro ror 'khrab kyin 'dug}
 'khor langs pa|{gnag phyugs mo rigs kyi chags sems langs pa/}
 'khor lo|1) {skor ba 'khor thub pa'i 'phrul chas sgor dbyibs can/ gser gyi 'khor lo/ chu 'khor/ me 'khor/} 2) {'phrul 'khor/ tshem bu'i 'khor lo/ chu tshod 'khor lo/} 3) {shing rta/ 'khor lo bkag pa/ lam byang la bzhag nas 'khor lo lho la gtong ba/} 4) {gsang sngags rdo rje theg pa'i yi dam lha'i phyag mtshan zhig ste/ dbyibs 'khor lo lta bu/ rtsib rim gyi kha phyir gdangs shing mu khyud med pa/ rtse mo mchog tu rno zhing rdo rje'i yu ba can zhig} 5) {gza' skar sogs so so'i sde'am khongs kyi grangs 'bor te/ gza' dang byed pa'i 'khor lo bdun/ skar sbyor gnyis ni nyer bdun te/ chu tshod chu srang drug cu la/ dbugs drug cha shas mang nyung dang/ gnas la nges pa med pa yin/ rang rang 'khor lo gang longs pa/ phud pa'i nor de gong mar bsre/ zhes pa ltar ro/} 6) {(mngon) rgyu skar gyi go la'i 'khor lo la nyer bdun yod pas grangs nyer bdun mtshon/}
@@ -5467,7 +5508,8 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khor lo can|{(mngon)} 1) {sbrul/} 2) {ngur pa/}
 'khor lo chen po bzhi|{mthun par gyur pa'i yul na gnas pa dang/ skyes bu dam pa la brten pa/ smon lam btab pa/ bsod nams bsags pa bcas bzhi'o/}
 'khor lo chen po'i rdzogs rim byin rlabs bzhi|{lus byin rlabs dang/ ngag byin rlabs/ yid byin rlabs/ de kho na nyid kyi byin rlabs bcas bzhi'o/}
-'khor lo bde mchog yi dam gyi lha zhig 'khor lo sdom pa|{bde mchog}
+'khor lo bde mchog|{yi dam gyi lha zhig}
+'khor lo sdom pa|{bde mchog}
 'khor lo rnam gsum|1) {klog pa thos bsam gyi 'khor lo dang/ spong ba bsam gtan gyi 'khor lo/ bya ba las kyi 'khor lo bcas gsum mo/} 2) {chos kyi 'khor lo rim pa gsum dang don gcig}
 'khor lo snon dang ma snon|{gza' rnams kyi nyi bar las skyes skar sbyangs tshe ma 'dang na 'khor lo 27 snon dgos/ 'dang na snon mi dgos/}
 'khor lo byed|{(mngon) mtshan mo/}
@@ -5497,7 +5539,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khor sems byung|{gtso sems las byung zhing sems kyi 'khor du gtogs pa'am rjes su 'gro ba'i yid shes/}
 'khor gsum|1) {mtshon cha mda' gri mdung gsum/ sked par 'khor gsum btags nas g.yul sar chas/} 2) {'khor lo gsum/ 'khor gsum rkang 'khor/} 3) {byed pa po dang/ bya ba'i las/ bya ba'i yul te gsum/ sbyin pa gtong skabs kyi 'khor gsum ni sbyin pa po dang/ sbyin rdzas/ sbyin yul te gsum/} 4) {mtshan nyid rtsod skabs kyi 'khor gsum ste rtags bsal khyab gsum/} 5) {lus ngag yid kyi las gsum/}
 'khor gsum khebs pa'i tshad|{'dul ba'i brda chad cig ste/ gos kyi rgyu lte ba'i 'khor lo dang pus mo gnyis kyi 'khor lo khebs thub pa'i tshad du longs pa'o/}
-'khor gsum rnam dag sa bdun pa'i yongs sbyong skabs las su bya ba dang|{byed pa po/ bya ba'i rang bzhin te 'khor gsum la mi dmigs pa'i rgyas btab pa/}
+'khor gsum rnam dag|{sa bdun pa'i yongs sbyong skabs las su bya ba dang/ byed pa po/ bya ba'i rang bzhin te 'khor gsum la mi dmigs pa'i rgyas btab pa/}
 'khor gsum rnam par mi rtog pa|{chos kun la dngos po dang byed po bya yul gsum la 'dzin pa'i rtog pa dang bral ba ste/ dper na sbyin pa gtong ba po dang/ gtang rgyu'i rgyu nor/ gtong yul slong ba po bcas phyogs gsum ga rang bzhin du ma grub par shes pa'i shes rab bo/}
 'khor lha|{yi dam lha'i 'khor/}
 'khol|{'khal ba'i skul tshig}
@@ -5509,11 +5551,11 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khos lcogs|{'khos kas lcogs tshod/ phyi nang gang sar 'khos lcogs kyi las kar 'bad 'bungs zhu mus red/}
 'khos bstun|{nus stobs dang bstun pa/ kho rang 'khos bstun gyi las ka gang shes gang lcogs lag len byed sgang red/}
 'khos pa|{(rnying) chud mi za ba/}
-'khos dpag nus stobs la gzhigs pa|{so so'i 'khos dpag gi las 'gan 'khur rgyu/}
+'khos dpag|{nus stobs la gzhigs pa/ so so'i 'khos dpag gi las 'gan 'khur rgyu/}
 'khos phebs pa|{(rnying) chud mi za ba/}
 'khos bab|{stobs nus kyi rang bzhin nam tshul/ rang gi 'khos bab dang mtshungs pa'i las khur len bzhin du yod/}
 'khos su phab pa|{(rnying) rang gnas su 'jog pa'am logs su 'jog pa/}
-#'khyag 'khyog kyag kyog 'khyag 'khyog gi lam 'dzeg rgyur ma skrag na yang rtser slebs thub|
+'khyag 'khyog|{kyag kyog  'khyag 'khyog gi lam 'dzeg rgyur ma skrag na yang rtser slebs thub/}
 'khyag grang|{grang ngad/}
 'khyag chen gangs rud|{shwa lam zhig bod rang skyong ljongs kyi spo mes rdzong khongs su yod/}
 'khyag dus|1) {grang ba'i skabs/} 2) {(mngon) dgun kha'i ming/}
@@ -5532,7 +5574,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyags nad|{lus 'khyags pa'i nad/}
 'khyags pa|1. {'khyag pa'i 'das pa/ }2.{chab rom/ 'khyags sob/ gtsang por 'khyags pa brgyab pa'i steng du mi phyugs phar tshur 'gro thub/ 'khyags pa zhu nas dpyid dpal rgyas/ 'khyags pa sil sil chags pa'i chu 'bogs pa/}
 'khyags spris|{'o ma bskol ba sogs grang nas chags pa'i kha spris/ 'o ma'i 'khyags spris/ sha khu'i 'khyags spris/}
-#'khyags bag chu sogs la chags pa'i 'khyags pa'am dar|
+'khyags bag|{chu sogs la chags pa'i 'khyags pa'am dar/}
 'khyags 'bur|{grang ngad kyis thon pa'i thor pa sib sib cig}
 'khyags 'brum|{'khyags te skyes pa'i 'brum bu lta bu/}
 'khyags sbos|{grang drags nas gzugs dang rma sogs la byung ba'i skrang sbos/}
@@ -5557,7 +5599,8 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyar bon|{thog mar kha che dang/ bru sha/ zhang zhung sogs su dar zhing/ de nas gri gum btsan po'i rjes su bod phyogs la mched pa'i bon zhig}
 'khyal pa|{don med pa dang/ 'brel ba med pa/ ngag 'khyal/ don med gtam 'khyal/}
 'khyal ba|{(tha mi dad pa) 'chal ba'am yan pa/ spyod tshul ngan par 'khyal ba/ dran shes yan por 'khyal ba/}
-'khyal tshig don med ngag kyal gyi tshig 'khyig pa|{(tha dad pa) bkyigs pa/ bkyig pa/ khyigs// 'ching ba/ rkang lag bkyigs pa/}
+'khyal tshig|{don med ngag kyal gyi tshig}
+'khyig pa|{(tha dad pa) bkyigs pa/ bkyig pa/ khyigs// 'ching ba/ rkang lag bkyigs pa/}
 'khyims|{'od skor te nyi 'od dam zla 'od sprin rim la phog tshe tshur ldog nas 'phros pa'i 'od skor/ nyi 'khyims/ zla 'khyims/ 'ja'i 'od 'khyims/}
 'khyims pa|{(rnying) skor ba/ 'od kyis mtha' nas 'khyims/}
 'khyir ba|{(tha mi dad pa) 'khor ba/ gdugs 'khyir ba/ klad pa gzi yom 'khyir ba/ 'khyil chu/} 1) {rdzing chu dang/ ko mog gi chu/ 'khyil chu yur bar 'dren/} 2) {bod rang skyong ljongs kyi 'bri ru rdzong gi lho rgyud kyi 'bab chu zhig yin zhing/ de'i chu 'go gnyan chen thang lha'i ri rgyud kyi byang ngos nas byung ste dpal 'bar rdzong khongs sa steng gi nye 'dabs su rgyal mo rngul chu'i nang du 'bab/}
@@ -5565,7 +5608,8 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyil pa logs rings|{(mngon) sbrul/}
 'khyil ba|1. {(tha mi dad pa)} 1) {'du ba/ 'od du 'khyil ba/ rdzing bu'i nang du chu 'khyil 'dug} 2) {'khyil ler 'khor ba/ sgor mor 'khyil nas nyal ba/ dung dkar g.yas 'khyil/ sbrul 'khyil ba/ }2. {lus kyi rtsa'i bye brag cig}
 'khyil rlung|{'khor nas ldang ba'i rlung 'tshub/}
-'khyug 'khyug yig gi bsdus tshig 'khyug 'khyug myur po'am mgyogs po'i rnam 'gyur|{chu la nya mo bde 'khyug 'khyug tu 'gro/}
+'khyug|{'khyug yig gi bsdus tshig}
+'khyug 'khyug|{myur po'am mgyogs po'i rnam 'gyur/ chu la nya mo bde 'khyug 'khyug tu 'gro/}
 'khyug chen|{bod yig ha cang 'khyug po/}
 'khyug bde|{lus mnyen pa'am lus rtsal che ba/}
 'khyug ldem|{lus bde zhing ldem pa/}
@@ -5574,9 +5618,9 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyug ma tshugs|{bod yig dbu med tshugs thung chung ba/}
 'khyug tsam|{khyug tsam dang 'dra/}
 'khyug gzhas|{zhabs bro shin tu mgyogs la gzhas kyang shin tu mgyogs pa'i glu gar gnyis kyi rnam pa zhig}
-#'khyug yig bod yig dbu med 'bri tshul mgyogs shos kyi yig gzugs|
+'khyug yig|{bod yig dbu med 'bri tshul mgyogs shos kyi yig gzugs/}
 'khyugs pa|{'khyug pa'i 'das pa/}
-'khyugs se 'khyug bde myur du 'khyug pa|{mun pa'i smag rum khrod du glog dmar 'khyugs se 'khyug}
+'khyugs se 'khyug|{bde myur du 'khyug pa/ mun pa'i smag rum khrod du glog dmar 'khyugs se 'khyug}
 'khyud 'tham|1) {mdza' bshes dga' sdug ches pa'i rnam 'gyur/} 2) {'khrig spyod/}
 'khyud 'thung|{(mngon) skyes ma thag pa dang nu zho 'thung mkhan phru gu/}
 'khyud nas ldang ba'i ma ning|{ma ning gi byed brag cig}
@@ -5591,7 +5635,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyer dman|{'khos zhan te dpal 'byor gyis dbul ba'i mi/ dpal 'byor 'khyer dman/ mi ser 'khyer dman/}
 'khyer zhan|{'khyer dman dang don gcig}
 'khyer so|1) {sems kyi bsam stangs sam dran stangs/ bsam pa'i 'khyer so rnam par dag pa/ sems kyi 'khyer so ngan pa/} 2) {rnam 'gyur/ lus kyi 'khyer so mdzes pa/}
-#'khyog 'khyog kyog kyog zam shing 'khyog 'khyog btang na zam sked ldem ldem zhig las mi yong|
+'khyog 'khyog|{kyog kyog  zam shing 'khyog 'khyog btang na zam sked ldem ldem zhig las mi yong/}
 'khyog ge ba|{kyog ge ba'am drang po min pa/ thig shing 'khyog ge bas thig btab na drang po mi yong/}
 'khyog bgrod|{kyog 'gro'am bskor nas skyod pa/}
 'khyog 'gro|{(mngon)} 1) {'bab chu/} 2) {sbrul/} 3) {me/} 4) {gza' spen pa/}
@@ -5604,7 +5648,8 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khyog po'i mchu can|{(mngon) ne tsho/}
 'khyog 'phye ba|{(mngon) sbrul/}
 'khyog 'bar|{(mngon) me/}
-'khyog tshig gtam drang po min pa'am kyog kyog 'khyog yon|{drang po min pa/}
+'khyog tshig|{gtam drang po min pa'am kyog kyog}
+'khyog yon|{drang po min pa/}
 'khyog bshad|{gtam kyog por bshad pa/ 'phros gtam 'khyog bshad byas nas gzhan la mgo skor btang ba/ dngos yod gnas lugs la 'khyog bshad ched du byed pa/ 'khyog bshad ched byed kyis mi kha 'gog thabs byed pa/}
 'khyogs pa|{'khyog pa'i 'das pa/}
 'khyong ba|{(tha mi dad pa) 'khyongs pa/ 'khyong ba// mu mthud pa'am 'khyol ba/ chu tshod gcig kyang rgyun 'khyong thub pa mi 'dug nyin 'khyong thub tsam byung/ las ka mthar 'khyongs song/}
@@ -5648,15 +5693,15 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khrid pa|{(tha dad pa) khrid pa/ 'khrid pa/ khrid//} 1) {sna 'dren pa/ yur chu 'khrid pa/ rta tshur khrid shog las sar 'khrid pa/ phru gu khrid nas phyin song/ char sne rlung 'khrid/ mgo skor btang nas khrid pa/ bu khrid/} 2) {slob ston pa/ dpe cha 'khrid pa/ sman rig 'khrid pa/ slob phrug 'khrid pa/ lam bzang gi thog tu khrid/ 'go khrid pa/ 'khrims pa/ byer ba dang/ zhed pa/ skrag pa/}
 'khril ldem|{mchor sgeg dang ldan pa'i lus kyi rnam 'gyur zhig sgeg mo 'khril ldem can/}
 'khril ba|{(tha mi dad pa) 'khyud pa/ shing tsan dan la sbrul 'khril ba/ gos mtha' rkang par 'khril ba/}
-#'khril bag 'tshams shing sgeg pa'i nyams|
+'khril bag|{'tshams shing sgeg pa'i nyams/}
 'khril bag chags pa|{mnyen zhing bab chags pa/ rgyan gos gang bzhes sku gzugs la 'khril bag chags pa/}
 'khril shing|{gzhan la 'khril te skye ba'i shing/}
 'khris|{nye 'gram/ gang pa'i 'khris su yod/}
 'khris pa|{'khri ba'i 'das pa/}
-#'khru skyug mar bshal ba dang yar skyug pa|
+'khru skyug|{mar bshal ba dang yar skyug pa/}
 'khru nad|{pho ba'i me drod zhan pas kha zas ma zhu ba dang/ mkhris pa snod lhung sogs kyis thur du bshal ba'i nad/ khog pa 'khru nad 'khrus pa/}
 'khru ba|1. {(tha mi dad pa) 'khrus pa/ 'khru ba// bshal ba/ grod khog 'khru ba/ }2. {bshal ba'i nad/ sman btungs te 'khru ba gcod thabs byed pa/ 'khru ba 'byams pa/}
-#'khru bag grod khog bshal ba'i nad|
+'khru bag|{grod khog bshal ba'i nad/}
 'khru sbyong|{grod khog bshal thabs byed pa/}
 'khru gzhi|{grod khog bshal ba'i nad gzhi/}
 'khrug rkyen|{zing 'khrug gi rgyu rkyen/ sngar yod mi mthun pa'i khar 'khrug rkyen gsar du slong ba/}
@@ -5676,7 +5721,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khrugs pa sdeb pa'i bstan bcos|{sde snod khag tu kha thor ba'i gzhung don rnams btus nas gcig tu bsdoms pa'i rtsom yig ste mdo sde rgyan nam bslab btus lta bu'o/}
 'khrugs tshad|{tsha ba sogs kyis gzugs po'i khams 'khrugs pa'i rims tshad/}
 'khrugs 'dzings|{go rim 'dzings pa/ bya rim 'khrugs 'dzings byung na las ka yag po 'grub mi thub/}
-#'khrung brtag skye brtag gi zhe sa|
+'khrung brtag|{skye brtag gi zhe sa/}
 'khrung ba|{(tha mi dad pa) 'khrungs pa/ 'khrung ba// skye ba'i zhe sa/ sku 'khrungs nas lo brgya dang lnga bcu tsam song/ thugs la rnam rtog 'khrungs pa/}
 'khrungs skar|{skye dus kyi tshes grangs gang yin la 'khel ba'i skar ma/}
 'khrungs pa|{'khrung ba'i 'das pa/}
@@ -5689,7 +5734,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khrud rdzas|{'khrud byed dam 'dag byed kyi rdzas/}
 'khrun|{dbye ba'am thag bden rdzun gang yin 'khrun gtsang mar 'byed pa/}
 'khrun chod|{dbye ba'am thag chod pa/ phyogs gnyis kyi rtsod pa 'khrun chod byung ba/}
-'khrun thag rtsod gleng sogs kyi mtshams|{lo rgyus thog gi 'khrun thag ma bcad pa rnams gcod par byed pa/ bzang ngan dbye ba'i 'khrun thag bcad pa/}
+'khrun thag|{rtsod gleng sogs kyi mtshams/ lo rgyus thog gi 'khrun thag ma bcad pa rnams gcod par byed pa/ bzang ngan dbye ba'i 'khrun thag bcad pa/}
 'khrul skyon|{nor 'khrul gyi nyes skyon/}
 'khrul 'khor khyim|{(mngon) khrims ra/}
 'khrul rgyu|{'khrul shes skyed byed kyi rgyu'am rkyen te/ bdag med bdag tu 'dzin pa sogs chos kyi tshul ci bzhin mi shes pa'i rmongs pa phugs kyi 'khrul rgyu dang/ dbang po bslad pa sogs 'phral gyi 'khrul rgyu rnams so/}
@@ -5734,13 +5779,13 @@ ga 'dra|{gang 'dra'am/ ci 'dra/ thon rdzas spus ka ga 'dra 'dug}
 ga sdum|{ga kha bsum dang don gcig}
 ga na ba|{ga la ba dang 'dra/}
 ga na tshad|{sngar dngos su bgrangs pa de las lhag pa da dung bgrang rgyu yod pa/ da dung de yis ga na tshad/}
-ga na pa ti|{(legs) tshogs kyi bdag po/}
+ga Na pa ti|{(legs) tshogs kyi bdag po/}
 ga nas ga nas|{(yul)} 1) {khengs skyung gi tshig ga nas ga nas dpe srid pas/} 2) {yong bzo med pa'i tshig de 'dra ga nas ga nas/ khos shes kyi ma red/}
 ga pa ga pa|{(yul) gnas sam/ yul ma nges pa'i gnas tshul dri tshig khyod kyis slob gnyer byed par ga pa ga par phyin pa yin/}
 ga pur|{ga bur dang 'dra/}
 ga pur dbang|{(mngon) zla ba/}
 ga pur 'dzin|{(mngon) zla ba/}
-ga phyi ga log phyin ci log pa|{skad cha bden rdzun ga phyi ga log shod pa/ las ka dkar nag ga phyi ga log byed pa/}
+ga phyi ga log|{phyin ci log pa/ skad cha bden rdzun ga phyi ga log shod pa/ las ka dkar nag ga phyi ga log byed pa/}
 ga phyi log pa|{phyin ci log pa/}
 ga bu thud gsob|{pha ba dgo dgo'i ming gi rnam grangs/}
 ga bur|{(legs) lus rgyas sam rab bsil te rtsi sman gyi rigs shig ro bska la tsha/ zhu rjes shin tu bsil/ nus pas rgyas tshad gsod/ rnying tshad sel/ ming gi rnam grangs la kha ba'i phye ma dang/ kha ba'i ming can/ rdul gyi snying po/ nus ldan/ sprin gyi snying po/ zla ba seng ge'i 'o ma/ zla ba'i thal ba/ zla ba'i ming can/ 'od dkar can/ ro'i ge sar/ shing gi snying po bcas so/}
@@ -5775,10 +5820,11 @@ ga shes|{(rnying) kha rdung btang ba'am/ kha zer ba/}
 ga sa|{sa phyogs nges med kun/ sa phyogs ga sa ga la dril bsgrags byed du phyin/ ga slog phyin ci slog pa/ las ka byed stangs ga slog tu gyur na don mi 'grub/}
 gag|{(rnying)} 1) {'bod pa'i sgra zhig} 2) {spyi sgra gang/}
 gag ge gog ge|1) {las su mi rung ba'am/ lus zor lci ba/ gag ge gog ge'i lus de 'gro mi bde/} 2) {gog ste 'gro ba byis pa'i 'gro tshul/ byis pa chung chung de gag ge gog ge byas nas thag ring du phyin song/}
-gag gog gag ge gog ge'i bsdus tshig gag pa|1) {gnyan nad lce'i steng du babs nas lce skrangs shing skad 'gag pa zhig ste/ nang gses su dbye na pho gag dang/ mo gag bu gag gnyan gag bcas rigs bzhi mchis/} 2) {bya gag pa ste/ mchu leb la rkang pa thung ba/ sder mo skyi mos sbrel cing chur rkyal mkhas pa'i bya'i rigs shig yin pa 'di la khyim bya dang ri bya gnyis yod/}
+gag gog|{gag ge gog ge'i bsdus tshig}
+gag pa|1) {gnyan nad lce'i steng du babs nas lce skrangs shing skad 'gag pa zhig ste/ nang gses su dbye na pho gag dang/ mo gag bu gag gnyan gag bcas rigs bzhi mchis/} 2) {bya gag pa ste/ mchu leb la rkang pa thung ba/ sder mo skyi mos sbrel cing chur rkyal mkhas pa'i bya'i rigs shig yin pa 'di la khyim bya dang ri bya gnyis yod/}
 gag tshil sgog pa'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ skyi g.ya' bar 'dod pa'i bsam pas dge slong la g.ya sgog pa/}
 gag zor|{gag pas lce steng thor pa thon pa dang/ lce 'og skrangs pa gshag byed kyi yo byad cig}
-gag lhog gnyan nad lce la babs te gre ba 'gag pa gag pa'i nad dang|{sha la babs te thor pa 'byung ba lhog pa'i nad dang gnyis kyi bsdus ming/}
+gag lhog|{gnyan nad lce la babs te gre ba 'gag pa gag pa'i nad dang/ sha la babs te thor pa 'byung ba lhog pa'i nad dang gnyis kyi bsdus ming/}
 gang|1. 1) {spyi sgra dngos la 'jug pa'i spyi sgra gang/ yon tan gang goms pa rnams bed spyod byas pa/ sems la gang dran bshad pa/ 'bras bu gang 'dod byung ba/ dngos po che chung gang na ci yod/ thabs shes gang nas kyang dmigs yul legs sgrub byed pa/ rang 'dod gang bsam zol med du zhu ba/ gang dga' gang skyid/ bsam 'char gang dran dran bshad pa yin/ dus yun gang thung thung du btang ba/ sang zhogs gang snga snga byas nas 'gro dgos/ 'brel lam gang 'grig 'grig byed pa/ rogs ram gang thub thub byas pa/} 2) {bye brag la 'jug pa'i spyi sgra gang/ gang la snying stobs mchog mnga' ba/ byas rjes 'jog mkhan gang zhig bum pa gang zhig gang nyid kyi bka' slob/} 3) {dri ba'i don du 'jug pa'i spyi sgra gang/ las don gang yin/ mi gang dang su yin pa/ dpe cha gang du gsal ba/ khyed rang sa phyogs gang nas phebs pa yin/ }2. {grangs gcig rgya ma gang/ dkar yol gang/ gom pa gang/}
 gang ga|{thams cad dam tshang ma/ khong tsho gang ga phebs bzhag}
 gang ga chung|{sngo sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas dug tshad dang/ rma tshad/ tsha 'khru/ tsha bas skrangs pa sogs 'joms par byed/}
@@ -5796,7 +5842,6 @@ gang nyid|{khyed rang/ gang nyid sku khams bde thang yin shag}
 gang tig|{(rnying) gang 'dod 'dod/}
 gang ltar|{gang yin yang ngam ga re yin na'ang/ gang ltar de 'dra byas na 'grig gi ma red/}
 gang stong|{'phel 'grib/ dbyar gyi gtsang po gang stong 'phel 'grib mang/ zla ba zla rer gang stong thengs re byed/}
-gang thub gang lcogs|{ci nus ci lcogs sam/ gang thub thub/}
 gang thub gang lcogs|{ci nus ci lcogs sam/ gang thub thub/}
 gang thub ci thub|{ji ltar nus nus/ nus shugs yod dgu rtsal sprugs kyis las don gang thub ci thub byed pa/}
 gang thon thon|{gang byung byung/ skad cha gang thon thon bshad na mi 'grog}
@@ -5825,12 +5870,13 @@ gang byung smra ba|1) {kha nas gang thon shod pa/} 2) {byung lugs ji bzhin drang
 gang mang gis zhi ba|{'dul ba las bshad pa'i rtsod pa zhi byed kyi chos bdun gyi gras/ mngon sum brgyad kyi sgo nas rtsod pa zhi bar ma nus na/ tshul shing brims te gang mang ba'i phyogs la dag pa byin te zhi bar byed pa'o/}
 gang min tshad|{ha las pa/ las ka gang min tshad yag po byas 'dug gang min tshad tshabs chen red/ de 'dra yin na gang min tshad yag po red/}
 gang myur ci myur|{gang mgyogs ci mgyogs/}
-#gang tsug gang 'dra'am ji ltar|
+gang tsug|{gang 'dra'am ji ltar/}
 gang 'tshams|{thal cha med pa'i 'tshams po'am/ gnyis mthar ma lhung ba'i 'tshams po/}
-gang zhig spyi sgra zhig bya ba gang zhig las don che chung gang zhig sgrub kyang do do brtan brtan byas nas sgrub dgos|{gang zhig yid la byed pa/}
-gang zhe na|{ci red zer na/ de ltar bshad pa'i rgyu mtshan gang zhe na/ mig gi rnam par shes pa gang zhe na/ gang zag (pungala:) gdags gzhi phung po lnga po gang rung la brten nas btags pa'i mi'am/ skyes bu'am/ sems can gang de'i rgyud la skyon yon gnyis ka re zhig gang ba dang/ re zhig zag pa ste 'jig par 'gyur ba'i ming/ gang zag gis gang zag la tshod 'dzin ma byed/ gang zag ma brtags par gtam bcol ma byed/ ming gi rnam grangs la skye ba dang/ skyes bu/ mthong ba po/ bdag byed du 'jug pa po/ byed pa po/ tshor ba po/ za ba po/ shed bdag shed las skyes/ shes pa po/ sems can/ srog slong ba po/ gso ba bcas so/}
+gang zhig|{spyi sgra zhig bya ba gang zhig las don che chung gang zhig sgrub kyang do do brtan brtan byas nas sgrub dgos/ gang zhig yid la byed pa/}
+gang zhe na|{ci red zer na/ de ltar bshad pa'i rgyu mtshan gang zhe na/ mig gi rnam par shes pa gang zhe na/}
+gang zag|{(pudgala:) gdags gzhi phung po lnga po gang rung la brten nas btags pa'i mi'am/ skyes bu'am/ sems can gang de'i rgyud la skyon yon gnyis ka re zhig gang ba dang/ re zhig zag pa ste 'jig par 'gyur ba'i ming/ gang zag gis gang zag la tshod 'dzin ma byed/ gang zag ma brtags par gtam bcol ma byed/ ming gi rnam grangs la skye ba dang/ skyes bu/ mthong ba po/ bdag byed du 'jug pa po/ byed pa po/ tshor ba po/ za ba po/ shed bdag shed las skyes/ shes pa po/ sems can/ srog slong ba po/ gso ba bcas so/}
 gang zag gi gdags gzhi|{phung po lnga ste/ gzugs dang/ tshor ba/ 'du shes/ 'du byed/ rnam shes bcas so/}
-#gang zag gi bdag gang zag rang rkya thub pa'i rdzas yod du grub pa|
+gang zag gi bdag|{gang zag rang rkya thub pa'i rdzas yod du grub pa/}
 gang zag gi bdag med|{bdag med gnyis kyi ya gyal/ rang rgyud kyis bsdus pa'i phung po bden par ma grub pa'o/}
 gang zag gi bdag 'dzin|{bdag 'dzin gnyis kyi ya gyal/ gdags gzhi rang rgyud kyis bsdus pa'i phung po la brten nas nga dang nga yir 'dzin pa'o/}
 gang zag gi gzhi|{'dul ba gzhi bcu bdun gyi nang gses/ dus dang dus ma yin pa bsdus pa 'byung ba'i gzhi ste/ gang zag gis ltung ba bcabs ma bcabs kyi rnam dbye ston pa la gang zag gi ming gis btags pa'o/}
@@ -5839,7 +5885,7 @@ gang zag snyan brgyud|{sngar dus rabs brgyad pa'i skabs slob dpon padma 'byung g
 gang zag sta gon|{dbyar gnas kyi sbyor ba'i cho ga zhig ste/ thog mar gnas mal stobs pa'i ched du/ khyad chos bcu ldan gyi dge slong gcig gam gnyis gsol ba dang gnyis kyi las kyis gnas mal stoms pa'i gang zag tu bskos te/ sbyor ba tshul shing nye bar bzhag pa dang/ khrims kyi bya ba brjod pa gsol ba'i las byang/ tshul shing 'grim pa sogs byas te/ dngos gzhi'i gnas gtsug lag khang dang/ shing drung sogs su khri dang stan dang gos la sogs pa'i gnas mal rnams rgan rim bzhin du bstabs/ mjug tu gnas mal la gding ba rnam par dag pas bskyabs nas longs spyod pa'i tshul brjod pa bcas so/}
 gang zag bzhi|{mun pa nas mun par 'gro ba/ mun pa nas snang bar 'gro ba/ snang ba nas mun par 'gro ba/ snang ba nas snang bar 'gro ba ste/ bzhi/}
 gang zag la mi rton|{mi rton pa bzhi'i nang gses shig ste/ chos dang mi mthun pa'i spyod pa can yin na rigs rus snyan grangs mnga' thang sogs ji star che na'ang nye bar mi brten pa'o/}
-gang yag yag 'grig tsam dang|{lo tsam/ ca lag 'di gang yag yag 'dug las ka byed stangs gang yag yag 'dug}
+gang yag yag|{'grig tsam dang/ lo tsam/ ca lag 'di gang yag yag 'dug las ka byed stangs gang yag yag 'dug}
 gang yang|{ci yang ngam/ gcig kyang/ mthun rkyen gang yang tshang ba/ nad rims na tsha gang yang med pa/ mi gang yang rung ba zhig rgyu rkyen gang yang rung ba gcig ma tshang na 'bras bu 'byung bar mi 'gyur ba/}
 gang yin|1) {gang 'dra'am ci 'dra yin/} 2) {yin pa thams cad/}
 gang yin 'di yin med pa|1) {tshad 'dzin rgyu med pa/ skad cha gang yin 'di yin med pa ma shod/} 2) {ha las pa/ rta 'di'i 'gros yag pa la gang yin 'di yin mi 'dug} 3) {cho med pa/ las ka 'di cho med gang yin 'di yin med pa zhig byas 'dug gang yod/}1) {yod tshad tshang ma'am ji snyed/ nus shugs gang yod/ bsam 'char gang yod bshad zin/} 2) {ci zhig yod dam ga re yod/ las don gang yod na'ang byed dgos/}
@@ -5870,7 +5916,7 @@ gangs thigs|{rdo sman gyi rigs shig ste/ ro bska/ zhu rjes bsil nus pas rus chag
 gangs thibs|{kha ba chen po bab pa/ 'brog khul du gangs thibs brgyab na nor phyugs la god nyen che/}
 gangs thul|{kha ba sib sib/ da nang lnga dro ri mgor gangs thul skya chags pa zhig bab 'dug sbrang bu lding ba bzhin du gangs thul si li si li 'bab kyin 'dug gangs mthon mthing rgyal mo/jo mo glang ma ri'i ming gzhan zhig}
 gangs da byid|{(mngon) gangs sbal/}
-#gangs mdog gangs ri'i mdog gam mdog dkar po|
+gangs mdog|{gangs ri'i mdog gam mdog dkar po/}
 gangs rdib|1) {gangs ri nas gangs nyil ba/} 2) {gangs chen po bab pa/}
 gangs ldan|{(mngon)} 1) {gangs ri/} 2) {bod yul/} 3) {shu dag dkar po/}
 gangs sbal|{srog chags kyi sman gyi rigs shig ste/ ro mngar la chung zad skyur/ zhu rjes drod/ nus pas ro tsa bar byed/ khu stobs 'phel/ mkhal ma'i drod skyed/ ming gi rnam grangs la gangs da byid dang/ stobs skyed/ stobs ldan mu tig gos can/ sha'i rgyal po rnams so/}
@@ -5891,7 +5937,7 @@ gangs rud|{gangs ri nas gangs nyil ba/}
 gangs shur glod pa|{gangs kyi dkyil du shur rer rgyug pa/}
 gangs sul|{gangs ri'i gseng ngam/ bar gseb/}
 gangs lhags|{kha rlung ste bu yug gi 'tshub ma/ gangs lhags 'tshub pa'i mtshan mo/ lam bar du gangs lhags drag po ldang byung/}
-gnydzir|{(legs) gan ji ra ste gtsug lag khang dang dgon pa sogs kyi khang pa'i mdzes rgyan zangs sogs las grub pa zhig}
+gany+dzira|{(legs) gan ji ra ste gtsug lag khang dang dgon pa sogs kyi khang pa'i mdzes rgyan zangs sogs las grub pa zhig}
 gad|{byi dor/ sdod khang gi phyi nang tshang mar gad brgyab zin/}
 gad ka|{g.yangs sa/ g.yas phyogs gad ka dang/ g.yon phyogs g.yang/}
 gad skyibs|{gad 'og g.yab phub pa ltar yod sa/}
@@ -5906,7 +5952,7 @@ gad snyigs|{gad brgyab pa'i thal rdul nyal nyil/ gad snyigs spungs pa rnams/ gad
 gad snyigs 'khrol 'dzin|{sngar smon lam tshugs dus lha sa'i mi dmangs kyi khyim nang gad snyigs phyi logs su 'don skyel chog pa tshogs chen zhal ngor dgongs pa zhus pa'i 'khrol 'dzin/}
 gad bdar|{byi dor/ khang par nyin ltar gad bdar rgyag dgos pa bzhin du rang gi bsam pa la'ang rtag par brtag dpyad byed bdagos/ gad bdar ma byas par gtsang sbra gang nas yong/}
 gad pa|1) {gad bdar byed mkhan nam gad rgyag mkhan/} 2) {gad ka/}
-#gad phug gad pa'i khug gam gad khung|
+gad phug|{gad pa'i khug gam gad khung/}
 gad mo|{bzhad gad/ gad mo bro ba/ gad mo slong ba/ gad mo 'byin du 'jug pa/ gad mo khra khra shor ba/ gad mo dbang med du shor ba/ kha ther ther byas nas gad mo dgod pa/ gzhan gyis gad mo rta gad ltar dgod pa mthong dus rang yang gad mo 'chor grabs byed pa/}
 gad mo rgod pa|{gad mo dgod pa/}
 gad mo'i gnas|{gad mo chor ba'i yul/}
@@ -5920,10 +5966,10 @@ gan kyal|{gan rkyal dang 'dra/}
 gan rkyal|{lus kyi mdun nam/ kha gnam la bstan pa/ lus gan rkyal du nyal ba/ thal mo gan rkyal du bstan pa/ gan rkyal du 'gyel ba/ bu chung thang la gan rkyal log pa yar bslangs/}
 gan rkyal bu|{(mngon) skar ma brtan pa/}
 gan rgya|{kha dan gyi yi ge/ gan rgya 'jog pa/ gan rgya 'dra gnyis/}
-gan ji ra|{gnydzira'i zur chag ste/ gtsug lag khang sogs kyi thog steng du 'dzugs rgyu'i rgyan cha'i rigs shig}
+gan ji ra|{gany+dzira'i zur chag ste/ gtsug lag khang sogs kyi thog steng du 'dzugs rgyu'i rgyan cha'i rigs shig}
 gan jir|{gan ji ra'i bsdus ming/}
 gan dar|{gos chen gyi rigs shig}
-gan de|{gandi dang don gcig}
+gan de|{gaN+Di dang don gcig}
 gan de the'u|{gan de rdung byed kyi shing dbyug}
 gan don|{gan rgya'i nang don/}
 gan dho la|{(legs)} 1) {gtsug lag khang/} 2) {gtsang khang/}
@@ -5936,12 +5982,12 @@ gan mdzod|{(rnying) bang mdzod/}
 gan 'dzin|1) {rtags thel bzhag pa'i kha dan yi ge bsdus pa/} 2) {gan rgya dang 'dzin yig}
 gan 'dzin gcig 'thus|{gan rgya dang 'dzin thung yi ge gcig gis 'thus pa/}
 gan yig|1) {gan rgya'i yi ge/} 2) {gan rgya dang yig rigs gzhan dag}
-gan g.yog gandi rdung byed kyi shing zhig ste|{rgyu tsan dan dang/ bil ba sogs gandir rdung ba'i shing de nyid las byas pa/ tshad gandi la 'phog pa'i tshad la sor bcu gnyis/ lag pas gzung bar bya ba'i 'chang gzung la yang tshad de nyid dang ldan pa/ rtse mo gnyis ne'u le'i mgo bzhin du yod pa'o/}
+gan g.yog|{gaN+Di rdung byed kyi shing zhig ste/ rgyu tsan dan dang/ bil ba sogs gaN+Dir rdung ba'i shing de nyid las byas pa/ tshad gaN+Di la 'phog pa'i tshad la sor bcu gnyis/ lag pas gzung bar bya ba'i 'chang gzung la yang tshad de nyid dang ldan pa/ rtse mo gnyis ne'u le'i mgo bzhin du yod pa'o/}
 gan shog|1) {gan rgya/} 2) {gan rgya 'bri sa'i shog bu/}
 gandha bha dra|{(legs) dri bzang ste/ sngo sman gyi rigs shig ro kha la mngar/ zhu rjes snyoms/ nus pas skran nad dang/ dreg nad/ cham pa/ dug nad/ bad kan skya bo bcas la phan/}
-#gan g.yog gan g.yog dang 'dra|
-gandi|{dge 'dun bsdu ba'i brda sprod byed kyi yo byad cig ste/ 'dul ba las bshad pa'i tshad ldan gyi gandi ni/ rgyu tsan dan dang/ bil ba dang/ pa lA sha dang/ tsan dan dmar po dang/ star bu dang/ 'o se la sogs pas/ tshad dbyibs srid du sor brgyad cu 'rtsa bzhi/ zheng du sor drug dpangs su sor gnyis/ zur bzhir brgyad bzhogs sor gnyis gnyis dang ldan pa/ rtse mo gnyis sbal ba'i mgo 'dra ba'o/}
-gandi the'u|{gan g.yog}
+gaN g.yog|{gan g.yog dang 'dra/}
+gaN+Di|{dge 'dun bsdu ba'i brda sprod byed kyi yo byad cig ste/ 'dul ba las bshad pa'i tshad ldan gyi gaN+Di ni/ rgyu tsan dan dang/ bil ba dang/ pa lA sha dang/ tsan dan dmar po dang/ star bu dang/ 'o se la sogs pas/ tshad dbyibs srid du sor brgyad cu 'rtsa bzhi/ zheng du sor drug dpangs su sor gnyis/ zur bzhir brgyad bzhogs sor gnyis gnyis dang ldan pa/ rtse mo gnyis sbal ba'i mgo 'dra ba'o/}
+gaN+Di the'u|{gan g.yog}
 gab rgya|{gsang rgya/}
 gab sgra|{gab tshig}
 gab pa|1. {(tha mi dad pa) gab pa/ gab pa/ gob// yib pa/ gab dmag gab 'dzul/ gab yib/ byi'u shing lo'i 'og tu gab pa/ 'phyi ba tshang du gab pa/ }2. {cha mnyam pa/ chu zheng gab pa/}
@@ -5955,7 +6001,7 @@ gab tshig|1) {gsang tshig} 2) {lde'u/}
 gab tshig gi rgyan|{rtsed mo sogs kyi mdun sar bzhad gad slong ba'i ched dang/gab tshig shes pa rnams nang phan tshun gsang gtam tshig tu smra ba dang/ rang dang mi mthun pa'i pha rol po rnams mgo bo rmongs par byed pa'i phyir du gab bya sna tshogs la gab byed sna tshogs sbyar te ston pa'i rgyan zhig}
 gab tshe|{gab tse dang 'dra/}
 gab 'tshol|{gsang ba byas nas 'tshol ba/}
-gab yig gsang ba'i yi ge|{gab yig rgya dam yod pa zhig bskur/}
+gab yig|{gsang ba'i yi ge/ gab yig rgya dam yod pa zhig bskur/}
 gab res 'ur res|{gab res yib res kyang zer/ byis pa'i rtsed mo'i gras shig ste/ gcig gab nas gzhan dag gis 'tshol ba/}
 gam|1. {nye 'gram mam drung/ sku'i gam du su ci'ang med/ }2. 1) {ming mtha' ga'i rjes su sbyor ba'i 'byed sdud kyi sgra'i rkyen zhig ga sang nyin dgong dag gam/ gnangs nyin zhogs par 'phebs pa khyad med/} 2) {ming mtha' ga'i rjes su sbyor ba'i the tshom ston byed kyi sgra'i rkyen zhig ga chu khol ma 'dug gam/ mi 'dug sku gzugs bde po 'dug gam.}
 gam car mkhan sde che chung|{sku'i drung du sdod pa'i mkhan chen dang mkhan chung ste/ tA la'i bla ma'i gsol dpon dang/ gzim dpon/ mchod dpon sogs/}
@@ -5963,10 +6009,10 @@ gam bcar ba|{sku gam mam nye 'gram du sdod mi/}
 gam chung la|{bod rang skyong ljongs kyi steng chen rdzong gi byang rgyud du yod/}
 gam pa|{rdzong zhig bod rang skyong ljongs kyi lho rgyud na yod cing/ 'di'i lho ngos 'bras ljongs dang sa 'brel yin/ rdzong mi dmangs srid gzhung de gam pa zhol du yod/}
 gam pa la|{bod rang skyong ljong gong dkar rdzong gi nub rgyud du yod/}
-#gam 'brog grong khyer gyi nye logs rtswa kha legs po yod pa'i 'brog sa|
+gam 'brog|{grong khyer gyi nye logs rtswa kha legs po yod pa'i 'brog sa/}
 gam gzong|{tshag rgyag skabs lcags sogs kyi ngos su gug thig 'bri byed kyi lag cha zhig}
 gam yo|{(rnying) drung ngam nye 'gram/}
-#gam g.yog drung na sdod pa'i bran|
+gam g.yog|{drung na sdod pa'i bran/}
 gam rum|{bod ljongs gam pa sa khul nas thon pa'i gdan rum/}
 ga'u|1) {lha sku 'jog sa'i ze'u lha khang/ ming gi rnam grangs la kha sbyar dang za ma tog go /}2) {pho mo'i rgyan zhig skra'i ga'u/ ske'i ga'u/}
 ga'u kha sbyar|{steng 'og gam/ rgyab mdun kha sbyar gyi snod sgrom mam par bu/}
@@ -5982,7 +6028,8 @@ gar gyi nyams dgu|{gar gyi cha byad dgu dang don gcig}
 gar gyi dbang po|{(mngon) rma bya/}
 gar glu|{tA la'i bla ma'i gar pas gtong ba'i glu/}
 gar glu rol gsum|{dge tshul gyi spang bya blangs 'das so gsum gyi nang gses/ rtsed mo'i rigs byed glu dang/ gar dang/ rol mo ste gsum mo/}
-gar dgos 'u lag sngar dgos gal gar byung la skul 'ded byed rgyu'i dmigs su bkar ba'i khral pa tsho chung zhig gar 'gros|1) {gar rtsed kyi 'gro stangs/} 2) {bang rtsal myur 'gros/}
+gar dgos 'u lag|{sngar dgos gal gar byung la skul 'ded byed rgyu'i dmigs su bkar ba'i khral pa tsho chung zhig}
+gar 'gros|1) {gar rtsed kyi 'gro stangs/} 2) {bang rtsal myur 'gros/}
 gar rgyan|1) {zlos gar gyi yo spyad rgyan cha/} 2) {(mngon) ba bla/}
 gar cig|{(rnying) gang zhig gar chang/chang gar po/}
 gar 'cham|1) {lus sgeg 'gying gi nyams ldan pa'i gar/} 2) {gar dang 'cham gnyis/}
@@ -5992,22 +6039,23 @@ gar stegs|{gar 'khrab sa'i sdings cha/}
 gar thabs|{gar gyi 'khrab stangs/}
 gar thig dbyangs gsum|{gar ni 'bag dang 'cham gos gyon nas 'cham rgyag pa dang/ thig ni dkyil 'khor 'bri ba/ dbyangs ni ngag nas gyer ba'i gdangs rnams so/}
 gar thod thod|{gang byung byung/ khe nyen bsam blo ma btang bar las ka gar thod thod ma byed/}
-#gar nag phag pa'i skyag pa me la bsregs pa'i thal ba|
+gar nag|{phag pa'i skyag pa me la bsregs pa'i thal ba/}
 gar pa|1) {tA la'i bla ma'i gar pa 'go dmangs spyi ming /} 2) {bro gar 'khrab mkhan/}
 gar po|1) {sla po min pa/ chang gar po/ ja gar po/ thug pa gar po/ gar tshad/ gar sla 'tshams po/} 2) {gyong po/ glags mi rnyed pa'i mi gar po zhig} 3) {gzhi chen po/ rtsod pa gar po/ kha mchu gar po/}
 gar dpon|{sngar bod sa gnas srid gzhung gi gar pa'i 'go khrid/}
-#gar phrug sngar bod sa gnas srid gzhung gi gar 'khrab mkhan phru gu|
+gar phrug|{sngar bod sa gnas srid gzhung gi gar 'khrab mkhan phru gu/}
 gar 'phyags|{sngar bod sa gnas srid gzhung skabs gar phrug bsdu ba'i khral/}
 gar ba|{gar po dang 'dra/}
 gar bab|{'gro gnas sdod gnas nges med gang du 'khel 'khel/}
 gar bu|1) {gong bu'am gcig tu 'gril ba'i rdog po/ lcags kyi gar bu/} 2) {(mngon) lcags/} 3) {(rnying) lce/}
 gar bro|{zlos gar bro gzhas/}
-gar 'bag gar 'cham gyi gdong 'bag gar ma|1. {gar mkhan ma/ }2. {sla po min pa/ thug pa gar ma/ ja gar ma/}
+gar 'bag|{gar 'cham gyi gdong 'bag}
+gar ma|1. {gar mkhan ma/ }2. {sla po min pa/ thug pa gar ma/ ja gar ma/}
 gar mo|{gar po dang 'dra/}
 gar rtsed|{gar 'khrab pa'i rtsed mo/}
 gar rol pa|{gar 'khrab mkhan dang rol cha gtong mkhan/}
 gar lo|{gar lham dang don gcig}
-gar log sngar kha che yul gyi mi rigs tu ru ka'i nang gses yan lag cig yin zhing|{dus rabs bcu gcig par de'i rgyal po zhig gis lha bla ma ye shes 'od bkrongs pa/}
+gar log|{sngar kha che yul gyi mi rigs tu ru ka'i nang gses yan lag cig yin zhing/ dus rabs bcu gcig par de'i rgyal po zhig gis lha bla ma ye shes 'od bkrongs pa/}
 gar sha|{mthe bong dang mdzub mo'i bar gyi sha/}
 gar song cha med|{gar phyin mi shes pa/ phru gu gar song cha med du gyur pa/}
 gar song rjes med|{gar song 'dir song med pa/}
@@ -6015,7 +6063,7 @@ gar sla|{gar ba dang sla ba'i bsdus ming/ rtsam thug gar sla 'tshams po zhig 'th
 gar lham|{(yul) bod lham gyi rigs shig}
 gal|1) {rgya'am/ rnyi/} 2) {gnad 'gag gam rtsa ba/ gal chen du 'dzin pa/ las don gyi gal che chung la gzhigs nas snga rting gi go rim sgrig pa/ rtsag rtsig gal chung ba'i gras la ha cang lta dgos don mi 'dug da res gal che la thug stabs mi zhu ka med byung/}
 gal gyis|{(rnying) nan gyis/ nyes can la gal gyis ngal rtsol byed 'jug pa/ gal gyis gcun pa/}
-gal 'gag gnad 'gag gam snying po|{rtag tu slob sbyong bya rgyu ni gal 'gag che ba zhig red/}
+gal 'gag|{gnad 'gag gam snying po/ rtag tu slob sbyong bya rgyu ni gal 'gag che ba zhig red/}
 gal 'gangs|{rtsa 'gangs/ don gnad gal 'gangs che rigs tsam du ma zad/ gal 'gangs chung ba'i skor la'ang gzab nan byed dgos/}
 gal chen sbyong ba'i sa|{sngags rnying ma'i gzhung du/ rnal 'byor gnyis pa'i skabs su thob pa'i sa gsum pa ste/ sbyor lam du mthong lam don gyi 'od gsal la sgrib pa'i mngon rgyu'i bag chags thams cad sbyong bas gal chen sbyong ba'i sa zhes bya'o/}
 gal ta|{re lde las bzos pa'i rgyags chas blug snod cig}
@@ -6031,7 +6079,7 @@ gal bzung|{(rnying) khas len dang sun 'byin/}
 gal la|{(rnying) bu ram dwangs ma/}
 gal srid|{the tshom gyi tshig gam brtag pa'i tshig drang bden gyi bya gzhag la gal srid 'phral du rgyal kha ma thob kyang/ mthar de ltar 'thob rgyu nges can yin/ khang pa'i nang du gal srid sdod mkhan gzhan med na'ang/ khang pa srung mkhan gcig yod pa thag chod/ gal srid brgya tham pa med kyang/ dgu bcu tham pa tan tan yod/}
 gas kha|{ser ka'i gas srubs/ sgo'i gas kha nas yar bltas pa/}
-gas chag ser gas dang chag grum|{dkar yol gas chag can/}
+gas chag|{ser gas dang chag grum/ dkar yol gas chag can/}
 gas pa|{tha mi dad par 'jug pa'i 'gas pa'i 'das pa/}
 gas 'phan|{ser kha gas pa'i skyon/}
 gas srubs|{ser ga/ dkar yol de tsho'i nang nas gas srubs med pa zhig 'doms shog rtsig pa der gas srubs chen po byung 'dug}
@@ -6054,8 +6102,8 @@ gu ge khams tshan|{dbus gtsang chos sde chen po rnams su stod mnga' ris gu ge na
 gu thung|{(yul) dor ma'am gos thung/}
 gu dung|{gu thung dang 'dra/}
 gu dog po|{rgya khyon cher med pa'am/ bar stong chung chung/ lam ga gu dog po/}
-#gu drag slob dpon padma drag po'i skur bzhengs pa'i rnam pa|
-gu na pA la|{bzang po bskyangs te/ bod du phebs myong ba'i rgya gar gyi slob dpon pA la rnam gsum zhes pa'i gras shig}
+gu drag|{slob dpon padma drag po'i skur bzhengs pa'i rnam pa/}
+gu Na pA la|{bzang po bskyangs te/ bod du phebs myong ba'i rgya gar gyi slob dpon pA la rnam gsum zhes pa'i gras shig}
 gu yangs pa|{gu yangs po dang 'dra/}
 gu yangs po|{bag yangs dang/ rgya khyon chen po'am bar stong chen po/ sems gu yangs po/ sa cha gu yangs po/}
 gu yu|{go yu'i 'bri srol gzhan zhig}
@@ -6070,10 +6118,10 @@ gu shi han|{(sog)} 1) {mkhas pa'i dbang po ste/ sngar sog po'i go thob cig} 2) {
 gu shrI|1) {(rgya) go thob kyi ming zhig} 2) {(legs) yon tan dpal/}
 gu shrI bstan 'dzin chos rgyal|{sngar a mdo sog rigs tsho ba ho shod kyi 'go dpon zhig yin pa 'di nyid rab byung bcu gcig pa'i lcags 'brug lo dpung tshogs dang bcas pa bod du 'byor/ chu rta lo pan chen sku phreng bzhi pa dang/ tA la'i bla ma sku phreng lnga pa rnam gnyis dang lhan cig tu da lta'i grong khyer hren dbyang zhes par man ju'i rgyal po tshang dang 'brel lam 'debs ched du sku tshab btang/ chu lug lo tA la'i bla ma sku phreng lnga par bkur bzos kyis chos srid gnyis ldan dga' ldan pho brang gsar du btsugs te gong ma'i bka' 'brel bod kyi rgyal po mdzad/ rab byung bcu gcig pa'i shing rta lo lha sar 'das/ (1582-}1654) {(}1640) {(}1642) {(}1643)
 gu shrI bsod nams grags pa|{phag gru sde srid khri rabs bzhi pa 'di rab byung drug pa'i sa phag lo la 'khrungs/ rab byung drug pa'i lcags bya lo nas shing glang lo'i bar lo bzhi srid bskyangs/ rtse thang gi tshogs pa lo bcu gsum bskyangs/ gdan sa mthil gyi spyan snga lo bcu dgu mdzad/ tA ming hung 'u rgyal pos kwa din gu shrI'i go sa gnang/ rab byung bdun pa'i sa byi lo la 'das/ (1359-}1408) {1381-1385}
-gug gi gu dang zhabs kyu gnyis kyi ming|{gi gu zhabs kyu}
+gug|{gi gu dang zhabs kyu gnyis kyi ming/ gi gu zhabs kyu/}
 gug kyed|{gug ni gi gu zhabs kyu gnyis dang/ kyed ni 'greng bu na ro gnyis/ gi gu zhabs kyu 'greng bu na ro}
 gug gu|{gi gu'i ming/}
-gug gug dbyibs thur du gug tshul|{sked pa gug gug stod gug gug}
+gug gug|{dbyibs thur du gug tshul/ sked pa gug gug  stod gug gug}
 gug ge ba|{gug gug rnga mong ske gug ge bar 'gro/}
 gug pa|{(tha mi dad pa) 'khyogs pa'am thur du dud pa/ shing gi yal ga gug pa/ rgad po'i gzugs gug pa/ dud 'gro'i lus gug pa/ ne tso'i mchu gug pa/}
 gug po|{gug gug dbyug pa gug po/ gri gug}
@@ -6081,8 +6129,7 @@ gug gzong|{dngul mgar gyis bu ga 'bigs byed kyi lag cha zhig}
 gug srang|{sngar gu ge lung par dar ba'i nya ga zhig gser gug srang sum brgya/}
 guggul|{(legs) gu gul/}
 gung|1) {(rgya) sngar rgya nag gong ma'i skabs kyi go sa zhig} 2) {dkyil te/ dgung yang snang/ nyin gung/ mtshan gung/} 3) {srog chags kyi rigs stag dang dbyibs cha tsam 'dra zhing/ spu ris nar mo dang sgor mo gnyis 'dres pa'i gcan gzan zhig ste/ de'i sha yis smyo byed kyi nad dang/ 'byung gdon gyi nad la phan/ gung lpags/ dpa' bo'i rkyen du gung dang stag} 4) {snga phyi'i rim pa/ bshad tshul mi 'dra ba rnams gung bsgrigs pa/}
-gung khran tang|{'byor med gral rim gyi srid tang zhig dang/ 'byor med gral rim gyi gdong len ru khag cig 'byor med gral rim gyi gral rim rtsa 'dzugs kyi rnam pa mtho shos shig bcas yin zhing/ tang de'i mdzub ston bsam blo ni mar khe si le nyin ring lugs yin/ de'i dmigs yul ni 'byor med gral rim dang de min gnya'}
-gnon myong mkhan ngal rtsol mi dmangs mtha' dag gi 'go khrid byas te gsar brje'i 'thab rtsod la brten nas srid dbang len pa dang|{'byor med gral rim gyi srid dbang sger 'dzin gyis 'byor ldan gral rim gyi srid dbang sger 'dzin gyi tshab byed pa'i sgo nas spyi tshogs ring lugs dang gung khran ring lugs mngon du 'gyur ba byed rgyu de yin/}
+gung khran tang|{'byor med gral rim gyi srid tang zhig dang/ 'byor med gral rim gyi gdong len ru khag cig 'byor med gral rim gyi gral rim rtsa 'dzugs kyi rnam pa mtho shos shig bcas yin zhing/ tang de'i mdzub ston bsam blo ni mar khe si le nyin ring lugs yin/ de'i dmigs yul ni 'byor med gral rim dang de min gnya' gnon myong mkhan ngal rtsol mi dmangs mtha' dag gi 'go khrid byas te gsar brje'i 'thab rtsod la brten nas srid dbang len pa dang/ 'byor med gral rim gyi srid dbang sger 'dzin gyis 'byor ldan gral rim gyi srid dbang sger 'dzin gyi tshab byed pa'i sgo nas spyi tshogs ring lugs dang gung khran ring lugs mngon du 'gyur ba byed rgyu de yin/}
 gung khran ring lugs|{mi'i rigs kyi phugs bsam dang mthun shos kyi spyi tshogs kyi lam lugs shig yin/ de 'phel rgyas 'gro ba'i dus rim gnyis su phye ste/ dus rim dma' ba ni spyi tshod ring lugs dang/ dus rim mtho ba ni gung khran ring lugs yin/ dus rgyun du bshad pa'i gung khran ring lugs ni gung khran ring lugs kyi dus rim mtho ba der zer/ dus rim de'i ring la thon skyed nus shugs 'phel rgyas chen po byung ba dang/ spyi tshogs kyi thon rdzas ches phun sum tshod pa byung ba/ mi rnams la bsam pa'i go rtogs mthon po dang ldan pa/ ngal rtsol bya rgyu de 'tsho ba'i nang la med du mi rung bar gyur pa/ khyad par chen po gsum rtsa med du gyur pa/ gung khran ring lugs kyi spyi la dbang ba'i lam lugs lag tu len pa/ bgo bsha'i rtsa don ni gang nus de sgrub dang mkho bstun thob sprod bya rgyu de yin/}
 gung bsgrigs|{gral lam go rim 'grig par byas pa/}
 gung ja|{nyin dgung gi ja/}
@@ -6109,7 +6156,7 @@ gun|{gyong/ gzhan la gun mi gtong/ rang gis gun 'khyer/ nga la gun phog byung sn
 gun mthud|{gyong gsab/ 'gro gron 'phar song gi gun mthud mtshon byed shog sgor lnga brgya tham pa sprad/}
 gun po|{pham po'am gyong chen po/}
 gun gsab|{gyong byung ba'i kha gsab/}
-gun pA la|{(legs) yon tan bskyangs te dus rabs bcu gcig par bod du phebs myong ba'i rgya gar gyi slob dpon pA la rnam gsum gyi gras shig}
+guN pA la|{(legs) yon tan bskyangs te dus rabs bcu gcig par bod du phebs myong ba'i rgya gar gyi slob dpon pA la rnam gsum gyi gras shig}
 gupta'i yi ge|{rgya gar gyi yi ge'i bye brag pa zhig ste sngar thon mi sambho tas bod yig gi gzud rtsom pa'i tshe ma dpe mdzad pa'i yi ge yin par grags/}
 gum pa|{'gum pa'i 'das pa/}
 gur|{ras dang re lde phying pa bcas las bzos pa'i sdod gnas/ phying gur/ dbu gur/ bzhugs gur/ dmag gur/ sog gur/ thab gur/ gur rgyug gur thag gur phub nas sdod pa/ sdod gur 'degs pa/ nyi ma shar nas gur phab ste thon pa/ ming gi rnam grangs la gur khang dang/ gos khyim/ sbra/ sbra gur bcas so/}
@@ -6124,19 +6171,20 @@ gur gyi mgon po|{ye shes pa'i srung ma zhig}
 gur gyi bab le|{gur gyi rgyan spros ri mo tshem drub ma/}
 gur gyi sham bu|{gur thog gi mthar btang ba'i rgyan/ gur gyi sham bu rlung gi yam yom du sgul ba/}
 gur mgon lcam dral|{ye shes pa'i srung ma gur mgon yab yum gnyis/}
-gur tig me tog ser skya 'char ba zhig ste|{ro kha/ zhu rjes snyoms/ nus pas khrag mkhris dang/ rma tshad 'joms/}
+gur tig|{me tog ser skya 'char ba zhig ste/ ro kha/ zhu rjes snyoms/ nus pas khrag mkhris dang/ rma tshad 'joms/}
 gur mthongs|{gur gyi thog khung/}
-gur drag bde mchog gi bka' sdod srung ma zhig gur gdung|{gur gyi gdung ma/}
-#gur nag sbra gur|
+gur drag|{bde mchog gi bka' sdod srung ma zhig gur gdung/ gur gyi gdung ma/}
+gur nag|{sbra gur/}
 gur bu|1) {dbyibs gru bzhi/} 2) {gur chung chung/}
 gur mo|{gting skyes rdzong gi sa cha sngar 'gro mgon chos rgyal 'phags pas btsugs pa'i bod khri skor bcu gsum gyi ya gyal zhig}
 gur zhol|{gur gyi gsham du yod pa'i chu len ras/}
-#gul nag gu gul nag po|
+gul nag|{gu gul nag po/}
 gus bkur|{gus 'dud bsnyen bkur/}
 gus 'dud|{gus pas 'dud pa/ gus 'dud yid smon/ gus gus 'dud 'dud/ dge rgan la gus 'dud zhus/}
 gus pa|1. {(tha mi dad pa) yid dang bas 'dud pa/ dpa' bo la gus pa/ }2. 1) {rang nyid dma' sar 'jog pa'i tshig gus pa rnam rgyal nas ched du zhu snying/} 2) {gus 'dud/ khengs dregs spangs nas gus pa zhu ba/ lus ngag yid gsum gyis gus pa'i rnam 'gyur ston pa/}
 gus po|{dang ba'i rnam pa can gyi sems dga' po'am mos po/ zhal bkod gang gnang gus por nyan pa/ phru gu 'di pha ma la gus po zhig red/}
-gus phyag gus pa'i sgo nas 'tshal ba'i phyag gus sbyor|{gus pa'i spyod pa/}
+gus phyag|{gus pa'i sgo nas 'tshal ba'i phyag}
+gus sbyor|{gus pa'i spyod pa/}
 gus rdzas|{'bul ba'i dngos po/}
 gus zhabs|{yid dang ba'i sgo nas zhabs phyi zhu ba/ g.yo zol med pa'i gus zhabs chen po byas pa/}
 gus zhen|{gus bkur dang sha zhen/}
@@ -6176,19 +6224,19 @@ go rgas ma|{pha ma'i khyim rang du na tshod rgas pa'i bud med/}
 go rgya|1) {thos rgya/ go rgya chung ba/} 2) {don go stobs kyi blo rgya/}
 go rgya can|1) {tshig don rgya cher go thub mkhan/} 2) {thos pa rgya che yod pa'i mi/}
 go rgyu|1) {don dag dang/ snying po/ ca co mang po bshad kyang/ go rgyu gang yang mi 'dug} 2) {tshig zur gyis bstan pa'i brda/ kho'i skad cha la go rgyu chen po zhig 'dug de ltar byas na mi 'grig pa'i go rgyu yang yang btang ba yin/ dngos su lab med kyang tshig shugs la brten nas go rgyu mang po yod/}
-go sgrig gra sgrig tshogs 'du'i go sgrig legs par zin pa|{slob sbyong gi go sgrig byed rgyu ma byung/}
+go sgrig|{gra sgrig tshogs 'du'i go sgrig legs par zin pa/ slob sbyong gi go sgrig byed rgyu ma byung/}
 go sgrub|{sher phyin don bdun cu'i nang gses/ theg chen la 'jug pa'i phyir go bgos pa go cha'i sgrub pa ste/ theg chen sems bskyed la brten nas don gnyis sgrub pa'i bya ba gang zhig phar phyin drug re re'i nang du drug drug tshang bar bsdus nas nyams su len pa'o/}
 go ngan klad blugs|{ngan bslab brgyab pa/}
 go ngan ma|{(yul) mna' mar phyin ma zin par rang gi nang du lus pa'i bsam shes med pa'i bud med/}
 go ca|{(rnying) go cha/}
-go cog rjes 'jug ga yig gi mthar 'jug pa'i thams cad|{ga}
+go cog|{rjes 'jug ga yig gi mthar 'jug pa'i thams cad/}
 go gcal|{pang gcal/}
 go bcad pa|1) {'dod don bsgrubs pa/ las don khag mang mi gcig gis go bcad pa/} 2) {tshab bam dod thub par byas pa/ lcags skyogs med sar shing skyogs kyis go bcad pa/}
 go cha|1) {go lag cha/ go gyon mtshon thogs/ go bkrag mtshon brjid/ dpa' bor go cha spras pa/} 2) {go khrab/ dmag mi thams cad go cha cha lag tshang ba zhig bgo ba/ ming gi rnam grangs la skyob byed dang/ khrab/ 'khrug gos/ go khrab/ lcags kyi bgo ba/ lcags gos/ dra ba can/ brang g.yogs/ mtshon skyob/ mtshon sgrib/ zhub can/ lus skyob/ lus srung bcas so/} 3) {lha dang sngags kyi srung thabs shig}
 go cha'i bkod pa bstan pa|{mdo sde zhig 'gos chos 'grub kyis rgya yig gzhir bzung nas bod yig tu bsgyur ba/}
 go cha'i brtson 'grus|{snying stobs mi zhum pa'i rtsol ba/}
-go cha'i lha yab drug rdo rje sems dpa' dang|{rnam snang/ padma gar dbang/ he ru ka nag po/ rdo rje nyi ma/ rta mchog ste drug}
-go cha'i lha yum drug rdo rje phag mo dang|{gshin rje ma/ rmongs byed ma/ skyong byed ma/ skrag byed ma/ tsanti ka ste drug}
+go cha'i lha yab drug|{rdo rje sems dpa' dang/ rnam snang/ padma gar dbang/ he ru ka nag po/ rdo rje nyi ma/ rta mchog ste drug}
+go cha'i lha yum drug|{rdo rje phag mo dang/ gshin rje ma/ rmongs byed ma/ skyong byed ma/ skrag byed ma/ tsanti ka ste drug}
 go chod pa|1) {las don 'pher ba/ gar btang go chod/} 2) {dod thub mkhan/} 3) {dod thub pa/}
 go chod po|{dgos don sgrub thub pa'am phan thogs po/ ca lag 'di go chod po zhig byung/ las don de'i skor la mi 'di go chod po yod dam/}
 go 'jo|{rdzong zhig bod rang skyong ljongs kyi shar rgyud dang 'bri chu'i nub 'gram du yod/ rdzong mi dmangs srid gzhung de a dkar du yod/}
@@ -6199,7 +6247,7 @@ go rtogs|{go don rtogs pa/ bsam blo'i go rtogs chu tshad mtho ru gtong ba/ bzang
 go stobs|{blo gros kyi stobs/ mi de lus stobs che ba tsam ma zad/ go stobs kyang chen po yod/}
 go thang|{bed spyod 'pher ba/ rta shed bzang/ mi go thang/}
 go thal|1) {thab kyi nang gi thal ba/} 2) {bya go bo'i skyag pa/}
-#go thal mdog kha dog sngo skya|
+go thal mdog|{kha dog sngo skya/}
 go thos|{rna bar go ba'am thos pa/ gnas tshul tshang ma go thos byung/ nang gi gnas lugs zhib gsal go thos ma byung/}
 go 'thun|{(rnying)} 1) {gang mos/} 2) {sna tshogs/} 3) {tshogs shing 'du ba/}
 go don|{go rgyu'i don dag snying po/ go don 'phigs pa/ dpe cha'i nang gsal go don khrid pa/}
@@ -6219,35 +6267,36 @@ go bab|{go sa'i rim pa dang mthun pa'i bab/ so so'i go bab la gzhigs te gzigs sk
 go bin da|{(legs) khyab 'jug}
 go be la|{(sog) sngar 'gro mgon chos rgyal 'phags pa dang sku thog gcig pa'i yon rgyal rabs kyi rgyal po zhig ste se chen rgyal po yang zer/}
 go bo|{mgo ser mgo nag gnyis su phye ba'i bya chen zhig}
-go bo glag gag pho drod che ba'i bya chen zhig go bye|{shing sman gyi rigs shig ste/ ro tsha/ zhu rjes drod/ nus pas srin nad gsod/ pho ba'i rims sel/ rma sogs rul ba gcod/ chu ser skem/ ming gi rnam grangs la dpal 'bras dang/ ma nu khrag can/ ma nu bse shing/ bse 'bras/bse ma nu bcas so/}
+go bo glag gag|{pho drod che ba'i bya chen zhig}
+go bye|{shing sman gyi rigs shig ste/ ro tsha/ zhu rjes drod/ nus pas srin nad gsod/ pho ba'i rims sel/ rma sogs rul ba gcod/ chu ser skem/ ming gi rnam grangs la dpal 'bras dang/ ma nu khrag can/ ma nu bse shing/ bse 'bras/bse ma nu bcas so/}
 go byed|{dge slong gi yo byad 'khar gsil/}
 go blo|{shes rab bam blo gros/}
 go 'byed can|{(mngon) nam mkha'/}
 go 'byed pa|1) {bar mtshams sam/ dbye ba 'byed pa/} 2) {go skabs 'byed pa/}
 go ma|{(yul) mna' mar ma phyin par pha ma'i nang du yod pa'i bud med/}
-#go mag mag pa|
+go mag|{mag pa/}
 go mi|{(legs) btsun pa/}
 go mi dge bsnyen|{ji srid 'tsho ba'i bar du dge bsnyen gyi spang bya rtsa ba bzhi dang yan lag bzhi srung zhing/ btsun pa'i cha lugs 'chang ba'i dge bsnyen/}
 go med tshor med|{bzang ngan dang dga' sdug gi tshor ba gang yang med pa/}
-go can thang chu|{tsan dan dkar po'i tshi'am rtsi/}
+go tsan thang chu|{tsan dan dkar po'i tshi'am rtsi/}
 go rtsed|{lha ldan smon lam chen mo'i gtor rgyag skabs gzim chung dmag mis me mda' dang/ mda'/ gri/ mdung/ phub sogs go cha khyer nas rtsal rtsed pa la go rtsed zer/}
 go tshod|{shes pa'i tshod yin nam shes yod shag thengs mang po bslabs tshar/ don ha go tshod yin/}
 go mtshams|{bar mtshams/ 'di ga'i gnas tshul go mtshams med par zhus yod pas gsal por mkhyen yod shag}
 go mtshon|{mtshon cha'i rigs/}
 go mdzod|{go mtshon 'jog khang/ go mdzod nas go lag ci yod bton pa/}
 go zhub|{(rnying) khrab/}
-go zlog go rim log pa|{dpe cha mgo mjug go zlog blang dor go zlog}
+go zlog|{go rim log pa/ dpe cha mgo mjug go zlog  blang dor go zlog}
 go yu|1) {shing sman gyi rigs shig ste/ ro kha la tsha ba/ zhu rjes drod/ nus pas mkhal nad sel/ so yi rtsi srung bar byed/} 2) {rwa rnying 'dzugs byed kyi rgyug pa zhig}
-#go yog go g.yog dang 'dra|
-go g.yog thab me dkrug byed kyi shing|{tsan dan gyis go g.yog dang/ gos chen gyis thab phyis/}
+go yog|{go g.yog dang 'dra/}
+go g.yog|{thab me dkrug byed kyi shing/ tsan dan gyis go g.yog dang/ gos chen gyis thab phyis/}
 go ra|1) {me thal 'then sa'i ra skyor/} 2) {(rnying) btson ra/}
-go rig go stobs kyi rig pa|{go rig la gzhigs nas slob phrug so sor slob gnyer byed pa/}
+go rig|{go stobs kyi rig pa/ go rig la gzhigs nas slob phrug so sor slob gnyer byed pa/}
 go rig can|{rig pa gsal po yod mkhan/}
 go rim|1) {ngang tshul lam skabs bab dang mthun pa'i rim pa/ go rim dang ldan pa/ shog grangs kyi go rim 'khrugs pa/ ang grangs kyi go rim 'chol ba/ ming gi rnam grangs la sngon rjes dang/ rim can/ rim pa/ srol ka bcas so/} 2){rgyu dang 'bras bu re re nas rim bzhin 'byung ba/ ldan min 'du byed kyi nang gses shig}
 go re|1) {(yul) bza' bya'i 'khur ba/} 2) {(rnying) }1. {nye reg }2. {rdzogs pa'am gang ba/}
 go re long|{(rnying)} 1) {lag g.yog gam/ g.yog byed pa/} 2) {bang phyin nam/ mngag gzhug pa/} 3) {rang dbang med par/}
 go la|1) {sra rtsi'i rgyu bse shing gi khu ba/} 2){mgron bu mer bsregs pa'i thal ba/} 3) {(legs) legs sbyar gyi skad du gu ru lci ba dang/ la gha ma yang ba'i don bsdus pa'i gu la/ au'i yon tan 'phel ba'i go la ste/ go ni mtho ris sogs dang/ la ni yang ba sogs don du mar 'jug pas mtho bar gnas pa'i gza' skar gyi ris rnams mi ltung bar 'dzin pas mtho ris 'dzin dang/ steng phyogs su khyim dang sa la dus bzhi 'khor bar byed pa'i las can yin pas phyogs 'khor dang/ ri gling rnams kyi steng du gdugs kyi rnam pas gnas pas zlum po dang/ lhun po'i steng du mtho la me dkyil thad kar dma' bas sgang gshong dang/ 'degs byed rlung stobs ljid che zhing 'phul byed rlung stobs kyi nus pa yang bas lci yang zhes kyang bya'o/ de la nam mkha'i go la dang/ skar khyim du rgyu ba'i nyi zla'i go la/ sa'i go la sogs yod do/ gu ru la gha ma gu la au go la go la}
-#go lag go mtshon|
+go lag|{go mtshon/}
 go la'i rlung|{rgyu skar sogs kyi 'gro lam steng gi rlung rgyun/}
 go leb|{rwa rnyi'i lhu lag gras shig}
 go lo|1) {go tsam shes tsam/ mi des bshad tshad go lo thos lo kho na red/} 2) {nges gsal med pa'i zer sgros/ skad cha 'di go lo thos lo yin ma gtogs brtan brtan shod rgyu med/}
@@ -6258,12 +6307,12 @@ go log ma|{mna' mar 'gro sa nas rang gi pha ma'i nang la log pa'i bud med/}
 go lod|{(yul) go brda 'phrod lod dam go bde lod/ kho'i skad cha de khyod kyi rna bar go lod ji 'dra 'dug}
 go lob|{(rnying)} 1) {myur ba/} 2) {g.yo sgyu/}
 go lA|{(legs) ldong ros/}
-go shirsha|{(legs) tsan dan dkar po/}
+go shir+Sha|{(legs) tsan dan dkar po/}
 go shes|{rtogs pa dang shes pa/}
 go bsher|{khrab rmog phub sogs mtshon cha 'gog srung byed pa'i rigs la blta bsher byas pa/ dmag dpon gyis dmag gi go bsher byas te song/}
 go sa|{go gnas/ go sa mtho ru btang ba/ go sa 'dra ba gcig nas gcig tu spo ba/ go sa 'phos nas las 'gan gsar pa zhig 'khur ba/}
 go gsed|{go don gsal por bkrol ba/ rang nyid rmongs pa'i gnad don rnams la go gsed gsal po gnang byung/}
-#go hrag mi dang go mtshon rta bcas bzang ba'i dpung|
+go hrag|{mi dang go mtshon rta bcas bzang ba'i dpung/}
 gog skyon|{brnyings nas skyon can du gyur pa/ lo rgas pa'i gog skyon can/ khang pa rnying hrul gog skyon can/}
 gog rnying|{gcong zom/ gog rnying hrul skyon/}
 gog pa|{(tha mi dad pa)} 1) {yan lag bzhi'am sug bzhi sa la btsugs te 'gro ba/ phru gu gog nas 'gro ba/} 2) {lhung ba'i don du 'jug pa'i 'gog pa'i 'das pa/}
@@ -6276,15 +6325,15 @@ gong bkur|{gong du bkur ba ste/ mthong cher brtsis pa dang/ thod du 'khur ba/ ra
 gong 'khod|{gong du gsal ba/}
 gong gu rme ru|{lha sa'i jo bo dbu skra'i rdo ring du gsal ba'i skabs de'i the'u cu'i phyogs kyi yul zhig gi ming/}
 gong gong|{snga ma'i snga ma/}
-#gong 'grig gong thag chod pa|
+gong 'grig|{gong thag chod pa/}
 gong rgyag pa|1) {rin tshad shod pa/ gong yang tig rgyag pa/ har gong brgyab pa/} 2) {rtsi mthong 'jog pa/ sha shi sha la mi lta yang/ sder ma gser sder la gong brgyab/}
 gong rgyan|{gos kyi gong ba'i phyi rgyan/}
-#gong sgrig tshong zog la rin thang yang tig shod res byed pa|
+gong sgrig|{tshong zog la rin thang yang tig shod res byed pa/}
 gong gtam pa|{rin gong sgrig pa/}
 gong ltar|{snga ma nang bzhin/}
 gong thag|1) {rin thang gi chod mtshams/ nyo tshong gi gong thag bcad pa/} 2) {sga'i gong thag}
 gong thang|{rin thang/ rta pho bres la btags na/ gong thang mi yis rgyag yong/}
-#gong thig sham bu'i gong ba'i steng gi thig le lnga tshom gyi ming|
+gong thig|{sham bu'i gong ba'i steng gi thig le lnga tshom gyi ming/}
 gong mthun|1) {snga ma dang mthun pa/} 2) {rin gong 'tshams pa/}
 gong 'thus|1) {gong gis go chod pa/} 2) {sngar gro mo ba'i mi ser gyi 'go byed de/rdzong gzhis gzhan dag gi tsho dpon dang 'dra ba zhig}
 gong du 'pho ba|{gzugs su nye bar 'gro ba gsum gyi nang gses/ gzugs khams su dang por skyes pa'i rten la myang 'das mi 'thob par gong du 'phos te 'da' ba'o/ de la'ang 'og min gyi mthar thug par 'gro ba dang/ srid rtse'i mthar thug par 'gro ba ste gnyis yod do/}
@@ -6297,9 +6346,10 @@ gong bu|1){gcig tu 'dril ba'i rdog po ril mo/ sa'i gong bu/ lcags kyi gong bu/ m
 gong bo|{yan lag med cing lto bas 'gro mkhan/}
 gong 'bab|{rin 'bab/}
 gong ma|1. 1){rgyal po chen po/ rgya nag gong ma/ gong ma'i pho brang/ gong ma chen po/ gong ma'i rgyal khab/} 2){snga rabs kyi bla ma dam pa/ sa skya gong ma lnga/ bon gyi gong ma che drug }2.{sngon ma dang/ steng ma/ mi rabs gong ma/ rim pa gong ma/ gong ma'i gong ma/ khams gong ma/ sa gong ma/}
-gong ma che drug bon gyi bla ma drug gong ma mchod yon|{sngar bod kyi mchod gnas sam bla ma mtho shos tA la'i bla ma dang yon bdag gam sbyin bdag mtho shos rgya nag gong ma lta bu la zer/}
+gong ma che drug|{bon gyi bla ma drug}
+gong ma mchod yon|{sngar bod kyi mchod gnas sam bla ma mtho shos tA la'i bla ma dang yon bdag gam sbyin bdag mtho shos rgya nag gong ma lta bu la zer/}
 gong ma tshang|{snga dus gong ma dpon 'khor bzhugs gnas dang bcas pa'i spyi ming/}
-gong ma sreg bya sreg pa ste|{bya gong mo dang cha 'dra yang mchu rkang dmar min ser po zhig}
+gong ma sreg|{bya sreg pa ste/ bya gong mo dang cha 'dra yang mchu rkang dmar min ser po zhig}
 gong ma'i cha mthun gyi kun sbyor lnga|{gong ma'i cha mthun lnga dang don gcig}
 gong ma'i cha mthun lnga|{khams gong ma'i cha mthun te/ gzugs dang gzugs med kyi kun sbyor lnga ni/ gzugs kyi 'dod chags dang/ gzugs med pa'i 'dod chags dang/ rgod pa dang/ rmongs pa dang/ nga rgyal bcas so/}
 gong ma'i gnas gtsang lnga|{gnas gtsang ma'i sa lnga dang don gcig}
@@ -6308,13 +6358,14 @@ gong mo mtsho|{bod rang skyong ljongs kyi sna dkar rtse rdzong khongs yar 'brog 
 gong rmed|{sga'i gong thag dang rmed thag}
 gong sman dkon cog bde legs|{rab byung brgyad pa'i nang gtsang sa skyar sku 'khrungs/ brang ti chos rgyal bkra shis sogs slob dpon mang po bsten pa dang/ gangs ri'i ljongs na grags pa'i gso ba rig pa'i yig cha phal mo che la zhib tu gzigs te/ rgya bod kyi mkhas pa du ma'i snyan brgyud gab pa rnams khol du bton nas khrigs su bsdebs pa'i man ngag po ti dmar po dang/ pod nag pod khra/ phyi ma rgyud kyi dka' 'grel gnas thams cad gsal ba'i sgron me/ brgyud pa'i rnam thar/ sman ming brda sprod/ rgyud kyi dka' 'phrang 'grol ba'i shog ser bcas pod bdun/ rtsa chu'i gnad 'grol zhal gyi gdams pa dmar 'byin/ sngo'i 'khrungs dpe don bsdus/ khyad par du dpal ldan rgyud bzhi la mchan 'grel shin tu rgyas par 'debs pa'i rgyud chen khra mo be bum seng lding mar grags pa slob dpon bsten mi dgos par bltas pa tsam gyis grol bar bzhed pa rnams mdzad de gso ba rig pa'i bstan pa dgung du btegs/}
 gong sman dkon cog phan dar|{rab byung dgu pa'i nang gtsang sa skyar sku 'khrungs/ dgung lo dgu'i thog rang gi mes po dkon cog bde legs sogs bsten nas gso ba rig pa dpyis phyin par sbyangs/ gso ba rig pa'i man ngag spyi dang khyad par du dpal ldan byang pa'i bzhed pa gtso bor bstan nas 'gro don bskyangs/ gsung rtsom yang rtsa rgyud kyi 'grel pa me long mthong gsal/ man ngag gi skor la gso rig dgos 'dod 'byung ba nor bu'i phreng ba zhes bya ba/ nyams yig brgya rtsar grags pa rnams mdzad/ brgyud 'dzin gyi slob ma mnga' ris pa bde chen dang/ mang mkhar bde gling pa nyi ma grags sogs byung/}
-gong 'og gong dang gsham mam steng 'og gong 'og bsnor ba|{gong 'og 'phos pa/ stod smad go rim gong 'og 'chol ba/ dpe cha'i le tshan gong 'og go ldog byas nas bsgrigs pa/}
+gong 'og|{gong dang gsham mam steng 'og gong 'og bsnor ba/ gong 'og 'phos pa/ stod smad go rim gong 'og 'chol ba/ dpe cha'i le tshan gong 'og go ldog byas nas bsgrigs pa/}
 gong rim|{gong gi rim pa/}
 gong rol|{snga rol lam sngon/}
 gong gsham|1){thang ga'i me long gi phyogs bzhi'i gos chen mtha' lcags phyi nang/} 2){steng dang 'og}
 gong sa|1){bla dpon mtho shos kyi go sa spyi'i ming/ sa skyong gong sa/ khrims bdag gong sa/} 2){gong ma'i sa/}
 gong sa mchod yon|{sngar bod kyi bla sprul mtho shos tA la'i bla ma lta bu dang/ yon bdag mtho shos bod kyi rgyal tshab lta bu bcas la zer zhing/ skabs 'gar tA la'i bla ma dang pan chen er te ni phan tshun bla slob tu gyur mtshams gong sa mchod yon yang zer/}
-gong sa'i snyoms 'jug gzugs gzugs med kyi snyoms 'jug gong sa'i dbang po|1){(mngon) gzugs khams kyi bdag po tshangs pa/} 2){sa gong mar yod pa'i dbang po/}
+gong sa'i snyoms 'jug|{gzugs gzugs med kyi snyoms 'jug}
+gong sa'i dbang po|1){(mngon) gzugs khams kyi bdag po tshangs pa/} 2){sa gong mar yod pa'i dbang po/}
 gong gsal|{thod du 'khod pa dang/ sngon du brjod pa/ zhu rgyu'i don gnad tshang ma yi ge'i brjod bya gong gsal ltar la he bag med/}
 god ka|{rgyu nor dang phyugs kyi stor brlag shi chad/ mi dmangs kyi rgyu nor la god ka yong du mi 'jug mi la nad gzhi dang phyugs la god ka gang yang med/}
 god kha|{god ka dang 'dra/}
@@ -6397,7 +6448,7 @@ gos 'jab|{(yul) gos chen gyi kha gdan ring po/}
 gos stod|{sngar bod sa gnas srid gzhung gi rtse drung tsho'i las gos shig gos thang/gos chen gyis bzos pa'i thang ga/}
 gos thung|1){gu dung/} 2) {gyon pa thung ngu/}
 gos mtha'|{gos kyi mtha' chag gos mthar sram lpags kyi rgyan btang ba/}
-gos 'dang|{gos 'gel sa'i gdang/}
+gos gdang|{gos 'gel sa'i gdang/}
 gos 'dang|{gos ldeng dang 'dra/}
 gos ldeng|{gyon pa gcig gi rgyu long tshad/}
 gos sne|1){gyon pa'i sne mo'am zur/} 2) {gos kyi rigs kha/}
@@ -6420,7 +6471,7 @@ gos 'dzar|1){gyon pa dang gos chen gyi sne 'dzar/} 2){gos lhug ste 'dzar ba/}
 gos zegs po|{gos rnying hrul/}
 gos gzan|{gos chen gyis bzos pa'i pho mo'i gzan/}
 gos yig ris ma|{yi ge'i ri mo yod pa'i gos chen/}
-gos yug gos chen bubs tshang|{gos yug gcig}
+gos yug|{gos chen bubs tshang/ gos yug gcig}
 gos len pa'i spang pa|{spang ltung sum cu'i nang gses/ rang la chos gos rnam gsum yod bzhin 'khor gsum khebs pa'i tshad du longs pa'i gos nye du ma yin pa'i dge slong ma las blangs pa'o/}
 gos gsham|{gos kyi sgab/}
 gos sul|{gos kyi gnyer ma'am ster kha/}
@@ -6460,7 +6511,7 @@ gyang sku|{gyang ldebs su bris pa'i sku brnyan/}
 gyang skor|{khang pa dang grong pa sogs kyi mthar bskor ba'i gyang gi ra ba/}
 gyang gying|1) {gyang ngi gying ngi'i bsdus tshig} 2) {(rnying) khengs dregs kyi lus kyi rnam 'gyur/}
 gyang gyong|{gyang nge gyong nge'i bsdus tshig}
-#gyang rgyug gyang sa rdung byed rgyug pa|
+gyang rgyug|{gyang sa rdung byed rgyug pa/}
 gyang sgrom|{gyang rdung snod shing sgrom/}
 gyang ngi gying ngi|{khengs dregs kyi rnam pa/ gyang ngi gying ngi'i mi la tshang mas dga' po mi byed/}
 gyang nge gyong nge|{ma thul ba'i gyong tshul/ sa gyang nge gyong nge chu lud kyis 'dul dgos/ mi gyang nge gyong nge der skad cha shod khag po 'dug}
@@ -6489,7 +6540,8 @@ gyam|{brag ri'i g.yab bam/ brag phug rgya che la gting sbug thung ba zhig brag g
 gyam pa|{(rnying) chu chen gyi bab shul/}
 gyam bu|{brag phug chung ba/}
 gyar ba|{(tha mi dad pa)} 1) {'gyur ba/ ci bya med pa'i gnas su gyar ba/ 'khrug zing gi gnas su gyar ba/ grogs med kher rkyang gi gnas su gyar ba/} 2) {'khyam pa/ gzhan yul du gyar ba/ yul gyar srid gzhung/} 3) {kha 'thor ba'am brlag pa/ kha gyar ba/ lhu gyar ba/ dpe cha'i shog lhe gcig gyar 'dug}
-gyar ma gyer khug skad gdangs kyi 'gyur khug 'degs 'jog gi rnam pa zhig gyi|1. {ming mtha' na ma ra la bcas kyi rjes su sbyor ba'i 'brel sgra'i rkyen zhig na ma ra la 'dzugs skrun gyi bya gzhag lam gyi zur/ gsol mar gyi ljags gong/ tshe dbang rnam rgyal gyi zhwa mo/ }2. {(rnying) gri/}
+gyar ma gyer khug|{skad gdangs kyi 'gyur khug 'degs 'jog gi rnam pa zhig}
+gyi|1. {ming mtha' na ma ra la bcas kyi rjes su sbyor ba'i 'brel sgra'i rkyen zhig na ma ra la 'dzugs skrun gyi bya gzhag lam gyi zur/ gsol mar gyi ljags gong/ tshe dbang rnam rgyal gyi zhwa mo/ }2. {(rnying) gri/}
 gyi thang|{tsong kha zhes pa'i ming gi rnam grangs te da lta mtsho sngon zhing chen khongs mtsho sngon po'i shar phyogs kyi rma chu'i rgyud spyi'i ming/}
 gyi na pa|{nga'am bdag khengs skyung byed pa'i tshig}
 gyi na ba|1) {rang ga'am tha mal/ 'gro ba gyi nar 'khyams pa ma lus pa bde la 'khod pa/} 2) {dman pa/ gyi nas 'tsho ba/ lto gyi na ba dang gos lhags skyob tsam gyis chog shes pa/} 3) {le lo can/}
@@ -6511,11 +6563,13 @@ gyu nam|{g.yo sgyu can gyi mi/}
 gyu ba|{(rnying)} 1) {gong du bkur ba/} 2) {zos pa/} 3) {bkru ba/} 4) {nga rgyal can/}
 gyu ru lugs|{(rnying) rgyun chags pa/}
 gyu ru lugs su shod pa|{(rnying) drang por smra ba/}
-gyur cig smon tshig cig sku tshe ring zhing nad med par gyur cig 'dzam gling yongs kyi ngal rtsol mi dmangs tshang ma bcings bkrol 'thob par gyur cig gyur cig gu|{yong bar shog ces yid shin tu bskyod pas ci ma rung snyam du smon pa'i tshig}
-gyur dug gyur pa'i dug ste|{kha zas sogs kyi ngo bo thog ma nas dug ma yin yang dus dang rkyen gyi dbang gis rang bzhin 'gyur nas dug tu gyur pa'i don/}
+gyur cig|{smon tshig cig  sku tshe ring zhing nad med par gyur cig  'dzam gling yongs kyi ngal rtsol mi dmangs tshang ma bcings bkrol 'thob par gyur cig}
+gyur cig gu|{yong bar shog ces yid shin tu bskyod pas ci ma rung snyam du smon pa'i tshig}
+gyur dug|{gyur pa'i dug ste/ kha zas sogs kyi ngo bo thog ma nas dug ma yin yang dus dang rkyen gyi dbang gis rang bzhin 'gyur nas dug tu gyur pa'i don/}
 gyur pa|{'gyur pa'i 'das pa/}
 gyur mid|{so ma brgyab par hril bur mid pa/ gzhan gyi mnga' khongs sa cha gyur mid gtong ba/ lto chas sos ma blad par gyur mid byas na 'ju dka'/}
-gyur 'dzag grang ba'i nad rigs shig gyen|{gyen thur gyi gyen nam dkan/ gyen lam/ gyen gzar po/ lag mthil gyen du bkan pa/ mig gyen du lta ba/ dbu skra gyen du gzengs pa/ nyi ma nub nas 'char ba dang chu bo gyen du 'gro ba mi srid/}
+gyur 'dzag|{grang ba'i nad rigs shig}
+gyen|{gyen thur gyi gyen nam dkan/ gyen lam/ gyen gzar po/ lag mthil gyen du bkan pa/ mig gyen du lta ba/ dbu skra gyen du gzengs pa/ nyi ma nub nas 'char ba dang chu bo gyen du 'gro ba mi srid/}
 gyen 'greng|{gyen du lang ba/}
 gyen rgyu|{(mngon) me/}
 gyen rgyu'i rlung|{lus kyi rtsa ba'i rlung lnga'i ya gyal zhig ste/ byed las tshig 'byin pa dang/ dbugs gyen du rgyu ba sogs byed pa'i rlung/}
@@ -6528,13 +6582,13 @@ gyen brdol|{yar 'phyur/}
 gyen rna can|{(mngon) bya 'ug pa/}
 gyen 'phyur|1) {yar lud pa/ rba rlabs gyen 'phyur/ chu mig gi chu gyen du 'phyur ba/} 2) {(mngon) ri/}
 gyen 'byung|{dbugs 'tshang ba'i nad kyi rigs shig}
-#gyen ma gseg gyen gzar po ma yin pa|
+gyen ma gseg|{gyen gzar po ma yin pa/}
 gyen mig can|{(mngon) sha ra bha ste/ seng ge rkang pa brgyad pa/}
 gyen brtsegs|{(mngon) ri/}
-#gyen zlog ngo log btsan dbang gi gnya' gnon 'khur mi thub pas gyen zlog byed pa|
+gyen zlog|{ngo log  btsan dbang gi gnya' gnon 'khur mi thub pas gyen zlog byed pa/}
 gyen log|1) {ngo log 'bangs gyen log gi lo rgyus/} 2) {kan tur slog pa/}
 gyen slong|{yar sgreng ba/ dar cha gyen slong/}
-#gyen gseg gsegs lam|
+gyen gseg|{gsegs lam/}
 gyer sgom tshul khrims seng ge|{rab byung gnyis pa'i shing byi lor yar klungs su khra 'brug pa'i rje rgyud du 'khrungs/ phag gru rdo rje rgyal po'i slob ma yin/ rab byung gsum pa'i lcags glang lor snye phur shug gseb dgon pa btab pas shug gseb bka' brgyud ces pa byung/ de nas rim par brgyud pa dag gis zhi byed pa'i rjes su 'brangs pas deb sngon du 'di nyid zhi byed par 'jog shing byi lo la 'das/}
 gyer sgom bzhi|{bon lugs phrin las skor gyi gzhung zhig}
 gyer ba|{(tha dad pa) gdangs 'then pa/ snyan tshig dbyangs rta mthon por gyer ba/ glu dbyangs gyer ba/}
@@ -6556,7 +6610,7 @@ gyong ba|{gyong po dang 'dra/}
 gyong ru ba|1) {rgyud gyong po can/} 2) {rlan med skam gyong song ba/}
 gyong rol|{(rnying)} 1) {sa zhag ste bskal pa ya thog skabs sa steng nas rang bzhin gyis thon pa'i zhag rtsi mi'i zas su rung ba/} 2) {sa rdul sogs rdzing chu'i khar chags nas byung ba'i spris ma lta bu zhig}
 gyong sil sil|{gyong shas che tsam gyi tshul/ mi de'i lus po gyong sil sil zhig red/}
-gyong hrag hrag gyong shas che ba'i tshul|{skad cha gyong hrag hrag cig bshad yong/ gyon pa gyong hrag hrag cig gyon pa/}
+gyong hrag hrag|{gyong shas che ba'i tshul/ skad cha gyong hrag hrag cig bshad yong/ gyon pa gyong hrag hrag cig gyon pa/}
 gyod kha|{rtsod pa/ phan tshun nang gros byas kyang ma 'grig par gyod kha gtugs pa/ nga khyod kha rtsod kyi lab gleng gyod kha langs pa/ lab rnyog mang po'i gyod kha rtsod pa/}
 gyod khongs|{gyod kyi phyogs gtogs sam/ gyod kyi nang du tshud mkhan/}
 gyod 'khrun|{gyod thag lo mang po song yang/ da dung gyod 'khrun chod ma song/}
@@ -6565,10 +6619,9 @@ gyod thog gyod brtsegs|1) {kha mchu gcig thog nyis brtsegs byung ba/} 2) {nag ny
 gyod brdal byas|{khag 'phang gi bsnyon btsugs pa'am ya la dkris pa/}
 gyod 'tshol|{rtsod gleng ched du 'tshol ba/ sngar 'khon zhe la bzhag nas ched du gyod 'tshol byas pa/}
 gyod zhib las khungs|{sngar bod sa gnas srid gzhung skabs sger chos sogs che khag bar gyi kha mchu thag gcod byed pa'i las khungs shig}
-gyod gzhi|{khrims gtug byas pa'i rgyu rkyen nam kha mchu'i rtsa ba/}
-#gyod gzhi slong ba|
+gyod gzhi|{khrims gtug byas pa'i rgyu rkyen nam kha mchu'i rtsa ba/ gyod gzhi slong ba/}
 gyod ya|{khrims gtug byed mkhan phyogs gcig}
-gyod log khra log kha mchu ma 'dums shing|{dpyad khra khrims sar phyir log pa/}
+gyod log khra log|{kha mchu ma 'dums shing/ dpyad khra khrims sar phyir log pa/}
 gyon gos|{gyon bya'i gos/}
 gyon chas|{gos spyi'i ming/ gyon chas sgyur ba/ pho mo'i gyon chas khag khag so so red/}
 gyon 'dang|{gyon ldeng dang 'dra/}
@@ -6578,17 +6631,17 @@ gyon pa|1. {(tha dad pa) klub pa/ gos gyon pa/ bong bus gzig lpags gyon pa/ }2. 
 gyon po|{(rnying) rtsal 'gran pa/}
 gyon phying|{gyon rgyu'i phying pa/}
 gyol po|{rkang pa 'theng po/ rta gyol po/ 'gros stabs gyol po/}
-gyos sgyug gyos po dang sgyug mo ste rang gi bza' zla'i pha ma|{chung ma'i pha ma khyo ga'i gyos sgyug red/ khyo ga'i pha ma'ang chung mar de dang mtshungs/}
+gyos sgyug|{gyos po dang sgyug mo ste rang gi bza' zla'i pha ma/ chung ma'i pha ma khyo ga'i gyos sgyug red/ khyo ga'i pha ma'ang chung mar de dang mtshungs/}
 gyos po|{khyo ga dang chung ma'i pha/}
 gyos mo|{khyo ga dang chung ma'i ma/}
-gyoo khwang re'u mig rgya nag rtsis kyi rgyu skar nyer brgyad dang|{gza' bdun gyi 'phrod sbyor brtag thabs kyi ming/}
+gyoo khwang re'u mig|{rgya nag rtsis kyi rgyu skar nyer brgyad dang/ gza' bdun gyi 'phrod sbyor brtag thabs kyi ming/}
 gra|1) {dud 'gro'i rigs kyi spu'i rtse mo/ spu'i gra/ gra 'dzum/} 2) {srog chags kyi pags pa'i spu la gra dang khul gnyis yod pa'i gra ste spu byings las rtsub cing ring ba zhig wa lpags gra khul gnyis 'dzoms/ wa shi yang spu gra nyams dogs med/ dgun dus nor phyugs kyi spu gra chad nas spu mdog nyams yong/ rta drel gyi sha shed nyams nas gra yang chag 'dug} 3) {cha shas sam yan lag gam dum bu/ rtse gra/ tshig gra ma nyams pa/ gna' dus kyi ca lag gra ma chag pa/} 4) {sngar bod yul gyi rigs rus drug gi ya gyal zhig}
 gra khebs|{rta drel gyi sgal par g.yog byed/}
-gra 'grig 'thus sgo tshang ba|{sngon 'gro gra 'grig pa dang dngos gzhi 'dzugs thub pa/ las don tshang ma gra 'grig phun sum tshogs pa byung song/ bsam gros mthun po byung na las ka gra 'grig po yong/ mthun rkyen 'dzoms med pa'i las ka gra ma 'grig tsha ba la/}
+gra 'grig|{'thus sgo tshang ba/ sngon 'gro gra 'grig pa dang dngos gzhi 'dzugs thub pa/ las don tshang ma gra 'grig phun sum tshogs pa byung song/ bsam gros mthun po byung na las ka gra 'grig po yong/ mthun rkyen 'dzoms med pa'i las ka gra ma 'grig tsha ba la/}
 gra 'grig 'thus tshang|{las don bgegs med gnad du song ba/ las don mtha' dag gra 'grig 'thus tshang byung song/}
 gra rgyas pa|{stobs 'byor dar che ba/ khyim tshang gra rgyas pa/ rgyal khab gra rgyas pa/}
 gra rgyas phun sum tshogs pa|{'dod yon yongs su tshang ba/ gra rgyas phun sum tshogs pa'i spyi tshogs ring lugs su 'gro ba'i gzhung lam bzang po/}
-gra sgrig sngon 'gro'i bya ba ste|{sta gon/ las 'go dngos su 'dzugs rgyu'i gra sgrig byed pa/ gra sgrig byas na bya ba 'grub/ gra sgrig med na 'grub mi thub/}
+gra sgrig|{sngon 'gro'i bya ba ste/ sta gon/ las 'go dngos su 'dzugs rgyu'i gra sgrig byed pa/ gra sgrig byas na bya ba 'grub/ gra sgrig med na 'grub mi thub/}
 gra brgyab pa|{gzan pa'i gra ma phyugs kyi lce 'og tu zug nas rma bzos pa/}
 gra chag gru nyams|{dngos por skyon shor ba/ g.yar zhus dngos po tshang ma gra chag gru nyams med par rtsis 'bul zhus yod/}
 gra chu|{(yul) spu gshis rtsub po'i gra/}
@@ -6605,7 +6658,7 @@ gra bzhur|{spu gra me la bsregs pa/ snam bu'i spu gra me la bzhur ba/}
 gra zug pa|{grang ngar che skabs rta'i spu rtse 'khums pa/}
 gra ru|{phor pa sogs dkrug byed kyi 'khor lo'i g.yas g.yon gyi ru shing/}
 gra lo rgyas po|{dar rgyas chen po/}
-grag lo grag zer gsum gyi grag ste mi 'dod pa dang|{ma rangs pa'i tshig shugs ston pa'i phrad cig bum pa bden grub tu grag mthun rkyen yod med la rag las par grag}
+grag|{lo grag zer gsum gyi grag ste mi 'dod pa dang/ ma rangs pa'i tshig shugs ston pa'i phrad cig bum pa bden grub tu grag mthun rkyen yod med la rag las par grag}
 grag stong|{rna shes kyi gzung yul bden gnyis/ khyed kyis grag stong bsgrags pa yis/ kho bo'i blo gros rgyas par byas/}
 grag stong dbyer med|{rna ba'i yul du grag pa'i sgra rnams stong nyid dang dbyer ma mchis pa/}
 grag pa|{(tha mi dad pa)} 1) {sgra skad thon pa/ glog 'khyugs pa dang chabs cig 'brug sgra grag pa/ khos nga la kha grag ma byung/} 2) {thos pa dang shes pa/ nga la skad cha khyad mtshar po zhig grag byung/ de ring gsar 'gyur 'di lta bu zhig grag pa/}
@@ -6616,9 +6669,9 @@ grags snyan dkar ba|{ming snyan grags bzang po/ byas rjes bzang ba'i grags snyan
 grags 'dod|{snyan grags 'dod pa/}
 grags pa|1. {(tha mi dad pa) khyab pa/ khyab pa/ 'jig rten na yongs su grags pa/ rna lam du grags par mi 'gyur ba/ }2. {ming grags/ grangs pa phul byung/ grags pa ngan pa/ mkhas pa'i grags pa rgya cher spel ba/ gzi brjid kyi grags pa mi nyams par srung ba/}
 grags pa rgyal mtshan|{sa chen kun dga' snying po'i sras sa skya gong ma gsum pa/ rab byung gsum pa'i me mo yos la 'khrungs/ dgung lo nyer drug pa la gdan sar bzhugs/ dgung lo bdun cu pa me pho byi ba la gshegs/}
-grags pa nyams pa'i rgyu drug rgyan 'gyed pa dang|{'dus pa la blta ba/ le lo/ chang 'thung ba/ sdig grogs bsten pa/ mtshan mo grong du 'gro ba bcas drug go /}
+grags pa nyams pa'i rgyu drug|{rgyan 'gyed pa dang/ 'dus pa la blta ba/ le lo/ chang 'thung ba/ sdig grogs bsten pa/ mtshan mo grong du 'gro ba bcas drug go /}
 grags pa byang chub|{phag gru sde srid khri rabs gsum pa/ 'dis rab byung drug pa'i shing stag lo nas lcags bya lo'i bar lo bdun srid bskyangs/}
-grags pa'i rjes dpag rjes dpag gsum gyi nang gses|{rang gi rten grags rtags yang dag la brten nas brda'm 'dod pa tsam gyis bzhag pa'i yul la mi bslu ba'i shes pa/ dper na/ rtog yul na yod pa'i rtags kyis ri bong can la zla sgras brjod rung du rtogs pa'i rjes dpag lta bu'o/}
+grags pa'i rjes dpag|{rjes dpag gsum gyi nang gses/ rang gi rten grags rtags yang dag la brten nas brda'm 'dod pa tsam gyis bzhag pa'i yul la mi bslu ba'i shes pa/ dper na/ rtog yul na yod pa'i rtags kyis ri bong can la zla sgras brjod rung du rtogs pa'i rjes dpag lta bu'o/}
 grags pa'i rtags|{rtags yang dag gsum gyi nang gses/ 'jig rten na ji ltar grags pa de nyid rgyu mtshan du byas nas bsgrub gzhi de bsgrub chos de yin par 'jog byed kyi rtags/ dper na/ ri bong chos can/ zla ba zhes pa'i sgras brjod du rung ste/ rtog yul na yod pa'i phyir/ zhes pa lta bu sgra rtog gis bzhag cing 'jig rten du grags pa nyid las rang ngos nas rgyu mtshan gzhan med pa/}
 grags pa'i mu khyud|{(mngon) brgya byin/}
 grags pa'i mtshan ma|{grags pa don mthun yin pa mi tshang mas khas len dgos pa'i rtags sam mtshan ma/}
@@ -6626,7 +6679,7 @@ grags pa'i mtsho chen bzhi|{ma pham g.yu mtsho/ byang gnam mtsho phyug mo/ yar '
 grags pas bsal ba|{bsal ba bzhi'i nang gses/ dam bca' dang 'jig rten grags pa dang 'gal ba/ mi'i thod pa gtsang bar bsgrub pa dang/ bum pa la zla ba zhes brjod pa lta bu'o/}
 grang|{(rnying) dri ba'am the tshom ston pa'i tshig grogs shig bya ba de ltar byas na nor 'khrul du mi 'gyur grang snyam/}
 grang skyob|{dro 'chos kyi gos rigs/}
-#grang khrag grang ba'i nad dang khrag nad 'dres pa'i nad|
+grang khrag|{grang ba'i nad dang khrag nad 'dres pa'i nad/}
 grang mkhris|{mkhris pa 'ju byed kyi byed las nyams pa'i grang ba shas che ba'i mkhris nad cig ste/ nad rtags su mig sprin dang sha mdog ser por 'gyur ba dang/ zas mi 'ju ba/ bshang ba/ dkar por 'gyur ba sogs so/}
 grang 'khums|{lus grang nas 'khums pa/}
 grang 'khru|{bad kan grang ba shas che ba'i lbu ba be snabs can 'khru ba zhig}
@@ -6640,10 +6693,12 @@ grang ngar che|{zla ba bcu gnyis pa'i sgang la grang ngar che ba'i dus tshigs ze
 grang cang cang|{'khyags tshul lam 'khyags stangs shig lhags bsil lus la phog pas grang cang cang byas byung/}
 grang chu|1) {grang nad can gyi gcin pa/} 2) {nad cig}
 grang thur|{dpyad kyi lag cha mer ma bsregs par zug rngu'i steng du dbug par bya ba'i thur ma spyi'i ming/}
-grang dug tsha grang 'thab nas glang thabs su gyur pa'i rta nad cig grang dus|{(mngon) dgun gyi dus/}
+grang dug|{tsha grang 'thab nas glang thabs su gyur pa'i rta nad cig}
+grang dus|{(mngon) dgun gyi dus/}
 grang dro|1) {tsha grang/} 2) {grang ba dang dro ba'i bsdus ming/}
 grang 'dar|{lus grang ba dang 'dar ba'i rlung gi nad rtags shig}
-grang nag nad cig grang nad|{'khyags nas byung ba'i nad rigs shig}
+grang nag|{nad cig}
+grang nad|{'khyags nas byung ba'i nad rigs shig}
 grang gnas|{gnam gshis grang ba'i sa gnas/}
 grang ba|1) {tsha ba'i ldog phyogs/ dgun dus gos lham ma gyon pas grang bas mnar ba/ char rlung 'thab pa'i grang bas mgo lus gzir ba/ 'khyag rom gyi nang du phyin nas grang bas mi tshugs/ ming gi rnam grangs la 'khyags pa dang/ grang ngad/ grang mo/ grang reg bser bu/ lhags ngar bcas so/} 2) {bad kan sogs 'khyags nas byung ba'i nad rigs shig} 3) {sman gyi zhu rjes sam yon tan/}
 grang ba gting 'khar|{nad grang ba bcos pa'i dus las 'das te lus zungs yongs su zhan par gyur nas sman pa'i dbugs phyi nang gi rgyu ba gcig la 'phar rtsa lan gnyis sam gcig las 'phar mi nus pa gso dka' ba srog gcod nad dgu'i ya gyal zhig grang ba lhing chad/bad kan smug po dus gsum gyi nang tshan tsha ba'i grogs dang bral te grang ba gcig pur gyur pa'i don/}
@@ -6664,8 +6719,9 @@ grang 'dzags|{lgang pa'i nad cig}
 grang gzha'|{rma kha gzha' ba rigs shig ste/ rma kha drod dang bral zhing reg bya tshor ba med pa zhig}
 grang gzhi|{grang ba'i nad gzhi/}
 grang zil|1) {grang ngad dam grang ngar/} 2) {zil pa grang mo/}
-grang zug bsil ba'i nus shugs|{sa cha de grang zug chen po 'dug grang 'or/kha zas ma zhu ba dwangs snyigs 'dres pa/ dwangs ma'i lam du shor ba des khrag ngan rgyas te sha lpags la byer bas chu ser 'phel ba dang/ chu ser de nyid thur du lhung zhing lus g.yo bar gyur pa la 'or zhes zer bas 'dir bad rlung grang ba dang bsdong ba'i 'or nad kyi ming/}
-#grang reg grang ba'i reg bya|
+grang zug|{bsil ba'i nus shugs/ sa cha de grang zug chen po 'dug}
+grang 'or|{kha zas ma zhu ba dwangs snyigs 'dres pa/ dwangs ma'i lam du shor ba des khrag ngan rgyas te sha lpags la byer bas chu ser 'phel ba dang/ chu ser de nyid thur du lhung zhing lus g.yo bar gyur pa la 'or zhes zer bas 'dir bad rlung grang ba dang bsdong ba'i 'or nad kyi ming/}
+grang reg|{grang ba'i reg bya/}
 grang reg can|{(mngon) dgun kha/}
 grang rlung|1) {grang ngad che ba'i rlung/ ston dus grang rlung ldang/} 2) {pho ba'i me drod nyams pa'i grang ba dang rlung gnyis 'doms te zas mi 'ju zhing lto ba sbos pa dang/ dpyi sked sogs na ba'i nad kyi ming/}
 grang shas|{grang ngad kyi cha/}
@@ -6706,7 +6762,7 @@ grab g.yer tshwa kha|{bod rang skyong ljongs kyi 'brong pa rdzong gi byang rgyud
 grabs|1. {nye ba'i don/ 'gro grabs yod/ shor grabs/ 'chi grabs yod pa/ }2. {sngon 'gro'i don/ gsol tshigs bsham rgyu'i grabs sgrig pa/ zhing pa tshos so nam gyi grabs byed pa/}
 grabs rgyags|{lam bar du bza' rgyur bsdogs pa'i zas rigs/}
 grabs 'bru|{mu ge sil ched du bsags pa'i za 'bru/}
-#grabs dmag rgyab gnon dang rogs byed kyi dpung sde|
+grabs dmag|{rgyab gnon dang rogs byed kyi dpung sde/}
 grabs yul|{sta gon nam gra sgrig}
 grabs gshom|{gra sgrig gam sngon 'gro/ 'grul pa tshang mas phyogs 'gro'i grabs gshom byed kyin 'dug lkog g.yo ngan jus kyi grabs gshom byed pa/}
 gram bkra shis rtse pa|{yul ming las btags pa'i snga dus bod kyi lha mo'i tshogs pa zhig yul de gtsang rnam gling rdzong na yod/}
@@ -6714,7 +6770,8 @@ gram kha|{chu'i gram pa'i kha/ chu'i gram khar gos nyi mar bskams pa/}
 gram stong|{rdo hrug gis khengs pa'i thang/}
 gram thang|{rdo gram pa yod sa'i thang/}
 gram pa|1. {(tha mi dad pa) khyab pa'am 'thor ba/ gnag phyugs tshang ma ri la gram 'dug nad gzhi pags par gram pa/ }2. 1) {chu nang gi rdo hrug gor ma/ chu 'gram gyi gram pa/} 2) {chu chen bab pa'i shul/ chu phyin kyang gram pa sdod dgos/}
-#gram gseg chu song shul gyi rdo hrug gram hrug rdo gor ma chung chung|
+gram gseg|{chu song shul gyi rdo hrug}
+gram hrug|{rdo gor ma chung chung/}
 gral|{star ram sbreng/ gral 'go/ gral sked/ gral mjug bzhugs gral/ g.yas gral/ g.yon gral/ mi gral/ gral 'grig po/ sdod gral bsgrigs te sdod pa/ gral 'go nas gtam bshad na gral mjug tu nyan mkhan yod dgos/}
 gral pa|{gral du sdod mkhan/}
 gral ma|{dral ma dang 'dra/}
@@ -6734,17 +6791,17 @@ gras pa|{(rnying)} 1) {thog steng gi lan kan nam sgrom skyor/} 2) {skas 'dzeg gi
 gri|1) {gcod byed dam gtub byed kyi lag cha zhig gri kha/ gri thung/ gri ring/ gri rtse/ gri shubs/ spu gri/ skra gri/ gri 'don rgya 'dre rgyag pa/ gri rno rdugs pa/ gri bsnun pa/ gri rtsed/ gri rub byed pa/ gri btsugs te bsad pa/ sha btsos btsos pa dang gri brdar brdar ba red/ ming gi rnam grangs la sgrol byed dang/ rjes su gcod/ dpal gyi snying po/ mtshon cha'i gzhi bcas so/} 2) {nad med glo bur du shi ba'i rkyen la gri'i brdar 'dogs pa/ rta grir shi ba/ skom grir shi ba/ mtshon grir 'chi ba/ 'khyags grir shi ba/ ltogs grir shi ba/}
 gri klad|{mchod rdzas shig ste mi 'thab grir shi ba'i klad pa/}
 gri kha lcags zam|{yun nan zhing chen gyi 'ba' lung rdzong khongs su zla chu'i thog la btsugs pa'i lcags zam zhig}
-gri khrag mchos rdzas shig ste|{mtshon 'og tu shi ba'i mi'i khrag}
+gri khrag|{mchos rdzas shig ste/ mtshon 'og tu shi ba'i mi'i khrag}
 gri gu|1) {gri chung ngu/} 2) {sa ming zhig bod rang skyong ljongs kyi mtsho smad rdzong gi ming rnying yin/}
 gri gu mtsho|{bod rang skyong ljongs kyi mtsho smad rdzong khongs su yod/}
 gri gug|1) {gri kyog po zhig} 2) {sngar gyi mtshon cha zhig gri gum btsan po/srib khri btsan po'i sras sngar bod rgyal stod kyi steng gnyis kyi gras shig yin pa 'di la sras sha khri dang/ bya khri/ nya khri dang sras mo gcig bcas yod cing/ phyis blon po lo ngam rta rdzis bkrongs/ bod du sku phung sa 'og tu sbas pa'i srol gyi 'go tshugs/ rgyal po de'i ring la rgya nag gi go khrab smar khams brgyud bod la drangs/}
 gri mgo|{gri'i yu ba/ snyob sar lag pa su ring dang/ gcod sar gri mgo su ring ma byed/}
 gri 'gag gsor|{(yul) sked gri thung ba/}
 gri dngo|{gri kha'am gri so/}
-#gri lcag gri'i leb bam ltag gsad bya'i sems can gri lcag gis brdungs pa|
+gri lcag|{gri'i leb bam ltag  gsad bya'i sems can gri lcag gis brdungs pa/}
 gri chad|{sngar mi bsad pa'i gri la 'khri ba'i nyes chad/}
-#gri ltag gri'i ltag pa|
-gri 'thag gri so gnyis kyis sha 'dra gtub byed pa'i ming|{gri gnyis kyis gri 'thag byas nas sha btsabs pa/}
+gri ltag|{gri'i ltag pa/}
+gri 'thag|{gri so gnyis kyis sha 'dra gtub byed pa'i ming/ gri gnyis kyis gri 'thag byas nas sha btsabs pa/}
 gri 'thab|1) {phan tshun gri kha bkye ba'am gri khyer nas 'dzing ba/ dpa' rtul rnams kyis gri 'thab ja yun tsam byas/} 2) {(yul) jem rtse/}
 gri mdur|{gri rtse'i gseg kha/}
 gri dpa' dam|{sked gri ring po/}
@@ -6763,7 +6820,7 @@ grib khung|{nyi ma mi 'char sa/}
 grib khrus|{grib nad sel thabs byab khrus kyi ming/}
 grib brnyan|{grib ma'am grib nag gi gzugs brnyan/}
 grib mdos|{grib nad sel thabs kyi mdos yas/}
-#grib nag 'od zer mi phog pa'i sa|
+grib nag|{'od zer mi phog pa'i sa/}
 grib nag 'drer mthong|{dogs pa skye mi dgos sar dogs pa skyes pa/}
 grib nad|{gza' phog pa'i nad/}
 grib gnon|{lag pa snying gar bzhag ste gnyid khug na 'jigs skrag skye ba'i 'khrul snang gi rmi lam/}
@@ -6771,7 +6828,7 @@ grib gnon gyi gdon|{lag pa snying gar bzhag ste gnyid khug na lus sems mnan nas 
 grib phyogs|{ri'i byang ngos nyi 'od phog dka' ba'i sa cha/}
 grib ma|{yan lag gi kha dog brgyad kyi gras nang gi gzugs mthong ba la mi sgrib pa'i kha dog nag po/ gzugs kyi grib ma lta bu nang na yod pa'i gzugs mig la snang thub pa'o/ shing gi grib ma/ nyi ma nub mtshams ri rtse'i grib ma slebs pa/ la 'go yi nyi ma/ la rting gi grib ma/ lus dang grib ma bzhin du 'grogs pa/ grags pa ngan pa grib ma bzhin du 'grogs par 'gyur ba/}
 grib ma snum po|{grib ma bsil zhing shin tu bag phebs pa'i don/ ljon shing bzang po'i grib ma snum por ngal gso ba/}
-#grib btsog btsog pa'i nad|
+grib btsog|{btsog pa'i nad/}
 grib tshod|1) {nyi grib las dus tshod lta byed} 2) {grib gzugs kyi ring thung gi tshad/}
 grib gzugs|{thur grib kyi nyi ma'i grib ma/ nyi ldog gi grib gzugs 'gyur ba/}
 grib lam|1) {gnam gyi dgu tshigs/} 2) {ri'i srib kyi 'gro lam/}
@@ -6783,7 +6840,7 @@ grib sel|{grib nad sel thabs/}
 grib so|{grib ma nyi ma phar phar 'gro dus grib so tshur tshur slebs byung/ khang pa btsigs thog mang yang/ grib so sa la 'bab dogs/ ri bo chen po'i grib so dang/ rkyal gog chen po'i zhabs ra/}
 grib bsangs|{grib btsog sel thabs byas pa/}
 grib bsil|{grib nag bsil po/}
-#grim cag bag zon|
+grim cag|{bag zon/}
 grim pa|{(tha mi dad pa) dam por 'gyur ba'i don/ thag pa bsgril nas grim par 'gyur/ tsid skud grim dka' ba/ bal skud grim sla ba/}
 grim po|1) {thang po dang/ gsal po'am spyang po/ sku grim po/ rig pa grim po/ lag pa grim po/} 2) {lhod po'i ldog phyogs sam ldog zla/ thag pa grim po/ lag rtsa 'phar stangs grim po/}
 grim lhod|{dam lhug rig pa grim lhod 'tsham po/}
@@ -6801,7 +6858,7 @@ gru chags ma'i lugs|{'phyugs par 'dod pa'i lugs nang gses gling bzhi dus bzhi 'k
 gru char|{char 'jam po/ yul gru kun la gru char bab/}
 gru chod|{sde tshan sde tshan du bcad pa'i re'u mig}
 gru gdub|{gru mo'i rgyan cha/}
-#gru nang sems gcig mi tshang ma bsam blo gcig pa|
+gru nang sems gcig|{mi tshang ma bsam blo gcig pa/}
 gru nar|{gru bzhi nar mo/}
 gru pa|{gru shan gtong mkhan/}
 gru dpung|{ko gru rgyong byed kyi shing/}
@@ -6845,7 +6902,7 @@ grung ba|{grung po dang 'dra/}
 grung sha dod po|{nyob po min pa/}
 grub chen|{mchog gi dngos grub thob pa'i rnal 'byor pa/}
 grub chen au rgyan pa|{mtshan dngos rin chen dpal zhes grags/ rab byung bzhi pa'i lcags stag lo la 'khrungs shing rab byung lnga pa'i sa byi lo karma pa gsum pa rang byung rdo rje karma pa pakisha'i skye srid du ngos 'dzin pa po yin/}
-#grub mchog grub thob kyi mchog ste mchog gi dngos grub thob pa'i skyes bu chen po|
+grub mchog|{grub thob kyi mchog ste mchog gi dngos grub thob pa'i skyes bu chen po/}
 grub mchog ma|{grub pa thob pa'i rnal 'byor ma/}
 grub brnyes|{grub pa thob pa ste sngags lugs kyi grub pa'i dngos grub brgyad gang rung sogs thob pa'i rnal 'byor pa/}
 grub rtags|{grub pa thob pa'i rtags mtshan/}
@@ -6863,11 +6920,12 @@ grub mtha' 'og ma|{bye brag smra ba dang mdo sde pa gnyis so/}
 grub mtha' la ma zhugs pa|{rigs pas sbyar ba'i gzhung lugs la ma brten par rang dgar tshe 'di'i bde ba tsam don du gnyer ba'o/}
 grub mtha' la zhugs pa|{tshe 'di'i bde ba tsam gyis chog par mi 'dzin par rang gi blo ngor 'thad pas sbyar ba'i gzhung lugs la brten nas dngos po'i gnas tshul la dpyad nas blang dor byed pa/}
 grub mtha'i tshes longs|{grub rtsis kyi tshes kyi longs spyod/}
-grub bde dbyer med kyi rdzas gcig chos gnyis po mnyam skye mnyam gnas kyi skye gnas 'jig gsum dus mnyam zhing chos de gnyis kyi rdzas yin khyab mnyam yang yin|{de gnyis phan tshun gcig snang ba'i mngon sum la gcig shos kyang snang dgos pa'o/}
-#grub bde rdzas gcig gzhi gcig gi steng gi ldog pa rigs mi mtshungs pa rnams mnyam skye mnyam gnas kyi skye gnas 'jig gsum dus mnyam zhing rdzas gcig pa yin pa|
+grub bde dbyer med kyi rdzas gcig|{chos gnyis po mnyam skye mnyam gnas kyi skye gnas 'jig gsum dus mnyam zhing chos de gnyis kyi rdzas yin khyab mnyam yang yin/ de gnyis phan tshun gcig snang ba'i mngon sum la gcig shos kyang snang dgos pa'o/}
+grub bde rdzas gcig|{gzhi gcig gi steng gi ldog pa rigs mi mtshungs pa rnams mnyam skye mnyam gnas kyi skye gnas 'jig gsum dus mnyam zhing rdzas gcig pa yin pa/}
 grub pa|1. {'grub pa'i 'das pa/ }2. {(siddhi) dngos grub/ }3. {(yul) dus 'das pa ston byed kyi tshig grogs shig zhal lag mchod grub pa yin nam/}
 grub pa'i spyod pa|{rgyud kyi lam gyi mngon rtogs spyod pa'i sgo bzhi'i nang gses te/ lha dang skal ba mnyam pa'i rig 'dzin nam mkha' spyod grub nas/ de'i rten la sngags kyi phyin drug gi spyod pa spyad de mthar thug gi 'bras bu lha'i sku gsung thugs dang mnyam par sbyor bas rigs gsum rdo rje 'dzin pa'i go 'phang mngon du byed pa'o/}
-grub pa'i dbang phyug mdo sngags gang rung gi rtogs pa mchog brnyes pa'i gang zag grub pa'i yan lag gnyis|{rten 'brel yan lag bcu gnyis kyi nang tshan/ skye ba'i yan lag dang/ rga shi'i yan lag ni 'gro ba tha dad pa'i skye ba sogs mngon par grub pas grub pa'i yan lag gnyis so/}
+grub pa'i dbang phyug|{mdo sngags gang rung gi rtogs pa mchog brnyes pa'i gang zag}
+grub pa'i yan lag gnyis|{rten 'brel yan lag bcu gnyis kyi nang tshan/ skye ba'i yan lag dang/ rga shi'i yan lag ni 'gro ba tha dad pa'i skye ba sogs mngon par grub pas grub pa'i yan lag gnyis so/}
 grub 'bras|{las ka byas nas byung ba'i 'bras bu/ dka' las brgyab nas grub 'bras thob pa/ grub 'bras 'od stong 'bar ba zhig thob 'dug}
 grub rtsis|{dus 'khor rtsa rgyud las dngos su bstan pa'i skar rtsis la grub mtha'i rtsis zhes bya'o/ grub rtsis 'di la lugs mang ste phug lugs dang/ mtshur phu lugs/ dga' ldan rtsis gsar sogs yod/}
 grub gzugs|1) {mang po gcig tu bsdus nas grub pa'i gzugs/} 2) {brtsis tshar nas bab pa'i grangs kyi ri mo/}
@@ -6883,8 +6941,9 @@ grum bu|{rlan can gyi yul du rgyun ring sdod pa sogs kyis rkyen byas nas tshigs 
 grum bu dkar po|{bad kan rigs drug gi ya gyal zhig ste/ nad rtags pho mchin mi bde zhing/ kha zas 'khru skyugs byed pa/ nywa bzhi mig rus sogs na nas mjug tu grum bur 'gyur ba'i nad cig}
 grum tse|{gdan gyi bye brag dre'u rngog}
 grums pa|{grum pa'i 'das pa/}
-#gru'i nyag thag gru 'then byed kyi thag pa|
-gru'i dar cog gru gzings thog tu 'dzugs rgyu'i dar cog gru'i dar shing|1) {gru'i rlung g.yab 'gel sa'i shing/} 2) {gru'i dar lcog bsgar sa'i shing/}
+gru'i nyag thag|{gru 'then byed kyi thag pa/}
+gru'i dar cog|{gru gzings thog tu 'dzugs rgyu'i dar cog}
+gru'i dar shing|1) {gru'i rlung g.yab 'gel sa'i shing/} 2) {gru'i dar lcog bsgar sa'i shing/}
 gru'i yan lag|{(mngon) gru'i skya ba/}
 gru'i rab|{(mngon) gru shan/}
 gru'i gshog pa|{(mngon) gru'i skya ba/}
@@ -6918,15 +6977,16 @@ gro khang|{rta drel sogs kyis bskor te gro zhib 'thag sa'i khang pa/}
 gro ga|{shing stag pa'am shing ltag pa'i shun pa/}
 gro gro|{bal dkar nag 'dres ma'i ming/}
 gro sngon|{rta dkar po sngo shas che ba/}
-#gro lcog spungs pa'i gro sog gro chag brdungs te leb mo bzos pa'i gro|
+gro lcog|{spungs pa'i gro sog}
+gro chag|{brdungs te leb mo bzos pa'i gro/}
 gro chan|{gro chag las bzos pa'i thug pa/}
 gro chas|{lam rgyags sam lam zas/}
 gro chu|{(yul) gro ril gyi thug pa/}
 gro rjen|{(yul) gro btags pa'i phye ma'am gro zhib/}
 gro rten|{phyogs 'grul skabs lam rgyags kyi dmigs rten dngul dang dngos rdzas/}
 gro thal|{lo tog gro nas kyi snye mar chags nas 'bru rdog thal ba nag por 'gyur ba'i nad cig}
-#gro thig ngo la nag thig chung chung mang po yod pa|
-#gro thug gro ril gyi thug pa|
+gro thig|{ngo la nag thig chung chung mang po yod pa/}
+gro thug|{gro ril gyi thug pa/}
 gro 'debs pa|1) {lam du tsha phogs rgyag pa/} 2) {gro'i zhing khar son 'debs pa/}
 gro lpags|{gro zhib btags nas thon pa'i shun lpags/}
 gro spyi|{sngar bod sa gnas srid gzhung skabs gro mo'i spyi khyab/}
@@ -6957,7 +7017,7 @@ gro lo|{gro ma'i lo ma/}
 gro lo sa 'dzin|{sngo zhig}
 gro sha|{phyogs 'grul gyi lam rgyags sha/}
 gro so phye mar|{bod du lo gsar sogs rten 'brel gyi byed sgo'i skabs su sgrig gshom byed pa'i gro yos dang phye mar 'bo nang du blugs nas de'i thog tu gro snye dang me tog sogs btsugs shing/ mgron po phebs dus de phul nas dga' bsu sne len zhu/}
-#gro sog 'bru rigs gro'i sog ma|
+gro sog|{'bru rigs gro'i sog ma/}
 grog|1) {gad 'obs/ ngam grog chu grog} 2) {glo bur du byung ba'i bza' btung ngam longs spyod/ kha grog grog byung ba/ grog che thag chod byung/}
 grog skad|{zas nor sogs yong ba'i ltas su pho rog dang bya khra'i skad/}
 grog sked|1) {srog chags grog ma'i sked pa/} 2) {ngam grog gi sked pa/}
@@ -6994,7 +7054,8 @@ grogs med kher rkyang|{rogs med gcig po/}
 grogs med gcig pu|{rogs med pa'i kher rkyang/ ma rabs spyod ngan kho na byas te grogs med gcig pur lus pa/}
 grogs med pa'i sdug bsngal|{sdug bsngal drug gi nang gses shig}
 grogs mo|{grogs po bud med/ ming gi rnam grangs la kun spyod mtshungs dang/ na mnyam ma/ pho nya mo/ blo dkar ma/ zla ma bcas so/}
-grogs dmag dmag rgyag skabs phan tshun rogs ram byed pa'i dmag grogs rtsa|{ma bu dgra grogs 'byung ba brtsis nas rtsa brtag skabs shing grogs sa lta bu grogs dang 'phrad pa de la grogs rtsa zhes zer/}
+grogs dmag|{dmag rgyag skabs phan tshun rogs ram byed pa'i dmag}
+grogs rtsa|{ma bu dgra grogs 'byung ba brtsis nas rtsa brtag skabs shing grogs sa lta bu grogs dang 'phrad pa de la grogs rtsa zhes zer/}
 grogs bshes|{blo bkal chog pa'i grogs po/}
 grong|1) {them dud dam mi tshang/} 2) {mi tshang gang 'tshams shig mnyam du chags pa'i sde/ brgya grong/ stong grong/ grong khang/ grong stod/ grong smad/ grong dkyil/ ming gi rnam grangs la grong sde dang/ rgyal lam/ sde tsho/ yul sde bcas so/}
 grong skad|{yul skad/}
@@ -7005,15 +7066,15 @@ grong khyer|{las rigs mang po 'dzoms pa'i sde ste sngar gyi bshad srol du lcags 
 grong khyer gyi sgab mo|{(rnying)} 1) {smad 'tshong ma/} 2) {gsang thag 'then mkhan/}
 grong khyer rje bo|{rgyal phran nam yul gyi bdag po/}
 grong khyer nye kor|{grong khyer gyi nye 'dabs/}
-grong khyer lta na sdug ri rab kyi rtse mo de'i dbus na grong khyer lta na sdug ces bya ba ngos re re la dpag tshad nyis stong lnga brgya lnga brgya pa mtha' skor na dpag tshad khris 'khor ba yod cing|{de'i 'phang du dpag tshad phyed dang gnyis gyen du 'phags pa gser gyi rang bzhin dbyibs legs shing lta na sdug pa rin po che'i ka ba drug khri yod pa/ rin po che sna bzhi'i zam pa brgyud ma bzhi dang/ nang gi sa gzhi tshon sna brgya rtsa gcig gis bkra bar byas pa mnan na nem zhing btegs na 'phar ba me tog man da ra bas pus nub tsam du khebs pa zhig yod do/}
+grong khyer lta na sdug|{ri rab kyi rtse mo de'i dbus na grong khyer lta na sdug ces bya ba ngos re re la dpag tshad nyis stong lnga brgya lnga brgya pa mtha' skor na dpag tshad khris 'khor ba yod cing/ de'i 'phang du dpag tshad phyed dang gnyis gyen du 'phags pa gser gyi rang bzhin dbyibs legs shing lta na sdug pa rin po che'i ka ba drug khri yod pa/ rin po che sna bzhi'i zam pa brgyud ma bzhi dang/ nang gi sa gzhi tshon sna brgya rtsa gcig gis bkra bar byas pa mnan na nem zhing btegs na 'phar ba me tog man da ra bas pus nub tsam du khebs pa zhig yod do/}
 grong khyer spyod|{(mngon) bya pho rog}
 grong gi gcan gzan|{(mngon) khyi/}
 grong gi spre'u|{(mngon) byi la/}
 grong gcig ma|{dud tshang gcig las med pa'i grong/}
-#grong chog khyim pa'i nang la tshugs pa'i zhabs brtan cho ga|
+grong chog|{khyim pa'i nang la tshugs pa'i zhabs brtan cho ga/}
 grong chog pa|{chos bton pa'i yon la brten nas 'tsho ba skyel mkhan/}
 grong chos|{'khrig spyod/ bu mo grong pa'i chos kyis ma gos pa/}
-grong 'jug phung po'i grong la rnam shes 'jug pa|{rgyal bu'i gdung la grong 'jug byas nas rang gi phung po chu bor bskyur ba/}
+grong 'jug|{phung po'i grong la rnam shes 'jug pa/ rgyal bu'i gdung la grong 'jug byas nas rang gi phung po chu bor bskyur ba/}
 grong 'joms|{(mngon)} 1) {khyab 'jug} 2) {brgya byin/} 3) {ngang pa spyi/}
 grong gnyis la|{la zhig bod rang skyong ljongs kyi rtsa mda' rdzong gi lho rgyud du yod/ mtho tshad rgya mtsho'i ngos nas smi 5611 yod/}
 grong bsnyen|{grong khyim du mtshams bcad de bsnyen sgrub byed pa/}
@@ -7024,7 +7085,7 @@ grong du rgyu ba'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ rang
 grong du 'jug pa'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ nye du ma yin pa'i khyim du gung yol nas sang gi skya rengs ma shar gyi bar du gnas pa'o/}
 grong du 'dren|{(mngon) bong bu/}
 grong drag dmag sgar|{bod sa gnas srid gzhung skabs sngar nas 'khri srol yod med la ma ltos par khyim tshang drag rigs tshang mar dmigs bsal 'phar ma'i dmag mi skong 'dems byas pa'i dmag sgar zhig}
-#grong bdag grong pa'i nang gi 'go byed|
+grong bdag|{grong pa'i nang gi 'go byed/}
 grong 'dabs|{grong gi nye 'dabs/}
 grong rdal|{sngar gyi bshad srol ltar na grong chung chung min pa grong khyer las chung ba/ bzo tshong mang tsam 'dzoms yod pa'i grong sde/}
 grong sde|{mi tshang mang po yod pa'i grong/}
@@ -7093,7 +7154,7 @@ grwa lnga|{gzungs chen grwa lnga'i bsdus ming/}
 grwa chas|{grwa pa'i gyon chas/}
 grwa ja|{grwa tshang nas gtong ba'i ja/}
 grwa rtags|{snam sbyar gyi grwa rtags te dung dang/ padma/ shing lo/ nor bu sogs/}
-#grwa thog grwa pa'i mi rabs rgan gzhon|
+grwa thog|{grwa pa'i mi rabs rgan gzhon/}
 grwa sdeb|{dpung stobs sgrig pa/}
 grwa nang byams gling|{rab byung brgyad pa'i chu 'brug lo la thu mi lhun grub bkra shis kyis btab pa'i dgon pa lho kha'i yar klungs gtsang po'i lho'i ri ldebs su yod pa zhig}
 grwa pa|{dge 'dun pa spyi'i ming/}
@@ -7103,11 +7164,11 @@ grwa pa mngon shes can|{mtshan gzhan shes rab rgyal ba'am dbang phyug 'bar te/ r
 grwa pa rdab be rdob be|1) {grwa pa lo tshod che min chung min/} 2) {dpe cha mi lta ba'i yang yeng can/}
 grwa pa dpe cha ba|{grwa pa mtshan nyid slob gnyer ba/}
 grwa phor|{grwa shag so sor ja 'thung ba'i shing phor/}
-grwa phrug grwa pa chung chung ngam|{btsun chung/}
+grwa phrug|{grwa pa chung chung ngam/ btsun chung/}
 grwa 'phyags|{rab tu byung ran pa'i mi tshang ma grwa pa byed du 'jug pa'i khral/}
 grwa bu slob|{grwa pa slob ma/}
 grwa mang|{grwa pa mang tshogs/}
-#grwa dmag ser dmag ste dmag 'gro mtshon cha 'khyer ba'i grwa pa|
+grwa dmag|{ser dmag ste dmag 'gro mtshon cha 'khyer ba'i grwa pa/}
 grwa dmangs|{grwa mang byings/}
 grwa tshang|{dge 'dun sde tshogs kyi tshan khag cung zad che ba/ mtshan nyid grwa tshang/ sngags pa grwa tshang/ dus 'khor grwa tshang/ shar rtse grwa tshang/ byang rtse grwa tshang/ ser byes grwa tshang/}
 grwa tshang chos mdzad|{grwa tshang la gtong sgo btang nas dmigs bsal dbang cha blangs pa'i grwa pa/}
@@ -7118,17 +7179,17 @@ grwa bzhi rtsis bsher|{hor zla dang po'i tshes nyer gsum nyin/ smon lam gtor rgy
 grwa zur|{zur sne'am gru/}
 grwa gzugs|{grwa pa'i gzugs brnyan nam cha byad/}
 grwa gzugs dbon po|{grwa chas gyon pa'i skya bo/}
-#grwa g.yog grwa pa'i g.yog po|
+grwa g.yog|{grwa pa'i g.yog po/}
 grwa rigs|{grwa pa'i gras/}
 grwa ru|{sngar dgon pa khag gi grwa tshang ngam/ grwa pa'i ru ba/}
-#grwa log ban log gam skya babs pa'i grwa pa|
-#grwa shag grwa pa sdod khang|
+grwa log|{ban log gam skya babs pa'i grwa pa/}
+grwa shag|{grwa pa sdod khang/}
 grwa shar|{grwa pa na gzhon/}
 grwa sa|{phyogs mang nas dge 'dun pa 'dus te chos lugs kyi gzhung dang rig gnas sogs 'chad rtsod rtsom gsum byed yul gyi dgon pa/}
 gla|{las ka byas par sprod rgyu'i thob skal/ 'tshem gla/ las gla blangs pa/}
 gla skyes|{gla cha dang/ gzigs bzos/}
 gla khol|{gla pa dang g.yog po/}
-#gla gag bya go bo klad kar|
+gla gag|{bya go bo klad kar/}
 gla rgyun|{gla lpags mnyes ma'i rgyun bu/}
 gla sgang|{sngo sman gyi rigs shig ste/ ro bska la mngar/ zhu rjes bsil/ nus pas skad 'gags pa dang/ glo ba'i tshad pa/ rgyu tshad sogs la phan/}
 gla sgril lto sgril|{las ka byas pa'i gla dang lto gnyis dngul sogs la sgril ba/}
@@ -7138,12 +7199,12 @@ gla chu|{mdo smad chab mdo brgyud nas 'bab pa'i chu bo zla chu'i ming gi zur cha
 gla lto|{gla chas dang lto chas/ gla lto'i mthun rkyen/ gla lto yog pa gzan sgril gyis sprad pa/}
 gla thang|{las gla'i tshad dam thang gzhi/}
 gla thob|{las ka byas pa'i gla'i thob cha/}
-#gla bdag gla pa gla mkhan|
+gla bdag|{gla pa gla mkhan/}
 gla pa|{gla pa byed mkhan te rang gi lus stobs btsongs nas 'tsho ba skyel mkhan/}
 gla po|{gla pa byed mkhan/}
 gla phogs|{las gla dngul dang bza' rten 'bru sogs/}
 gla phor|{shing gla ba'i phor pa/}
-#gla phrug ri dwags gla ba'i phru gu|
+gla phrug|{ri dwags gla ba'i phru gu/}
 gla ba|1.{(tha dad pa) glas pa/ gla ba/ glos/ /dngul sogs sprad nas bed spyad chog pa'i dbang cha nyo ba/ rta drel gla ba/ sdod khang gla ba/ }2. 1) {dri zhim rtsi ldan gyi ri dwags shig gla lpags/ gla mche/ ming gi rnam grangs la gla rtsi can dang/ dri bzang dbang po/ rlung bsregs/ sa lus bcas so/} 2) {shing zhig}
 gla ba gla rtsi can|{gla ba pho/}
 gla ba mche ba can|{gla ba pho/}
@@ -7160,10 +7221,10 @@ gla rtsi kha|{si khron zhing chen khongs rnga ba bod rigs rang skyong khul gyi z
 gla tsher|{shing zhig}
 gla zan|1) {las ka'i gla za mkhan/} 2) {gla mi'i zas/}
 gla rin|{gla dang rin pa'i bsdus ming/}
-#glag mchu dang sder mo lcags kyu ltar gug cing rno la spu mdog dud kha can gyi bya zhig lu gu bya glag gis khyer na skad rgyag sa nam mkha'i mthongs las med|
+glag|{mchu dang sder mo lcags kyu ltar gug cing rno la spu mdog dud kha can gyi bya zhig  lu gu bya glag gis khyer na skad rgyag sa nam mkha'i mthongs las med/}
 glag khra mo|{bya glag mo/}
 glag pa|{(rnying) ltag pa/}
-#glag rog bya glag nag po|
+glag rog|{bya glag nag po/}
 glags|1) {dus tshod dang skabs mtshams/ khom glags med pa/ lta glags med pa/ khyim du sdod glags med pa/ phan tshun gcig gis gcig la glags rnyed dka' bar gyur/} 2) {thabs/ sdug bsngal bzod glags med pa/ zhe 'khon bzod glags med pa/}
 glags skabs 'tshol ba|1) {pha rol po nyams nyes thub pa'i dus skabs 'tshol ba/} 2) {khag 'dogs sa'i gnad 'tshol ba/}
 glags khel ba|1) {'gran zla byed thub pa/}2) {pha rol pham par byas pa/}
@@ -7176,7 +7237,7 @@ glang klad|{khrus rdzas te/ rgya skad du yI rtsi/}
 glang sker bel btags|{che chung ngam/ bzang ngan mnyam sbrel gyi dpe/ mi tsho'i lus stobs bzang ngan glang sker bel btags bzhin mnyam sbrel sgrigs 'dzugs byas pa/}
 glang khyim|{khyim bcu gnyis kyi gnyis pa/ khyim zhag nyi bar smin drug steng du slebs nas chu tshod bco lnga 'das nas glang khyim la slebs/}
 glang khyu mchog|{(mngon) glang po'am glang chen/}
-#glang gog ba lang pho|
+glang gog|{ba lang pho/}
 glang rgod|{glang chen ma thul ba'am/ dul ma min pa/}
 glang rgyab|1) {glang gog gi sgal pa/} 2) {glang gis khyer ba'i do rgyab/} 3) {dkyil 'khor rta babs kyi bang rim zhig}
 glang sgur|{mchin nad cig}
@@ -7205,7 +7266,7 @@ glang po che cang shes|{legs nyes kyi ltas sod shes pa'i glang chen/}
 glang po che dmu rgod|{gzhan la gnod 'tshe byed pa'i glang chen/}
 glang po che sa la rab brtan|{glang chen sa srung dang don gcig}
 glang po che'i stabs su gshegs pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang gses shig ste/ klu zil gyis gnon pa la mkhas pa nyid kyis glang po che'i stabs su gshegs pa/}
-glang po mchog glang po'i rgyal po|{ming gi rnam grangs la khyu yi mgon po dang/khyu yi bdag mche ba drug ldan/ gnyis 'thung dbang po/ thal dkar/ spos kyi glang bcas so/}
+glang po mchog|{glang po'i rgyal po/ ming gi rnam grangs la khyu yi mgon po dang/khyu yi bdag mche ba drug ldan/ gnyis 'thung dbang po/ thal dkar/ spos kyi glang bcas so/}
 glang po 'joms|{(mngon) seng ge /}
 glang po gtum po|1) {ma btul ba'i glang po/} 2) {glang chen smyon pa/}
 glang po rin po che|{rgyal srid sna bdun gyi gras shig}
@@ -7221,7 +7282,7 @@ glang zal po|{glang gog khra khra/}
 glang zla|{hor zla bcu gnyis pa/}
 glang ri thang pa|{rab byung dang po'i shing rta lor 'khrungs/ mtshan rdo rje seng ge/ po to ba'i dngos slob/ bka' gdams blo sbyong gi man ngag dmigs pa'i sa bcad brgyad du mdzad pa la blo sbyong tshigs brgyad mar grags pa de tshogs chos su mdzad/ rab byung gnyis pa'i chu bya lor glang thang dgon pa btab/ rab byung gnyis pa'i chu yos la 'das/}
 glang ru|{ba lang gi rwa co/}
-#glang rog glang gog spu mdog nag po|
+glang rog|{glang gog spu mdog nag po/}
 glang rwa|{glang gog gi rwa co/}
 glang lo|{lo skor bcu gnyis kyi gras shig}
 glang lo pa|{skyes pa glang lo pa/ glang lo pa'i chag sgo yos lo par 'khel/}
@@ -7237,7 +7298,7 @@ glal ba|1. {(tha mi dad pa)} 1) {kha g.yal ba/ thang chad nas gnyid bro bas glal
 glas 'thung|{(mngon) rus sbal/}
 glas pa|1) {gla ba'i 'das pa/} 2) {(rnying) sdod sa spos pa/}
 glas mi|{gla mi/}
-#glas dmag gla pa bsgrigs pa'i dmag sde|
+glas dmag|{gla pa bsgrigs pa'i dmag sde/}
 glas 'tsho ba|{las ka'i gla char brten nas 'tsho thabs byed pa/}
 gling|1) {gtsang po'am rgya mtsho'i chus mtha' nas bskor ba'i skam sa che chung/ 'dzam bu gling/ mtsho dbus gling/ gser gling/ rin chen gling/ gling chen lnga/} 2) {dum bu dang/ cha shas/ zog sha bzhi gling gcig lug sha bzhi gling gsum/} 3) {dgon sde che khag la btags pa'i ming/ theg chen gling/ byams pa gling/ rin chen spungs pa'i gling/} 4) {(mngon) ri rab kyi khor yug tu zla ba dang/ 'od dkar/ ku sha/ mi'am ci/ khrung khrung/ drag po'i gling/ 'dzam gling chen po bcas gling bdun yod pas grangs bdun mtshon/}
 gling kha|{gling ga dang 'dra/}
@@ -7245,7 +7306,8 @@ gling ga|{lcags ri'am rwa bas bskor ba'i skyed tshal khang pa dang bcas pa/ gcan
 gling ge sar|{sgrung nas byung ba'i dmag gi rgyal po/}
 gling chen|{rgya mtshos bskor ba'i skam sa chen po/}
 gling chen 'jig rten shing rta ma|{(mngon) 'bab chu/}
-gling drug gling drug longs spyod kyi sa dang don gcig gling drug longs spyod kyi sa|{bsil ri'i nang gi ri mtsho gling gsum la nyi zla'i 'od zer mi 'phog kyang/ mi rnams rang 'od kyis 'tsho ba sogs lha dang longs spyod mnyam pas na/ gling drug longs spyod kyi sa ste zla ba dang/ 'od dkar/ ku sha/ mi'am ci/ khrung khrung/ drag po'i gling bcas so/}
+gling drug|{gling drug longs spyod kyi sa dang don gcig}
+gling drug longs spyod kyi sa|{bsil ri'i nang gi ri mtsho gling gsum la nyi zla'i 'od zer mi 'phog kyang/ mi rnams rang 'od kyis 'tsho ba sogs lha dang longs spyod mnyam pas na/ gling drug longs spyod kyi sa ste zla ba dang/ 'od dkar/ ku sha/ mi'am ci/ khrung khrung/ drag po'i gling bcas so/}
 gling bdun|{dus 'khor nas bshad pa'i ri rab kyi khor yug tu 'khod pa'i gling bdun te/zla ba dang/ 'od dkar/ ku sha/ mi'am ci/ khrung khrung/ drag po'i gling/ 'dzam gling chen po bcas so/}
 gling mda'|{dgon pa'am gling ga'i gsham/}
 gling phran|{rgya mtsho chen po'i dkyil du chags pa'i skam sa/}
@@ -7258,9 +7320,11 @@ gling me|{'das mchod skabs mtshan mor thog khar spar ba'i mchod me/}
 gling tshom|{rgya mtsho'i nang la phan tshun thag nye bar gnas pa'i gling phran khag gcig}
 gling 'dzin|{(mngon) sa gzhi/}
 gling bzhi|{ri rab kyi phyogs bzhi rgya mtshor chad pa'i gling chen bzhi ste/ shar lus 'phags po dang/ lho 'dzam bu gling/ nub ba lang spyod/ byang sgra mi snyan bcas so/}
-gling g.yog gling lag dang don gcig gling ras padma rdo rje|{rab byung gnyis pa'i sa pho sprel gyi lor gtsang myang stod du 'khrungs/ rang lo so brgyad par phag mo grub pa'i slob mar gyur/ rab byung gsum pa'i sa sprel lo sna phu dgon par gshegs/ de'i brgyud 'dzin gyi gtso bo gtsang pa rgya ras kyis skyid smad gnam gyi phur 'brug dgon pa btab pas 'brug pa bka' brgyud ces pa'i grub mtha'i ming chags/}
+gling g.yog|{gling lag dang don gcig}
+gling ras padma rdo rje|{rab byung gnyis pa'i sa pho sprel gyi lor gtsang myang stod du 'khrungs/ rang lo so brgyad par phag mo grub pa'i slob mar gyur/ rab byung gsum pa'i sa sprel lo sna phu dgon par gshegs/ de'i brgyud 'dzin gyi gtso bo gtsang pa rgya ras kyis skyid smad gnam gyi phur 'brug dgon pa btab pas 'brug pa bka' brgyud ces pa'i grub mtha'i ming chags/}
 gling lag|1) {gling kha'i le lag chung ngu/} 2) {dgon pa'i 'du khang gi nye 'dabs su yod pa'i lha khang dang/ dgon pa chen po'i nye 'dabs su yod pa'i ri khrod lta bu/} 3) {rgyug chu kha grams pa'i bar gyi skam sa dang/ gling chen gyi nye 'gram du yod pa'i gling chung/}
-gling log nang 'khrug gling bsre|{sngon gsang phu ne'u thog gi dgon par gling stod smad gnyis bzang 'gran gyi tshul du phan tshun bsres nas chos kyi rtsod pa mdzad pa la gling bsre zhes grags pa/phyis su 'bras spungs sod grwa sa gzhan du'ang de'i srol dar/}
+gling log|{nang 'khrug}
+gling bsre|{sngon gsang phu ne'u thog gi dgon par gling stod smad gnyis bzang 'gran gyi tshul du phan tshun bsres nas chos kyi rtsod pa mdzad pa la gling bsre zhes grags pa/phyis su 'bras spungs sod grwa sa gzhan du'ang de'i srol dar/}
 gling bsre'i dge bshes|{gdan sa 'ga' re'i tshogs chen du gling yongs kyi dge 'dun bsres te bza' btung gi chos ston bzang po gshom bzhin du mtshan nyid dam bca' 'jog pa'i dge bshes/}
 glings stan|{(rnying) phying ba'i gdan/}
 glings pa|{(rnying) phying ba'i stan/}
@@ -7277,7 +7341,7 @@ glu dbyangs lta bu'i sems bskyed|{sems bskyed nyer gnyis kyi nang gses/sa bcu pa
 glu dbyangs zla ba|{(mngon) hor zla bcu pa/}
 glu ma|1) {glu dbyangs gtong mkhan gyi bud med/} 2) {snyan zhing 'jebs pa'i glu dbyangs kyis lha tshogs mchod pa'i lha mo'i ming/}
 glu ma dbyangs|{nyams mgur ram mgur ma/ yid skyo ba'i glu ma dbyangs blangs/}
-glu tshig glu len pa'i tshig ste|{dbyangs su gyer chog pa'i tshig sbyor/}
+glu tshig|{glu len pa'i tshig ste/ dbyangs su gyer chog pa'i tshig sbyor/}
 glu gzhas|{glu dang/ gzhas/ glu gzhas mnyam gtong/}
 glu gzhas 'khrol 'dzin|{sngar smon lam tshugs dus lha sa'i mi dmangs kyi khyim du glu gzhas btang chog pa tshogs chen zhal ngor dgongs pa zhus pa'i 'khrol 'dzin/}
 glu len bro 'khrab|{glu gar mnyam byed/ dga' spro'i ngang nas glu len bro 'khrab byed pa/}
@@ -7290,15 +7354,14 @@ glud chas|{glud gtong skabs sprod pa'i rdzongs skal dngos chas/}
 glud gtor|{nad pa sogs kyi don du 'dre gdon la gtong ba'i gtor ma/}
 glud rdzas|{gtor glud dang mnyam du gtong ba'i rdzas sna tshogs/}
 glud yas|{glud dang rdzongs chas/}
-glum|{chang rtsi brgyab nas bsnyal ba'i 'bru btsos ma/ glum la chu}
-#btab nas chang gsing ba|
+glum|{chang rtsi brgyab nas bsnyal ba'i 'bru btsos ma/ glum la chu btab nas chang gsing ba/}
 gle|{chu gnyis bar gyi gram thang/}
 gle gdams pa|{sle 'dams pa dang 'dra/}
 gle 'dam can|{sle 'dam can dang 'dra/}
 gle bar|{gling phran/}
 gleg po|{(rnying) mthug po dang/ mi gsal ba/ glegs/ shing leb/ sgo glegs/}
 glegs chab|{chos thag gi sne mor sbyar ba'i chab tse'am chab mgo /}
-#glegs thag glegs bam 'ching byed kyi thag pa|
+glegs thag|{glegs bam 'ching byed kyi thag pa/}
 glegs bam|{glegs shing gi bar du bcug pa'i dpe cha po ti/}
 glegs bu|1) {chos gos kyi gling gru bzhir bcad pa'i grwa/} 2) {glegs bam sogs kyi ming dang/ ang grangs rnams rags tsam bkod nas mthong gsal sar btags pa'i dzar bu/} 3) {yig cha/ bka'i glegs bu/}
 glegs ma|{zangs lcags shing sogs las bzos pa'i leb mo pang leb lta bu/}
@@ -7337,9 +7400,9 @@ glo dkar can|{gzhang 'brum gcod byed kyi yo byed ldebs sam logs su bug pa yod pa
 glo dkar can pho|{pho'i gzhang 'brum gang na yod shes nas 'brum pa gcod byed kyi yo byad cig}
 glo dkar can mo|{mo'i gzhang 'brum gang na yod shes nas 'brum pa gcod byed kyi yod byad cig}
 glo skar|{glo dkar dang 'dra/}
-#glo khug gzhogs la 'dogs rgyu'iu khug ma|
+glo khug|{gzhogs la 'dogs rgyu'iu khug ma/}
 glo gri|{glor 'dogs pa'i gri chung shubs ldan/}
-glo 'gog glo brgyab ste lud pa 'gog pa|{ming gi rnam grangs la 'khogs pa dang/ glo rgyag pa/ lu ba/ lud 'bod pa bcas so/}
+glo 'gog|{glo brgyab ste lud pa 'gog pa/ ming gi rnam grangs la 'khogs pa dang/ glo rgyag pa/ lu ba/ lud 'bod pa bcas so/}
 glo rgod|{lug dang be'u sogs glo drag tu lu ba'i phyugs nad cig}
 glo rgyag|1) {glo lu ba'am langs pa/} 2) {glo bur/}
 glo rgyan|{gzhogs la 'dogs rgyu'i rgyan cha/}
@@ -7351,17 +7414,18 @@ glo cham|{cham pa glo bar bab pa zhig ste/ nad rtags su glo rgyag cing lud pa ma
 glo chung|{phyi glo'am rgyu glo/}
 glo mchin 'doms rtsa|{glo ba'i sgang rtsa dang mchin rtsa ru thung gnyis 'doms pa'i mkhrig ma'i tshigs 'bur rgyab ngos kyi gtar rtsa ste/ de gtar na mchin pa na ba dang/ mig sprin dmar ser chags pa/ glo lu ba bcas la phan/}
 glo snying|1) {nang khrol glo ba dang snying/ dngangs skrag skyes nas glo snying ldeg ldeg tu 'gul ba/} 2) {sems sam yid/ glo snying gtad pa/}
-glo snyin 'doms rtsa|{glo ba'i sgang rtsa dang snying rtsa snod kha gnyis 'doms pa'i 'khrig ma'i yar zur gyi rus 'bur nas gyen du song bzhi gzhal ba'i sar yod pa'i gtar rtsa ste/ de gtar na glo snying la tsha ba zhugs pa dang/ brang rgyab gzer ba/ khrag ngan rgyas pa/ glo langs nas lud pa/ 'gog dka' ba sogs la phan/}
+glo snying 'doms rtsa|{glo ba'i sgang rtsa dang snying rtsa snod kha gnyis 'doms pa'i 'khrig ma'i yar zur gyi rus 'bur nas gyen du song bzhi gzhal ba'i sar yod pa'i gtar rtsa ste/ de gtar na glo snying la tsha ba zhugs pa dang/ brang rgyab gzer ba/ khrag ngan rgyas pa/ glo langs nas lud pa/ 'gog dka' ba sogs la phan/}
 glo snying brang gsum gtod pa|{yid gnyis med par rtse gcig tu blo gtad 'chol ba/}
-#glo thag sga'i glo thag pa|
+glo thag|{sga'i glo thag pa/}
 glo 'dogs|{lus kyi glo g.yas g.yon la 'dogs pa'i gri dang khab shubs sogs/}
-glo rdeg glo bur|{glo rdeg tu mi mang po 'dzoms pa/}
+glo rdeg|{glo bur/ glo rdeg tu mi mang po 'dzoms pa/}
 glo ldeg pa|{snying 'gul ba/}
 glo nad|1) {mi phyugs kyi glo bar byung ba'i nad cig} 2) {nor phyugs la glo nad thog mar phog skabs nyal dus lus stod mthon por byas te nyal ba dang/ nang du glo ba rnag gis bzas te 'chi ba'i phyugs kyi 'gos nad che gras shig}
 glo nad brgyad|{glo nad theng po dang/ glo ba skya rbab/ glo tshad/ chu shor/ thes po/ glo gcong/ glo rgyas/ glo ba bung tshang bcas brgyad mchis so/}
 glo nad theng po|{glo nad rigs brgyad kyi nang tshan rlung dang 'doms pa'i glo nad de/ nad rtad glo 'gog dka' zhing dgong dang tho rengs kyi dus su wu sob can lu ba zhig}
 glo nad thes po|{glo nad brgyad kyi nang tshan lus stod lci zhing khengs la dbugs 'tshang ba dang/ lud pa lngo ljang du lu ba zhig}
-glo rnag glo bar tsha ba zhugs nas glo ba'i rtsa sbubs kyi khrag dang chu ser rnams rul nas rnag tu gyur pa zhig glo phug|1) {rtsig ldebs su brus pa'i ca lag 'jog sa/} 2) {rtsa lam gyi glo'am logs ngos nas gtar kha brgyab ste khrag 'don pa'i sman bcos byed thabs shig}
+glo rnag|{glo bar tsha ba zhugs nas glo ba'i rtsa sbubs kyi khrag dang chu ser rnams rul nas rnag tu gyur pa zhig}
+glo phug|1) {rtsig ldebs su brus pa'i ca lag 'jog sa/} 2) {rtsa lam gyi glo'am logs ngos nas gtar kha brgyab ste khrag 'don pa'i sman bcos byed thabs shig}
 glo phreng|{long phreng dang 'dra/}
 glo ba|1) {mi lus kyi byang khog stod du gnas shing/ don lnga'i ya gyal zhig ste/ de'i byed las ni dbugs kyi rten byed cing nang gi dbugs rnying pa phyir 'dor zhing/ phyi yi dbugs gsar pa nang du rngubs pa sogs byed pa yin no/ glo bar mi phan mchin pa'i dug} 2) {sems sam yid/ drang gtam gnas lugs tshang ma glo bar chud pa/}
 glo ba dkar ba|{sems dkar ba/}
@@ -7377,14 +7441,14 @@ glo ba ma lnga'i gsang|{rgyab kyi sgal tshigs bzhi pa glo ba ma lnga dang 'brel 
 glo ba ring ba|{rgyab gtod byas pa'am/ snying thag ring ba/}
 glo ba'i sgang rtsa|{gru mo'i phyi zur nas mas su sor bzhi gzhal mtshams kyi sgang zur du yod pa'i glo ba dang 'brel ba'i gtar rtsa ste/ de gtar na glo tshad dang/ skad 'gag pa sogs la phan/}
 glo bu|{glo ba'i mdun phyogs kyi cha shas chung ba/}
-glo bug glo gnyis la rma khung thon pa|{rta rgan rgyab chad glo bug}
+glo bug|{glo gnyis la rma khung thon pa/ rta rgan rgyab chad glo bug}
 glo bur|1) {ma bsams ma dran par 'phral du byung ba/ glo bur chags rkyen/ glo bur gyi nad/ 'grul pa glo bur du 'byor ba/ glo bur drag tu khros pa/ glo bur stag gis mi tshugs/nam mkhar sprin nag glo bur du 'khrigs pa/} 2) {gnyug ma min pa'am sngar med gsar du byung ba/ dri ma glo bur/}
 glo bur gegs dbang gdon skyod|{glo bur 'dre yis rgyud brlams pa ste/ nges med thog rgyag tu bar chad byung ba'i dpe/}
 glo bur gyi dri ma|{nyon mongs pa dang shes bya'i sgrib pa gnyis ni sems kyi rang bzhin la ma zhud par sems dang 'bral rung du yod pas na glo bur gyi dri ma zhes bya'o/}
-glo bur thog rgyag ma bsams ma dran pa'i ngang la gsar du byung ba'i rigs|{glo bur thog rgyag la lhags pa chen po langs pa/}
+glo bur thog rgyag|{ma bsams ma dran pa'i ngang la gsar du byung ba'i rigs/ glo bur thog rgyag la lhags pa chen po langs pa/}
 glo bur thog bab|{glo bur thog rgyag dang don gcig}
 glo bur dri bral gyi myang 'das|{glo bur gyi dri ma nyon sgrib spangs pa'i myang 'das/}
-#glo bur rnam dag glo bur gyi dri ma dang bral ba'i 'gog bden|
+glo bur rnam dag|{glo bur gyi dri ma dang bral ba'i 'gog bden/}
 glo bur ba|{thol gyis byung ba'am 'phral du byung ba'i gras/ bsam blo glo bur ba/ 'grul pa glo bur ba/}
 glo bur rma|{phyi rol nas mda' rdo gri mtshon sod phog pa'i rkyen las byung ba'i rma ste/ nang gses su dbye na bshus pa'i rma dang/ gshags pa'i rma sogs rigs brgyad mchis so/}
 glo 'bu'i nad|{nor lug gi glo bar 'bu zhugs pa'i nad cig}
@@ -7395,7 +7459,7 @@ glo ma|{glo ba'i rgyab phyogs kyi cha shas che ba/}
 glo rtsa|1) {sog pa'i me long 'og gi sngon bu dang gru mo'i sgang rtsa lta bu glo ba dang 'brel ba'i rtsa/} 2) {sems shugs dang bsam tshul/ don med gtam 'chal mang pos grogs po'i glo rtsa dkrugs/}
 glo tshad|{glo nad rigs brgyad kyi nang tshan glo bar tsha ba zhugs pa'i nad de/ nad rtags su lus stod mdun rgyab gzer zhing/ glo drag tu lu ba/ lud pa'i nang nas khrag 'byung ba zhig}
 glo zung|{khams phyogs kyi pho mo gnyis kas gzhogs la 'dogs rgyu'i rgyan cha zhig}
-glu|{glo ba 'dzin byed kyi yu ba ltar gyur pa dbugs rgyu ba'i lam ol krong gi ming gzhan zhig}
+glo yu|{glo ba 'dzin byed kyi yu ba ltar gyur pa dbugs rgyu ba'i lam ol krong gi ming gzhan zhig}
 glo len|{rta sga'i glo 'ching thag pa/}
 glo sho rgod|{(rnying) rig pa spyang ba/}
 glo sor|{glo yu'i lam nas sor sor zhes pa'i sgra 'byung ba'i glo nad cig}
@@ -7403,7 +7467,7 @@ glo gsang|{rgyab kyi sgal tshigs bzhi pa dang lnga pa glo ma dang glo bu 'brel b
 glo gsang bar pa|{lus kyi gsang gnad cig}
 glo gsang 'og ma|{lus kyi gsang gnad cig}
 glo gsud|{glo rgyun mi 'chad par rgyag stangs shig phru gu chung ngu de glo gsud rgyun mi 'chad par rgyag pa/}
-glog rnam gsal lam skad cig 'od|{'phrul 'khor nas glog 'don pa/ chu shugs glog 'don/ me shugs glog 'don/ rta yi bang rtsal glog 'khyug pa ltar rgyug pa/ mtshams rer yod cing/ mtshams rer med par 'gro ba de dag nam mkhar glog 'gyu ba ltar 'gyur skyen po 'dug mun nag tu glog rgyag pa/ ming gi rnam grangs la skad cig 'od dang/ skad cig gsal ba/ skyod byed/ sgra 'gyed/ chu skyes can/ chun mdzes can/ 'jug pa brgya pa/ bde 'thung/ sprin gyi lcug ma/ gzhi sngon skyes/ lus phra/ rnam gsal bcas so/}
+glog|{rnam gsal lam skad cig 'od/ 'phrul 'khor nas glog 'don pa/ chu shugs glog 'don/ me shugs glog 'don/ rta yi bang rtsal glog 'khyug pa ltar rgyug pa/ mtshams rer yod cing/ mtshams rer med par 'gro ba de dag nam mkhar glog 'gyu ba ltar 'gyur skyen po 'dug mun nag tu glog rgyag pa/ ming gi rnam grangs la skad cig 'od dang/ skad cig gsal ba/ skyod byed/ sgra 'gyed/ chu skyes can/ chun mdzes can/ 'jug pa brgya pa/ bde 'thung/ sprin gyi lcug ma/ gzhi sngon skyes/ lus phra/ rnam gsal bcas so/}
 glog skas|{glog shugs can gyi skas 'dzeg}
 glog skud|{glog rgyu sa'i lcags rigs kyi skud pa/}
 glog khang|{glog 'don sa'i 'phrul 'khor khang/}
@@ -7414,8 +7478,8 @@ glog dmar|{glog gi kha dog 'brug sgra ma bsgrags gong du glog dmar 'khyug drag c
 glog zhags|{glog 'od zhags pa'i gzugs su bkod pa/ char sprin nang du glog zhags yang yang 'khyug}
 glog bzhu|{glog gi nus par brten nas 'od 'byin pa'i sgron me/}
 glog 'od|{glog gi 'od mdangs/}
-glong thang sgrol ma lha khang|{srong btsan sgam po'i skabs btab pa khams 'dan ma sa khul du yod pa ru gnon gyi gtsug lag khang bzhi'i ya}
-gyal zhig glod bkrol|{glod pa/ btson pa glod bkrol btang ba/}
+glong thang sgrol ma lha khang|{srong btsan sgam po'i skabs btab pa khams 'dan ma sa khul du yod pa ru gnon gyi gtsug lag khang bzhi'i ya gyal zhig}
+glod bkrol|{glod pa/ btson pa glod bkrol btang ba/}
 glod pa|{(tha dad pa) 'grol ba'am gtong ba/ bcings pa glod pa/ sems glod pa/ gdong glod pa/ ma bzung ma glod par sdod pa/}
 glod shor|{btags pa dang bcug pa'i rigs glod pa'am/ rang bzhin gyis shor ba/ btson pa rnams glod shor med par do dam byed pa/}
 glon|{glon pa'i skul tshig}
@@ -7821,7 +7885,7 @@ dgongs pa 'tshoms pa|{khong khro za ba/ dus thog tu bcar ma thub pas dgongs pa m
 dgongs pa zab mo nges par 'grel pa'i mdo rgya cher 'grel pa|{mdo 'grel zhig thang rgyal rabs skabs yon tshes brtsams shing/ 'gos chos 'grub kyis bod yig tu bsgyur/ bar skabs rgya yig cha lag mi tshang bar gyur kyang/ bod yig po ti cha tshang yod par brten nye char rgya lo tsA ba byams pa kun mkhyen gyis ma tshang ba rnams bod yig nas rgya yig tu bsgyur/}
 dgongs pa'i klong|{blo rgya'am bsam blo'i nang/}
 dgongs rdzogs|{dgongs pa rdzogs pa ste shi pa'i zhe sa/}
-dgogns rdzogs rjes dran|{gshegs pa'i dran gso zhu ba/}
+dgongs rdzogs rjes dran|{gshegs pa'i dran gso zhu ba/}
 dgongs rdzogs dus mchod|{gshegs pa'i dus tshigs kyi mchod pa/}
 dgongs zhu|{dgongs pa zhu ba ste gnang ba zhu ba'i ming/}
 dgongs gzhi|{bsam blo gtong sa'i gzhi'am bsam don/}
@@ -8225,8 +8289,8 @@ mgo las dpung mtho|{go rim mi brtsi ba'i dpe ste ham pa chen po/}
 mgo las rma che ba|{don gyi rtsa ba las yal ga che ba/ gyod don chung ngu zhig la rnyog gra mang po mgo las rma che ba langs pa red/}
 mgo ling|{(mngon) yal ga /}
 mgo lus mtshungs pa|{cha tshad snyoms pa/}
-mgo len bsten bskyil|{mi gzhan mgo btad blangs nas bsten nyar byed pa/}
-mgo len pa|1) {gzhan gyis skyabs bcol ba ltar khas len pa/ dmag brgyab ste pham pa rnams kyi mgo len pa/} 2) {dgra yi ? bsad pa'i mgo bo rgyal rtags su len pa/}
+mgo len bsten bskyil|{mi gzhan mgo btags blangs nas bsten nyar byed pa/}
+mgo len pa|1) {gzhan gyis skyabs bcol ba ltar khas len pa/ dmag brgyab ste pham pa rnams kyi mgo len pa/} 2) {dgra ya bsad pa'i mgo bo rgyal rtags su len pa/}
 mgo log|{(yul)} 1) {rnyog 'dzing/ don med bya gzhag mang na mgo log btsal yong/} 2) {mtsho sngon zhing chen khongs mgo log bod rigs 'dus sdod kyi sa khul zhig}
 mgo log bod rigs rang skyong khul|{mtsho sngon zhing chen khongs kyi shar lho rgyud du yod/ 1954 lor rang skyong ljongs btsugs shing/ 1955 lor rang skyong khul du bsgyur/ de'i khongs su gcig sgril dang/ rma stod/ rma chen/ dga' bde/ pad ma/ dar lag bcas rdzong drug yod/ rang skyong khul mi dmangs srid gzhung de rma chen rdzong du yod/}
 mgo shu|{mgo la skyes pa'i rma shu/}
@@ -8298,7 +8362,7 @@ mgron ra|{mgron po sdod gnas/}
 mgron rogs|{mgron phal pa ste/ mgron gtso bo'i zhor la skad btang ba'i mgron po/}
 #mgron shog sku mgron gdan zhu'i brda tho shog lhe|
 mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
-'gag mdo|{gnad 'gag zam pa'i 'gag ri 'gag klung 'gag sgo 'gag gzims chung gi 'gag}
+'gag|{mdo/ gnad 'gag zam pa'i 'gag  ri 'gag  klung 'gag  sgo 'gag  gzims chung gi 'gag}
 'gag sgo|1) {sa mtshams kyi tshong khral bsdu ba sogs kyi 'gag sgo/} 2) {rtsa ba la thug pa'i don gnad/}
 'gag thung|{grwa pa'i stod 'gag}
 'gag dog po|{'phrang lam/ thang bde po byung na glu a li la mo/'gag dog po byung na bla ma o rgyan padma/}
@@ -8322,7 +8386,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'gan khur gtso skyong|{'gan khur ba gtso bo/}
 'gan 'khur ba|1) {las 'gan khas len byed pa/} 2) {'gan len pa po/}
 'gan 'khor|{'gan len las dus re mos su 'khor ba/}
-'gan 'jir|{(gnyidzar) mdzod ldan te/ khang bzang gi thog steng mdzes rgyan gser zangs las bzos pa zhig}
+'gan 'jir|{(gany+dzira) mdzod ldan te/ khang bzang gi thog steng mdzes rgyan gser zangs las bzos pa zhig}
 'gan ljid po|1) {khur chen po/} 2) {nyen kha chen po/ khos don med 'gan ljid po shod kyin 'dug}
 'gan nag|{(yul) sre da'am spre da/}
 'gan dbang|{las 'gan dang dbang cha/ 'gan dbang tshab 'dzin/ gzhan gyi 'gan dbang la the gtogs byed pa/}
@@ -8467,7 +8531,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'go rims|{'gos nad cig}
 'go ril|1) {nas kyi bye brag cig} 2) {bying ma spu rug gi 'go ma'i snam bu/}
 'go ling rgyas|{ljon shing gi rtse mo'i yal 'dab rgyas pa/}
-'go snyoms|{'gog pa'i snyoms 'jug gi bsdus tshig}
+'gog snyoms|{'gog pa'i snyoms 'jug gi bsdus tshig}
 'gog snyoms zhugs sems|{tshor 'du rags pa 'gog par byed pa'i snyoms 'jug gi sems so/}
 'gog bden|{'gog pa'i bden pa'i bsdus tshig}
 'gog bden gyi rnam pa bzhi|{'gog pa'i bden pa'i rnam pa bzhi dang don gcig}
@@ -8524,7 +8588,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'gyangs pa|{'gyang ba'i 'das pa/}
 'gyam|{(yul) 'gram/ brag 'gyam/ gad 'gyam/ phong 'gyam/ pha bong 'gyam/ ri'i 'gyam/ chu'i 'gyam/}
 'gyar 'gyur|{brtan po med pa'i rnam pa/ sems brtan 'gyar 'gyur med pa/}
-'gyig shing sdong dang rtswa rigs kyi nang nas byung ba'i 'byar bag can gyi spyin zhig 'gyig lham|{'gyig mdong/ 'gyig 'khor/}
+'gyig|{shing sdong dang rtswa rigs kyi nang nas byung ba'i 'byar bag can gyi spyin zhig  'gyig lham/ 'gyig mdong/ 'gyig 'khor/}
 'gyig byi ril|{mngar char 'gyig rgyu bsres pa'i byi ril/}
 'gying 'gros|{nyams chen po'i gom pa spo stangs/}
 'gying 'cham|{gar 'cham gyi bye brag cig}
@@ -8540,8 +8604,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'gyur skad|{skad kyi 'gyur khug}
 'gyur khug skad kyi snyan 'gyur|{glu dbyangs kyi 'gyur khug bde po'i skad snyan zhig rgyang ring nas thos byung/}
 'gyur bcos|{yig rigs shig yig rigs gzhan la bsgyur zin pa la slar bzo bcos byed pa/}
-'gyur ta re|{'gyur bar nges/ hur brtson ma byas na las don nyams par}
-'gyur ta re|{las don ngan pa byas na 'bras bu mi 'dod pa 'byung bar 'gyur ta re/}
+'gyur ta re|{'gyur bar nges/ hur brtson ma byas na las don nyams par 'gyur ta re/ las don ngan pa byas na 'bras bu mi 'dod pa 'byung bar 'gyur ta re/}
 'gyur rten|{(yul) tshong thag chod de rin ma byung bar du gzhan la mi 'tshong ba'i kha chad du bzhag pa'i dngos po/ zog rin grangs tshang sprod len byas mtshams sngar bzhag 'gyur rten dngul 'bor de dag rin 'bab thog nas gcog dgos/}
 'gyur ldog 'pho 'gyur|{dbyar dus kyi gnam gshis la 'gyur ldog chen po 'dug lo gcig nang gi gnas tshul la'ang 'gyur ldog mang po yong/ brtan brtan tig tig byas na 'gyur ldog byung yang nor mi yong/ las ka tshang ma 'gyur ldog gnas lugs nges can zhig yod pa sha stag yin/}
 #'gyur phyag bka' dang bstan bcos kyi gzhung bod du bsgyur ba'i tshe thog mar lo tsA ba rang nyid gus pa'i lha la phyag byas pa'o|
@@ -8562,7 +8625,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'gyur med 'tsho rten|{'pho 'gyur med pa'i 'tsho ba'i rten sa khang pa sogs/}
 'gyur med yongs grub|{yongs grub kyi nang gses/'khrul gzhi gzhan dbang dang 'khrul ba kun btags gnyis kas stong pa'i med dgag de bzhin nyid 'dus ma byas pa ste bdag med dang stong nyid do/}
 #'gyur tshig skad yig lo tsAs bsgyur ba'i rjod byed|
-'gro|{(mngon) chu/}
+'gyus 'gro|{(mngon) chu/}
 'gyus pa|{'gyu ba'i 'das pa/}
 'gyed|{dge 'dun sogs tshogs pa la 'bul rgyu'i dngul dang rgyu dngos gang rung/ ris med kun 'gyed/ sku 'gyed btang ba/}
 'gyed chen bzhi|{gcod lugs las bshad pa'i dkar 'gyed dang/ dmar 'gyed/ khra 'gyed/ nag 'gyed bcas bzhi/}
@@ -8795,8 +8858,7 @@ mgron bsu ba|1) {bos pa'i mgron po bsu mkhan/} 2) {lam 'grul la bsu ba byed pa/}
 'gros ma|{rta gom 'gros bzang po yod pa/}
 'gros bzhi|{rkang longs dbang gis gza' rnams la myur 'gros dang/ dal 'gros/ 'khyog 'gros/ 'byung 'gros bcas 'gros bzhi yod/}
 'gros bzang|{gom 'gros bzang ba/}
-rga ba|{(tha mi dad pa) rgas pa/ rga ba// lo na son pa dang na tshod yol ba ste/ shing tog smin nas rnying pa dang 'dra bar lus kyi phung po lnga po de dag rgyun gzhan dang gzhan du 'gyur nas tha ma skra dkar dang gnyer ma can la sogs pa'i bar du 'gyur ba'o/ lus rgas pa/ lo rgas kyang snying stobs che/ yun ring na nas gdong ris ha cang rgas 'dug khyi rgas}
-rim bzhin zhe sdang che|{gos chen rgas kyang ri mo'i gzhung/}
+rga ba|{(tha mi dad pa) rgas pa/ rga ba// lo na son pa dang na tshod yol ba ste/ shing tog smin nas rnying pa dang 'dra bar lus kyi phung po lnga po de dag rgyun gzhan dang gzhan du 'gyur nas tha ma skra dkar dang gnyer ma can la sogs pa'i bar du 'gyur ba'o/ lus rgas pa/ lo rgas kyang snying stobs che/ yun ring na nas gdong ris ha cang rgas 'dug khyi rgas rim bzhin zhe sdang che/ gos chen rgas kyang ri mo'i gzhung/}
 rga ba'i sdug bsngal|{sdug bsngal brgyad kyi ya gyal zhig ste/ gzugs dang lang tsho yongs su rgud de 'dod pa'i yon tan la ji bzhin longs su spyod pa'i mthu dang bral bas sdug bsngal ba'o/}
 rga bu|{(yul) pha glang dang ma 'bri las skyes pa'i be'u pho mo/}
 rga shi|1) {rga ba dang shi ba/} 2) {rten 'brel yan lag bcu gnyis kyi ya gyal zhig}
@@ -8983,8 +9045,9 @@ rgya 'don|{ching rgyal rabs skabs su gsar dar rgya sbyong dmag 'khri'i sa rten/}
 rgya 'dra|{gos rgya gser gyi 'dra/}
 rgya 'dre|{'khrug rtsod/ yin min bden rdzun gyi dbye ba 'byed rgyur rgya 'dre brgyab na mi phan/ kha phog sna phog gi tshig rtsub go 'phral du rgya 'dre rgyag snying bro ba/ mi la mi dgos rgya 'dre dang/ shing la mi dgos 'dzer pa/}
 rgya rdo|1) {rdo dkrugs ma zur can ring po/} 2) {'jal byed rgya ma'i rdo/}
-rgya nag yul gru rgya che zhing chas gos nag po gtso bo byed pa ste|{rang ri'i rgyal khab nang gtso cher rgya rigs 'dus sdod kyi sa khul rnams la zer/ ming gi rnam grangs la stong khun dang/ma ha tsi na'o/}
-rgya nag skag zlog rgya nag nas dar ba'i lo zla zhag dus kyi skag ngan bar chad phyir zlog gi cho ga zhig rgya nag gong ma|{sngar gyi krung go'i gong ma rim byung/}
+rgya nag|{yul gru rgya che zhing chas gos nag po gtso bo byed pa ste/ rang ri'i rgyal khab nang gtso cher rgya rigs 'dus sdod kyi sa khul rnams la zer/ ming gi rnam grangs la stong khun dang/ma ha tsi na'o/}
+rgya nag skag zlog|{rgya nag nas dar ba'i lo zla zhag dus kyi skag ngan bar chad phyir zlog gi cho ga zhig}
+rgya nag gong ma|{sngar gyi krung go'i gong ma rim byung/}
 rgya nag rgyal po|1) {rgya nag gong ma/} 2) {nywa lhog ske skrangs sogs gnyan nad la phan pa'i sman sbyor zhig}
 rgya nag lcags ri|1) {shar hran ha'e kon 'gag sgo nas nub ca yus kon 'gag sgo'i bar ring tshad spyi le drug stong bdun brgya tsam yod pa'i lcags ri ring po/} 2) {dkar yol dang gos chen sogs la lcags ri ring po'i ri mo yod pa zhig}
 rgya nag stong khun|{rgya nag dong kun dang don gcig}
@@ -9028,7 +9091,7 @@ rgya rtsi|{rgya nag nas thon pa'i shing la gtong rgyu'i rtsi/}
 rgya rtsi dug lo|{thang sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas shu ba dang rngo 'joms/ 'bras skran 'dul/ dug shas shin tu che/}
 rgya rtsis|{rgya nag yul nas bod du dar ba'i skar rtsis dang 'byung rtsis/}
 rgya brtson 'grus seng ge|{dus rabs bcu gcig pa'i thog mar jo bo rje dpal ldan a ti sha bod du gdan 'dren zhu mkhan lo tsa' ba zhig}
-rgya cha|1) {rgya rigs dang bod rigs 'dres pa'i phru gu/} 2) {rdzong zhig bod rang skyong ljongs kyi shar lho'i khul yar klungs gtsang po'i chu rgyud du yod/ rdzong mi dmangs srid gzhung de brum par yod/}
+rgya tsha|1) {rgya rigs dang bod rigs 'dres pa'i phru gu/} 2) {rdzong zhig bod rang skyong ljongs kyi shar lho'i khul yar klungs gtsang po'i chu rgyud du yod/ rdzong mi dmangs srid gzhung de brum par yod/}
 rgya tshad|1) {rgya khyon/} 2) {rgya gar nag sogs yul drod che sar 'byung ba'i tsha ba'i nad/}
 rgya tshigs|{bol gong tshigs kyi ming gzhan zhig}
 rgya tshugs|{sngar man ju gong ma'i skabs btsugs pa'i nyin gcig la slebs pa'i lam gyi bab tshugs/}
@@ -9119,7 +9182,7 @@ rgyags pa brgyad|{rigs bzang bas rgyags pa/ gzugs kyis rgyags pa/ lang tshos rgy
 rgyags spyod|{skyid lang shor ba'i spyod pa/}
 rgyags phye|{phyogs 'gro'i skabs kyi zas rigs/}
 rgyags sbyangs|{lto nar mar ster ba/ gos hrul gyon/ lto ngan zos nas bu'i rgyags sbyangs pa/}
-rgyags chad|{grod pa 'grangs pa'i tshad/}
+rgyags tshad|{grod pa 'grangs pa'i tshad/}
 rgyags zong|{phyogs 'gro'i skabs kyi zas rigs/}
 rgyags sha|{skyid lang/ rgyags sha langs nas spyod pa gang byung byas pa/}
 rgyang|1) {bar thag gi tshad/ mig rgyang thung ba/ rgyang ha cang ring po ma yin pa/} 2) {thag ring ba/ lam thag ring po rgyang gis chod pa/ rgyang du 'phen pa/ grong pa phan tshun gyi bar la mda' rgyang gang tsam re yod/ dngos po hral hrul rnams rgyang du bskyur ba/ gnam gru 'phur yong ba rgyang nas mthong ba/ dgra mkhar la me sgyogs kyi mde'u zhig rgyang nas phog pa/ phan tshun mi mthun pa rnams khag khag so sor rgyang bsrings nas bsdad pa/ rgyang gi gnyen las rgyud kyi khyim mtshes dga'/}
@@ -9872,7 +9935,7 @@ sger tshong|{mi sger gyi tshong las/}
 sger gzhis|{sngar dpon rigs so so'i sger gyi pha gzhis sam thab rten du byung ba'i gzhis ka/}
 #sger g.yog sger gyi g.yog po|
 sger ru|{sngar dpon rigs so so sger la dbang ba'i gnag phyugs sems can gyi ru ba/}
-sger lngas|{rgyal khab bam srid dbang zhig rgyal khab bam srid dbang gzhan zhig gi dbang sgyur 'og tu ma tshud par rang btsan du gnas pa/}
+sger langs|{rgyal khab bam srid dbang zhig rgyal khab bam srid dbang gzhan zhig gi dbang sgyur 'og tu ma tshud par rang btsan du gnas pa/}
 sger sems|{rang don gyi bsam pa/ mdza' brtse'i grogs por sger sems med pa'i rogs ram byed pa/}
 #sger gsog rang gis sger don du rgyu dngos gsog pa|
 sger lha|{rang rang la 'go ba'i lha srung/}
@@ -10089,13 +10152,12 @@ sgyu lus|{rnam pa med kyang sna tshogs snang ba'am/ snang yang rang bzhin ma gru
 sgyu lus bdun|{sgyu lus kyi dbye ba bdun ni/ dpe'i sgyu ma/ snang ba sgyu ma/ rmi lam sgyu ma/ bar do sgyu ma/ 'od gsal sgyu ma/ sprul pa sgyu ma/ ye shes sgyu ma bcas so/}
 sgyu shom|{yon tan ngoms pa/}
 sgyug po|{khyim bdag pho mo gang yin pa de'i pha/}
-sgyug po|{khyim bdag pho mo gang yin pa de'i ma/}
+sgyug mo|{khyim bdag pho mo gang yin pa de'i ma/}
 sgyur|{sgyur ba'i skul tshig}
 sgyur rtags|{sgyur rtsis rgyag dgos pa'i rtags/}
 sgyur thabs|{sgyur rtsis rgyag pa'i tshul lugs/}
 sgyur phyogs|{gtong 'then byed stangs/ rta kha srab kyis sgyur phyogs dang/ rgyal kha blon pos sgyur phyogs/}
-sgyur ba|{(tha dad pa) bsgyur pa/ bsgyur ba/ sgyur//} 1) {gzhi phar tshur spo ba/ mdog sgyur ba/ ming sgyur ba/ chos lugs bsgyur pa/ yul phyogs sgyur ba/ bsam blo sgyur ba/ kha lo sgyur ba/ dbang du bsgyur ba/ snam bu dkar po'i tshos mdog gang la sgyur sgyur red/} 2) {skad rigs phan tshun brje ba/ skad sgyur ba/ yi ge sgyur ba/ tshig sgyur ba/ don sgyur/ thad sgyur ba/ sgra sgyur ba/} 3) {grangs 'bor ldab kyis spel ba'am bsgyur bya de sgyur byed de'i grangs su spel ba/ sum sgyur/ lnga ldab kyis bsgyur pa/ ming gi rnam grangs la bsnun pa dang/ bsgres pa/}
-spel ba|{gsil ba bcas so/}
+sgyur ba|{(tha dad pa) bsgyur pa/ bsgyur ba/ sgyur//} 1) {gzhi phar tshur spo ba/ mdog sgyur ba/ ming sgyur ba/ chos lugs bsgyur pa/ yul phyogs sgyur ba/ bsam blo sgyur ba/ kha lo sgyur ba/ dbang du bsgyur ba/ snam bu dkar po'i tshos mdog gang la sgyur sgyur red/} 2) {skad rigs phan tshun brje ba/ skad sgyur ba/ yi ge sgyur ba/ tshig sgyur ba/ don sgyur/ thad sgyur ba/ sgra sgyur ba/} 3) {grangs 'bor ldab kyis spel ba'am bsgyur bya de sgyur byed de'i grangs su spel ba/ sum sgyur/ lnga ldab kyis bsgyur pa/ ming gi rnam grangs la bsnun pa dang/ bsgres pa spel ba/ gsil ba bcas so/}
 sgyur byed|{(mngon)} 1) {sa phag lo/} 2) {lo tsA ba/} 3) {sne 'khrid mkhan/}
 sgyur rtsis|{ldab mang por spel ba'i rtsis/}
 sgyur rtsis dgu mtha' re'u mig sgyur rtsis rgyag skabs mkho ba'i man ngag cig sgyur rtsom|{yi ge sgyur ba dang/ rtsom pa/}
@@ -10194,8 +10256,7 @@ sgra rig pa|{rig gnas che ba lnga'i ya gyal/ tshig gi 'khrul ba tshar gcod pa'am
 sgra rig pa'i bstan bcos|{sgra'i gzhung/}
 sgra la gzhol ba|{gzhol ba gsum gyi bzlas pa'i ya gyal te/ zla dkyil gyi steng du sngags phreng rang sgra sgrog par gsal gdab pa'o/}
 sgra lan|{brag ca/}
-sgra bshad|{nges tshig ste/ tha snyad kyi tshig 'bru so sor phral te de'i don bshad pa'i 'grel bshad rgyag tshul/ sgra bshad tsam gyis don yang dag pa shes mi thub/}
-sbal ba la chu skyes kyi sgra bshad du yod kyang|{chu skyes kyi sgra mi 'jug}
+sgra bshad|{nges tshig ste/ tha snyad kyi tshig 'bru so sor phral te de'i don bshad pa'i 'grel bshad rgyag tshul/ sgra bshad tsam gyis don yang dag pa shes mi thub/ sbal ba la chu skyes kyi sgra bshad du yod kyang/ chu skyes kyi sgra mi 'jug}
 sgra sing nge ba|{sgra chung zhing gsal bar thon tshul/ ting shags kyi sgra sing nge ba zhig thos/}
 sgra sil sil|{dril bu sogs kyi sgra 'byung tshul/}
 sgra gsang|{skad sgra/ sgra gsang mtho ba/}
@@ -10218,8 +10279,8 @@ sgrig chas|{'phrul 'khor dang khang pa sogs kyi yan lag tu gyur pa'i dngos chas/
 sgrig stangs|{sgrig lugs/}
 sgrig pa|{(tha dad pa) bsgrigs pa/ bsgrig pa/ sgrigs//}1) {gshom pa/ mi mang po star bsgrigs te phyin pa/ dmag dpung gi bkod pa gsar du bsgrigs pa/} 2) {sbyor ba/ snyan tshig kha 'thor ba rnams phyogs gcig tu bsgrigs pa/ shing kha bsgrigs pa/}
 sgrig rtsom|{gsar 'gyur sogs phyogs bsdus kyis rtsom pa/ sgrig rtsom par skrun/}
-sgrig 'jugs|{sgrigs lam dang ldan pa'i mnyam sdeb tshogs pa/}
-sgrig 'jugs med pa|1) {tshogs pa'i spyi sgrigs brtsi khur mi zhu ba/} 2) {tshogs pa'i nang du ma zhugs pa/}
+sgrig 'dzugs|{sgrigs lam dang ldan pa'i mnyam sdeb tshogs pa/}
+sgrig 'dzugs med pa|1) {tshogs pa'i spyi sgrigs brtsi khur mi zhu ba/} 2) {tshogs pa'i nang du ma zhugs pa/}
 sgrigs|1. {sgrig pa'i skul tshig }2. {tshul mthun lam lugs/ sgrigs yag po/ sgrigs med/ bya spyod ngan pa lang shor gyis sgrigs lad pa/ lus ngag gi bya spyod tshul dang mthun par sgrigs gcun pa/ ma rabs kyi kun spyod la brten nas sgrigs 'chal ba/}
 sgrigs khrims|{sgrigs lam dang khrims srol/ bag yod tshul mthun gyi sgo nas sgrigs khrims brtsi khur byas pa/ ngan spyod ngo khyer gyis sgrigs khrims 'dral ba/ sgrigs khrims dkrugs pa/}
 sgrigs dbyung|{sgrigs khongs nas phyir phud pa/}
@@ -10284,7 +10345,7 @@ sgrub ngag ltar snang gsum|{rtags tshul gsum ma tshang ba bkod pa don skyon can 
 sgrub ngag yan lag gnyis|{tshul gsum tshang ba'i sgrub byed ston pa'i sbyor ba 'god tshul gyi yan lag gnyis te/ chos mthun sbyor gyi ngag dang/ chos mi mthun sbyor gyi ngag go /}
 sgrub chag 'jags gsum|{khral 'ul sgrub pa dang/ chag yang gtong ba/ rang 'jags 'jog pa bcas la zer/}
 sgrub mchod|{yi dam sgrub cing mchod bstod sogs byed pa'i cho ga/}
-sgrub 'jug yul can gyis yul la 'jug tshul gyi khyad par zhig ste|{rtog med kyi shes pa rang yul la cha shas su mi phye bar rang yul du bsgrubs nas 'jug pa/ dper na bum 'dzin mig shes kyis bum pa bzung ba na bum pa'i steng gi byas mi rtag la sogs pa'i khyad par ram cha shas gcig kyang phar ma bsal bar thams cad tshogs pa'am 'dres pa'i sgo nas tshur rang gi yul du byas nas 'jug pa lta bu'o/}
+sgrub 'jug|{yul can gyis yul la 'jug tshul gyi khyad par zhig ste/ rtog med kyi shes pa rang yul la cha shas su mi phye bar rang yul du bsgrubs nas 'jug pa/ dper na bum 'dzin mig shes kyis bum pa bzung ba na bum pa'i steng gi byas mi rtag la sogs pa'i khyad par ram cha shas gcig kyang phar ma bsal bar thams cad tshogs pa'am 'dres pa'i sgo nas tshur rang gi yul du byas nas 'jug pa lta bu'o/}
 sgrub 'jug gi blo|{rang yul la cha shas su ma phye bar 'jug pa'i rig pa/ rtog med kyi shes pa'o/}
 sgrub 'jug gi blo don mthun|{mngon sum gyi shes pa'o/}
 sgrub 'jug gi blo don mi mthun|{rtog med log shes so/}
@@ -10396,7 +10457,7 @@ sgron pa|{(tha dad pa) bsgron pa/ bsgron pa/ sgron//}1) {'bul ba'i zhe sa/ snyan
 sgron ma|{sgron me dang 'dra/}
 sgron ma bzhi|{thod rgal gyi dngos gzhi sang ba yul gyi nad dbyings rig 'du 'bral med pa'i sku mngon sum du 'char bar byed pa'i lam ste/ rgyang zhags chu yi sgron ma dang/ rig pa dnyings kyi sgron ma dang/ thig le stong pa'i sgron ma dang/ she srab rang byung gi sgron ma bcas bzhi'o/}
 sgron me|{snang gsal lam mar me/ lag na sgron me thogs yod kyang/ long bas lam ni mthong mi 'gyur/ lhags pa chen po'i nang du sgron me 'bar mi thub par yang yang shi ba/ mar khu zad de sgron me gzims pa/ ming gi rnam grangs la khyim gyi nor bu dang/ snang gsas/ snum zam snum la dga'/ 'bar ba'i rla pa can/ mar me/ mtshan no'i snang byed bcas so/}
-sgron mi shing|{sgron shing dang 'dra/}
+sgron me shing|{sgron shing dang 'dra/}
 sgron shing|{shing sman gyi rigs shig sste/ ro mngar/ zhu rjes dro la snyoms/ nus pas bad rlung dang/ chu ser/ grang ba/ 'or nad bcas la phan/ shing des gsal sgron yang byed rung/}
 sgron shing dkar po|{ljon shing bye brag cig}
 sgrob|{'bying nyams dang/ dregs pa'i rnam 'gyur/ mi de pho sgrob che bas rang mnyam su dang yang mtun po mi 'dug 'dra chags chags kyi spros pa la dga' ba'i sgrob chen bas nas gzhung sger gyi rgyu dngos 'phro brlag tu btang ba/}
@@ -10521,7 +10582,7 @@ bsgags pa|{sgag pa dang sgog pa'i 'das pa/}
 bsgab pa|{sgab pa'i 'das pa dang ma 'ongs pa/}
 bsgar ba|{sgar ba'i 'das pa dang ma 'ongs pa/}
 bsgug pa|{sgug pa'i ma 'ongs pa/}
-sgugs pa|{sgug pa'i 'das pa/}
+bsgugs pa|{sgug pa'i 'das pa/}
 bsgur ba|{sgur ba'i 'das pa dang ma 'ongs pa/}
 bsgul ba|{sgul ba'i 'das pa dang ma 'ongs pa/}
 bsgo gyur gyi lhag ma bzhi|{dge 'dun lhag ma bcu gsum gyi nang gses/ dbyen byed pa dang/ de rjes phyogs pa dang/ khyim sun 'byin pa dang/ bka' blo mi bde ba bzhi ni/ bsgo ba las gyur pa'i lhag ma'o/}
@@ -10549,8 +10610,7 @@ bsgyur bcos|{rnying pa bsgyur nas gnas tshul gsar pa dang mthun pa byed pa/}
 bsgyur deb|{bsgyur rgyu'am bsgyur zin pa'i deb/}
 bsgyur pa|{sgyur ba'i 'das pa/}
 bsgyur ba|{sgyur ba'i ma 'ongs pa/}
-bsgyur ba ldem dgongs|{grags pa'i yi ge ngan pa ma grags pa'i don zab mo ston byed du}
-bsgyur ba ste|{snying po med la snying por shes zhes pa lta bu'o/}
+bsgyur ba ldem dgongs|{grags pa'i yi ge ngan pa ma grags pa'i don zab mo ston byed du bsgyur ba ste/ snying po med la snying por shes zhes pa lta bu'o/}
 bsgyur ba'i gnas|{sgra'i gnas brgyad kyi gsum pa ste/ skad kyi byings ma bsgyur ba la bsgyur bas the tshom mtha' dag sel ba ste/ dper na/ ka zhes pa tsam gyis the tshom dang sgro 'dogs mi chod la/ bka' zhes pa lta bu sngon rjes kyis bsgyur bas/ bka' lung la go ba bzhin de ltar yi ge byings la sgra sgrub byas pas the tshom thams cad sel ba'o/ ka/ bka'/}
 bsgyur bon|{bod rgyal khri srong lde'u btsan nas glang dar ma'i bar pandi ta sham thabs sngon po can dang/ rgyal ba'i byang chub zer ba dang gshen sgur klu dga' sogs kyis nang pa'i chos lugs khag bon du bsgyur pa'i lugs la zer/ bsgyur bon la chab dkar zer te 'bras bu'i bon zhes kyang zer/ bon lugs kyi glegs bam rnams dus 'di nas byung ba yin/}
 bsgyur byang|{bka' bstan mjug gi lo tsAs bsgyur rabs/}
@@ -10643,7 +10703,7 @@ nga ro dkyus ma|{klad kor ram rjes su nga ro ste/ sgra'i yi ge'i steng du bris n
 nga ro can|{(mngon) seng ge /}
 nga lan khyod lan|{nyes skyon byung ba'i ngan khag phan tshun pg.yog res byed/ las 'gan thad nga lan khyod lan ma yin par phyar ba gru 'degs byed pa/}
 nga las nu|{'khor los sgyur rgyal zhig}
-ngag skyes bu'i lce rkan mchu so sogs kyi rtsol ba las byung ba'i rjod byed kyi sgra gang zhig rang yul khyad chos 'jug ldog gi gzhi dang sbyar nas rjod par byed pa|{dper na bum pa chung ngus chu skyor cig ces pa'i sgra lta bu'o/ snyan ngag gdams ngag man ngag lus ngag yid gsum/ ngag ldab ldib/ ngag tu mi smra ba/ 'jam bshad kyi ngag nyan pa/ ngag brel gyi gtam/ ngag 'jam po byas na don go sla/}
+ngag|{skyes bu'i lce rkan mchu so sogs kyi rtsol ba las byung ba'i rjod byed kyi sgra gang zhig rang yul khyad chos 'jug ldog gi gzhi dang sbyar nas rjod par byed pa/ dper na bum pa chung ngus chu skyor cig ces pa'i sgra lta bu'o/ snyan ngag gdams ngag man ngag lus ngag yid gsum/ ngag ldab ldib/ ngag tu mi smra ba/ 'jam bshad kyi ngag nyan pa/ ngag brel gyi gtam/ ngag 'jam po byas na don go sla/}
 ngag kyal|{don snying med pa'i skad cha/ don ldan gyi 'phros mol bzhag nas don med kyi ngag kyal kho na shod kyin sdod pa/}
 ngag bkod|{skad cha'i thog gi slob ston/ ngag bkod dang len/ las ka byed lugs byed stangs kyi ngag bkod byed pa/}
 ngag bkyal|{ngag kyal dang 'dra/}
@@ -10660,7 +10720,7 @@ ngag gi rnam par rig byed|{sems kyi dbang gis ngag gi rang bzhin gyi sgra byung 
 ngag gi spyod yul|{ngag gis brdzod thub pa'i gnas/}
 ngag gi dbang phyug|{(mngon) 'jam pa'i dbyangs/}
 ngag gi rtsal gsum|{pho rtsal sna dgu'i nang gses/ lo rgyus kyis dge thon pa/ gtam gyis bzhad gad thon pa/ gshags kyis pha rol gnon pa bcas so/}
-ngag gi mchon cha|{(mngon) lha/}
+ngag gi mtshon cha|{(mngon) lha/}
 ngag gi las|{ngag gi sgo nas bsags pa'i las te rdzun smra ba sogs ngag gi las mi dge ba dang/ rdzun smra ba spang ba sogs ngag gi las dge ba lta bu/}
 ngag gi las thams cad ye shes sngon du 'gro zhing ye shes kyi rjes su 'brang ba|{sngar ye shes kyis sems can gyi don du gang 'gyur ba gtan la phab nas sems can gyi bsam pa dang mthun par yan lag drug cu dang ldan pa'i gsung 'byung ba ste/ sangs rgyas kyi ma 'dres pa'i chos btso brgyad kyi nang gses shig}
 ngag gi las lam|{ngag gis byas pa'i las dang las kyi 'jug sgo/}
@@ -10748,7 +10808,7 @@ ngan 'gro|{rgyu mi dge ba'i las che ba mang du bsags nas 'bras bu sdug bsngal ch
 ngan 'gro thams cad yongs su sbyong ba gtsug tor rnam par rgyal ma|{gzungs kyi bye brag cig rgya gar gyi mkhan po dzi na mi tra dang/ su rentra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur pa'o/}
 ngan 'gro ba|{ngan 'gro gsum du skyes pa'i sems can/}
 ngan 'gro gsum|{dmyal ba/ yi dwags/ dud 'gro ste gsum/}
-ngan 'gro'o mthil|{(mngon) dbyal ba/}
+ngan 'gro'i mthil|{(mngon) dbyal ba/}
 ngan 'gro'i sdug bsngal|{ngan song gsum gyi sdug bsngal te/ dmyal ba la tsha grang gi sdug bsngal dang/ yi dwags la bkres skom gyi sdug bsngal/ dud 'gro la bkol spyod kyi sdug bsngal bcas so/}
 ngan 'gro'i lam|{(mngon) mi dge ba/}
 ngan rgu|{ngan pa'i rigs sna tshogs sam/ yod tshad/ gzhi gcig la bkra mi shis pa'i mtshan ltas ngan rgu tshang ba/ rten 'brel legs tshogs sgrig sgo gcig gis mi shis mtshan ltas ngan rgu thub pa/}
@@ -11091,7 +11151,7 @@ ngo 'dzum dkar nag dga' sdug gi ngo gdong dkar nag ngo 'dzum gting gnag kha 'dzu
 ngo rdzun brje ba|{bden pa khungs thub rigs la bzo bcos kyis lhad 'jug pa'am rdzun ma dang brje po rgyag pa/}
 ngo zil|{ngo'i gzi mdangs/ mi ngo zil che ba'i dpa' bo/}
 ngo zum pa|{gdong nag po bstan pa/ kha sbos ngo zum/}
-ngo zlog ngo slog pa ste re ba byas pa khas mi len pa|{khas len rgyab bskyur gyis ngo zlog byed/ snang ba gdong 'ded kyis ngo zlog byed pa/ yang yang nan skul byas pa'i ngo ldog dka'/ ngo ma zlog}
+ngo zlog|{ngo slog pa ste re ba byas pa khas mi len pa/ khas len rgyab bskyur gyis ngo zlog byed/ snang ba gdong 'ded kyis ngo zlog byed pa/ yang yang nan skul byas pa'i ngo ldog dka'/ ngo ma zlog}
 ngo zlog gi tshig|1) {gdong thug gis rgol ba'i gtam/} 2) {re ba khas mi len pa'i tshig}
 ngo ya|{kha ya'am kha gtad/ kha mchu'i ngo ya/ rtsod pa'i ngo ya/ dpa' bo'i ngo ya lon par dka'/}
 #ngo g.yog sku no'am dpon dang 'khor g.yog dpon ngo g.yog tshang ma lhan du phebs pa|
@@ -11120,8 +11180,7 @@ ngoms|{ngom pa'i skul tshig}
 ngoms pa|1. {ngom pa'i 'das pa/ }2. {(tha mi dad pa) tshim pa/ lta bas mi ngoms/ ham sems che ba'i mi de ngoms mi shes/ }3. {ngoms pa'i ming/}
 ngoms pa med pa'i sdug bsngal|{'dod yon gyis ngoms mi shes pa'i sdug bsngal te sdug bsngal drug gi ya gyal zhig}
 ngor snang btsan mong|{stag ri gnyan gzigs skabs kyi blon po zhig ste/ khong gis bre phul srang bcos nas 'bru mar tshad kyis bcal/ dga' gnyis tshong byas mthun gnyis la lung bsdebs/ de gong bod na tshong dang bre srang med/ de phyir mdzangs mi bdun gyi nang gses su grags/}
-ngor rdzong gnyis|{dpal ldan sa skya ba'i gsang}
-sngags kyi bstan pa 'dzin mkhan ngor chen kun dga' bzang po dang|{rdzong pa kun dga' rnam rgyal gnyis/}
+ngor rdzong gnyis|{dpal ldan sa skya ba'i gsang sngags kyi bstan pa 'dzin mkhan ngor chen kun dga' bzang po dang/ rdzong pa kun dga' rnam rgyal gnyis/}
 ngor lugs|{sa skya'i grub mtha' 'dzin mkhan/ ngor chen kun dga' bzang po/ sems dpa' dkon mchog rgyal mtshan/ dkon mchog lhun grub sogs nas brgyud pa'i lugs/}
 ngos|1. 1) {phyogs/ shar ngos/} 2) {logs/ ri ngos/ gyang ngos/ me long gi ngos/ ngos 'jam po/ ngos mnyam pa/ ngos snyoms pa/ ngos gzar po/ ngos yangs pa/} 3) {mdun/ ngos zas dang lkog zas/ gtam ngos su shod/ }2. {bdag ngos rang blo gros dman po yin/}
 ngos chod|{ngo shes pa/ rag gser gang yin ngos chod/ mtshan mor mi zhig thug kyang ngos mi chod/}
@@ -11175,7 +11234,7 @@ dngul tig tig ta rigs brgyad kyi nang tshan me tog dkar po 'char ba zhig ste|{ro
 dngul ting|{dngul las bzos pa'i yon chab 'bul snod ting phor/}
 dngul tib|{(yul) dngul las bzos pa'i ja chang gi snod/}
 dngul tel|{dngul las bcos pa'i nad dmigs sreg byed kyi tel pa ste/ nus pas 'bras nad dang/ rtsa dkar sogs kyi nad la phan/}
-dngul tam|{dngul sgor mo'i bye brag cig}
+dngul Tam|{dngul sgor mo'i bye brag cig}
 dngul gter|{dngul gyi gter kha/}
 dngul rta rmig ma|{rta'i rmig pa 'dra ba'i dngul lugs ma/}
 dngul ltir|{dngul las bzos pa'i khog ltir/}
@@ -11190,7 +11249,7 @@ dngul mdung|{smin dbrag gi dkyil nas g.yon ngos su tshon gang re gzhal ba dang/ 
 dngul mdong|{dngul shan brgyab pa'i snod spyad mdong mo/}
 dngul rdo|{rdo sman gyi rigs shig ste/ ro bska/ zhu rjes bsil/ nus pas rus chag gso/ chu ser skem/}
 dngul rdo tshad|{bod dngul srang lnga bcu/}
-dngul sbyad|{dngul gyi yo byad/}
+dngul spyad|{dngul gyi yo byad/}
 #dngul phag dngul lugs ma sa phag gi dbyibs can|
 dngul phogs|1){dngul gyi thog nas sprad pa'i phogs/} 2){sngar dgon sde rnams nas dngul bun btang ba'i skyed thog nas grwa pa rnams la sprod pa'i dngul phogs/}
 dngul phor|1) {dngul las bzos pa'i 'thung snod tshags ris ma/} 2) {dngul shan brgyab pa'i shing phor/}
@@ -11442,8 +11501,7 @@ mngon shes lnga|{rdzu 'phrul gyi mngon shes dang/ lha'i mig gi mngon shes/ lha'i
 mngon shes drug|{mngon shes lnga'i steng du/ zag zad mkhyen pa'i mngon shes bsnan pas drug ste/ sangs rgyas kho na la mnga' ba'i mngon par shes pa'o/}
 mngon shes drug ldan|1) {(mngon) sangs rgyas/} 2) {mngon shes drug dang ldan pa/}
 mngon sum|1) {'khrul ba min pa'i dngos gnas/ rigs lam mngon sum gyis bsal ba/ byas rjes mngon sum du bzhag pa/ sngar gyi lo rgyus rnams mngon sum mtshon pa/} 2) {lkog gyur min pa'i thad ka/ mig gis mngon sum du mthong ba/ tshig rtsub mngon sum du brjod pa/ mngon sum du skyon brjod byed pa/} 3) <{pratyaksha}>{ blo rig bdun gyi nang gses/ rtog bral ma 'khrul ba'i shes pa/ dper na/ bum 'dzin dbang mngon dang/ gzhan sems shes pa'i mngon shes dang/ 'phags pa'i mnyam bzhag ye shes lta bu'o/}
-mngon sum gyi bcad shes|{bcad shes kyi nang gses/ rang 'dren byed mngon sum tshad mas rtogs zin pa de slar yang rtogs pa ste/ dbang}
-mngon lnga'i skad cig gnyis pa lta bu dbang mngon gyi bcad shes dang|{bum 'dzin mngon sum dang rtog pa gnyis kyi skad cig gnyis pa nyams su myong ba'i rang rig lta bu rang rig mngon sum gyi bcad shes dang/ mthong lam pa'i rgyud kyi bden bzhi'i rnam pa bcu drug mngon sum du rtogs pa'i ye shes skad cig gnyis pa lta bu rnal 'byor mngon sum gyi bcad shes rnams so/}
+mngon sum gyi bcad shes|{bcad shes kyi nang gses/ rang 'dren byed mngon sum tshad mas rtogs zin pa de slar yang rtogs pa ste/ dbang mngon lnga'i skad cig gnyis pa lta bu dbang mngon gyi bcad shes dang/ bum 'dzin mngon sum dang rtog pa gnyis kyi skad cig gnyis pa nyams su myong ba'i rang rig lta bu rang rig mngon sum gyi bcad shes dang/ mthong lam pa'i rgyud kyi bden bzhi'i rnam pa bcu drug mngon sum du rtogs pa'i ye shes skad cig gnyis pa lta bu rnal 'byor mngon sum gyi bcad shes rnams so/}
 mngon sum gyi gnod pa|{mngon sum gyis bsal ba'o/}
 mngon sum gyi shes pa|{rtog bral gyi shes pa/}
 mngon sum gyis bsal ba|{bsal ba bzhi'i gras/ dam bca' dang mngon sum gyi myong ba dang 'gal ba/ dper na/ sgra mnyan bya min par 'dod pa lta bu'o/}
@@ -11568,7 +11626,7 @@ rngo shu|{rngo nad za phrug can/}
 #rngog sngar bod kyi rigs rus shig ste lo tsA ba chen po rngog blo ldan shes rab dang rngog legs pa'i shes rab gnyis rigs rus de las byung ba yin|
 rngog dkar|{rta drel gyi rngog ma dkar po/ rnga nag rngog dkar can gyi rta/}
 rngog chos sku rdo rje|{mar pa'i slob ma ka chen bzhi'i nang gses/ gzhung bshad chu bo'i rgyun lta bu'i bka' bab yin/ khong rab byung dang po'i me byi lor 'khrungs/ rab byung gnyis pa'i chu stag lor 'das/}
-rngog sten|{gdan grum ze/}
+rngog stan|{gdan grum ze/}
 rngog stan grum rtse|{bdan gyi bye brag cig}
 rngog stan grum ze|{rngog stan grum rtse dang 'dra/}
 rngog blo ldan shes rab|{rngog lo yab sras la stos/}
@@ -11846,7 +11904,7 @@ sngon 'gro ba|{sngon skyod pa ste/ snga mar 'gro mkhan/}
 sngon 'gro'i khrid yig kun bzang bla ma'i zhal lung|{rdzogs chen dpal dge sprul sku 'jigs med chos kyi dbang pos mdzad pa'i klong chen snying thig gi sngon 'gro'i khrid yig ste/ thun mong phyi'i sngon 'gro/ thun min nang gi sngon 'gro/ nyams len dngos gzhi'i rim pa/ nye lam 'pho ba'i cha lag dang bcas pa'i dmigs rim rnams nyams khrid du bshad pa'i gzhung/}
 sngon chags|{(mngon) 'khor ba/}
 sngon chad|{da lta phan chad/ sngon chad byas pa'i bya bar da lta phyi bltas byed pa/}
-sngon chog bsnyen par rdzogs pa la tshegs chung ngus rdzogs pa sngon gyi cho ga zhes sangs rgyas zhal bzhugs dus mkhan po 'phags pa yin pa dang|{gdul bya blo dag pa ste las nyon rnam smin gyi sgrib pa shas chung zhing/ shes srab dang/ rgyud dang/ dbang po gsum smin pa'i gang zag kho na la sdom pa 'bog pa'i cho ga zhig}
+sngon chog|{bsnyen par rdzogs pa la tshegs chung ngus rdzogs pa sngon gyi cho ga zhes sangs rgyas zhal bzhugs dus mkhan po 'phags pa yin pa dang/ gdul bya blo dag pa ste las nyon rnam smin gyi sgrib pa shas chung zhing/ shes srab dang/ rgyud dang/ dbang po gsum smin pa'i gang zag kho na la sdom pa 'bog pa'i cho ga zhig}
 sngon chog bcu|{sangs rgyas mya ngan las ma 'das gong gi bsnyen par rdzogs pa'i sngon gyi cho ga bcu ste/ rdzogs pa'i sangs rgyas dang rang sangs rgyas gnyis zad mi skye shes nas byang chub brnyes pa'i rang byung gis bsnyen par rdzogs pa gnyis dang/ lnga sde bzang po mthong lam skyes tshe ye shes khong chud kyis dang/ shA ri'i bu sogs tshur shog gis dang/ 'od srung chen po ston par khas blangs pas dang/ bzang sde tshogs drug cus skyabs gsum khas blangs pas dang/ skye dgu'i bdag mo sogs lci chos brgyad bslab par khas blangs pas dang/ legs byin dris pa'i lan la dgyes pas dang/ mchod sbyin ma pha ma'i dbang du song ba la dge slong ma autapa las pho nya byas te dge 'dun gyis phrin chog la brten nas dang/ dge 'dun gyi grangs yul dbus su bcu tshogs dang/ mtha' 'khob tu lnga tshogs so sos gsol bzhi'i las kyi rab byung bsnyen rdzogs cig char du byed pa rnams so/}
 #sngon 'jug rang rang 'jug rung du gyur pa'i ming gzhi'i sngon du 'jug pa'i yi ge|
 sngon 'jug lnga|{ming gzhi'i sngon du 'jug pa'i yi ge ga da ba ma 'a ste lnga po 'di'i rtags la ba pho dang/ ga da ma ning/ 'a mo/ ma shin tu mo bcas nang gses dbye ba bzhir phye yod pa/ ga da ba ma 'a ba ga da 'a ma}
@@ -12071,7 +12129,7 @@ cus tse|{(rgya) shog sgril tha mag 'then byed dang/ gang zag 'then byed 'jib kha
 ce na|{zer na'am bshad na ste ga da ba dang da drag bcas kyi mthar sbyar nas rgyu rkyen ston byed dam dri bas mtshams sbyor byed kyi phrad gzhan dbang can zhig ga da ba da drag yong mkhan 'dug gam mi 'dug ce na/ da dung yod dam med ce na/}
 ce spyang|{khyi spyang/ ming gi rnam grangs la ngan g.yo ma dang/ ba lang 'tshe/ mtshan mo'i ri dwags/ wa skyes/ ri dwags khram pa/ sa myos/ slu byed bcas so/}
 ce spyang mgo|{rlung khrag pus mor babs pa'i nad de/ nad rtags su ngar gdong nas gnyan gong sbal nag gi bar ce spyang gi mgo bo ltar skrangs pa zhig}
-ce spyang rwa/rgya gar du ce spyang zhes pa'i gcan gzan zhig yod pa de ce spyang nas ce spyang gzhan gyi bar ma chod pa'i skye ba lnga pa na rwa skyes pa de nor bu yin par bshad/ nus pas nor phyugs kyi nad rnams srung/
+ce spyang rwa|{rgya gar du ce spyang zhes pa'i gcan gzan zhig yod pa de ce spyang nas ce spyang gzhan gyi bar ma chod pa'i skye ba lnga pa na rwa skyes pa de nor bu yin par bshad/ nus pas nor phyugs kyi nad rnams srung}
 ce re|{mig gdangs te mi g.yo bar lta ba'i khyad par zhig mig thad kar ce re lta ba/ zhal 'dzum pa dang bcas pa'i ngang nas cung zhig bdag la spyan ce re gzigs kyin 'dug}
 ce re long ba|{lta ba ltar snang yang mi mthong ba ste ha re long ba/}
 ce le ba|{thar thor/}
@@ -12097,7 +12155,8 @@ co pa|{(yul) lo gnyis lon pa'i rte'u/}
 co bregs|{ze dang rnga ma bregs ma thag pa'i lo gnyis lon pa'i rte'u/}
 co re|1) {'thung ba'am rngub pa'am blug pa'i sgra/} 2) {chang skyur mo/} 3) {ro skyur mo/}
 co le ba|1) {tho re ba'am phra mo/ nyes pa co le ba tsam gyis kyang ma gos pa/} 2) {cu li dang 'dra/}
-cog rdzogs tshig gi mthar sbyar nas tshang ma dang mtha' dag gi don ston pa'i tshig grogs shig rdzogs tshig yin no cog skyes so cog rgyu nor yod do cog rgya dpe bod yig tu bsgyur to cog cog khebs|{cog tse'i khebs/}
+cog|{rdzogs tshig gi mthar sbyar nas tshang ma dang mtha' dag gi don ston pa'i tshig grogs shig rdzogs tshig yin no cog skyes so cog rgyu nor yod do cog rgya dpe bod yig tu bsgyur to cog}
+cog khebs|{cog tse'i khebs/}
 cog gur|{mi gcig sdod sa'i gur chung ngu/}
 cog ge|{tsog tsog ri bong cog ger bsdad 'dug}
 #cog cog tsog tsog khang pa cog cog steng du dar chen zhig btsugs|
@@ -12208,8 +12267,7 @@ gcin 'gags|{lgang pa dang/ rgyu grog gi gnas su rde'u 'phel ba sogs kyi rkyen by
 gcin snyi|{rlan can yul du rgyun ring sdod pa dang bad tshil 'phel ba sogs kyis rkyen gyis rgyun ldan ltar ma yin pa gcin pa grangs mang du gtong dgos pa'am dbang med du shor ba'i don/}
 #gcin stug dri chu dag dri chen|
 gcin dreg dri chu'i dreg pa|{sman pas de gzhir bzung nas nad gzhi brtag dpyad byed sa zhig}
-gcin pa|{dri chu/ gcin pa bro ba/}
-gcin dri kha ba|{gcin pa gtong dus gsang spyod dran/ ming gi rnam grangs la rgyun 'bab dang/ dri chu/ mi bskyod pa/ rab 'dzag bcas so/}
+gcin pa|{dri chu/ gcin pa bro ba/ gcin dri kha ba/ gcin pa gtong dus gsang spyod dran/ ming gi rnam grangs la rgyun 'bab dang/ dri chu/ mi bskyod pa/ rab 'dzag bcas so/}
 gcin phyi sa|{gcin pa dang skyag pa/}
 gcin bzed|{chab tog gam gcin snod/}
 gcin lam|{gcin pa 'bab lam/}
@@ -12346,8 +12404,9 @@ bcad mtshams|{phan tshun dbye ba bcad pa'i bar mtshams/ khrims kyi bcad mtshams/
 bcad shul skyes pa|{(mngon) skra dang sen mo sogs/}
 bcad shes|{blo rig bdun gyi nang gses/ rtogs zin rtogs pa'i rig pa ste/ rang 'dren byed kyi tshad mas rtogs zin gyi don slar yang rtogs pa/ dper na bum 'dzin mngon sum skad cig gnyis pa dang/ sgra mi rtag rtog pa'i rjes dpag skad cig gnyis pa lta bu/ tshad ma'i shes pas sgro 'dogs bcad zin pa de slar yang shes pa'o/}
 bcad lhag 'breg gcod byas pa'i lhag 'phro|{gos chen bcad lhag shing tog bcad lhag}
-bcad lhug tshigs bcad dang tshig lhug bcad lhug spel ma|{tshigs bcad tshig lhug 'dres ma/}
-#bcad lhug spel ma'i snyan tshig tshigs bcad dang tshig lhug 'dres ma'am rim bzhin spel ba'i snyan ngag gi tshig rgyan|
+bcad lhug|{tshigs bcad dang tshig lhug}
+bcad lhug spel ma|{tshigs bcad tshig lhug 'dres ma/}
+bcad lhug spel ma'i snyan tshig|{tshigs bcad dang tshig lhug 'dres ma'am rim bzhin spel ba'i snyan ngag gi tshig rgyan/}
 bcad lhug spel gsum|{tshigs bcad tshig lhug so so dang de gnyis ad lhug spel gsum/}
 bcab pa|{'cab pa'i ma 'ogns pa/}
 bcab pa'i bsam pa|{byas nyes sogs gzhan la gsang ste sba ba'i bsam pa/}
@@ -12355,8 +12414,8 @@ bcabs pa|{bchab pa'i 'das pa/}
 bcam pa|{gcom pa'i ma 'ongs pa/}
 bcams pa|{gcom pa'i 'das pa/}
 bca' ka|{yo byad/ rab gnas rgyas pa'i bca' ka sta gon thams cad tshang bar gyis/}
-bca' dgu|{ca dgu dang 'dra/}
 bca' khrims|{chog dang mi chog gi bya rim rnam gzhan ston pa'i khrims/ bca' khrims ltar khrims bcod byed pa/}
+bca' dgu|{ca dgu dang 'dra/}
 bca' 'grig cha tshang|{rta sga 'khor bcas bcas 'grig cig go lag bca' 'grig}
 bca' sga|{bza' dang bca' zhes kha zas kyi ming yin pas/ 'dir ka zas la 'debs rgyu'i spod kyi nang tshan sga smug rlon pa'i ming/}
 #bca' sgrig sngon du grabs gshom byed pa|
@@ -12413,7 +12472,6 @@ bcu gnyis drug sna|{sngar khral rkang bcu gnyis re'am 'don drug re'i sa nas gzhu
 bcu gnyis bdag po|{(mngon) nyi ma/}
 bcu gnyis ma|{(mngon) bud med/}
 bcu gnyis mig ldan|{(mngon) gzhon nu gdong drug}
-bcu gnyis 'od 'phro|{(mngon) gza' phur bu/}
 bcu gnyis 'od 'phro|{(mngon) gza' phur bu/}
 bcu ltir|{(yul) dngul srang bcu ri ba'i chang blug sa'i snod khog ltir/}
 bcu drug grangs ka bcu dang drug ming gi rnam grangs la rgyal po dang|{cha shas/ mi bdag bcas so/ bcu drug cha/} 1) {zla ba'i 'phel cha bco lnga rdzogs pa'i cha gcig ste bcu drug} 2) {dum bu bcu drug tu btang ba'i dum bu gcig} 3) {(mngon) zla ba/}
@@ -12504,7 +12562,7 @@ bcos min|1) {bden pa'am dngos gnas/} 2) {don dam stong nyid/}
 lca rgod|{ri skyes kyi lca ba'i rigs shig}
 lca ba|{thang sman gyi rigs shig ste/ ro kha zhing tsha la mngar ba/ zhu rjes snyoms/ nus pas tshe sring ba dang/ rgas dka'/ lus stobs 'phel/ bad kan dang mkhal ma'i grang ba sel/ chu ser skem/}
 lca g.yung|{klung skyes kyi lca ba'i rigs shig}
-lcag rdung byed dam gzhu byed|{rta lcag sba lcag lcag yu/ 'gram lcag thal lcag gzhus pa/ rta mgyogs pa'i thog la lcag skul lcag byed pa/ rta pho lcag gis bskul nas 'phur ba ltar rgyug pa/}
+lcag|{rdung byed dam gzhu byed/ rta lcag _sba lcag _lcag yu/ 'gram lcag _thal lcag gzhus pa/ rta mgyogs pa'i thog la lcag _skul lcag byed pa/ rta pho lcag gis bskul nas 'phur ba ltar rgyug pa/}
 lcag gi lcig gi|{tha re tho re/ na kha lcag gi lcig gi/ chu lcag gi lcig gi/}
 lcag lcig|1) {lcag gi lcig gi'i bsdus tshig} 2) {ljan ljin/ 'dam dang lcag lcig khrod na pad ma rnam par 'phel/}
 lcag thags|{(mngon) 'brog pa/}
@@ -12562,7 +12620,7 @@ lcags brgyad|{gser dang/ dngul/ zangs/ lcags/ bsha' dkar/ ra gan/ 'khar ba/ za n
 lcags ngar|{zangs mgar gyi lag cha mgo skon g.yog sa'i lcags hreng mgo gug can/}
 lcags mchog|{(mngon) gser spyi/}
 lcags snyigs|{lcags bzhus tshar ba'i snyigs ma/}
-lcags tig thang sman gyi rigs shig ste|{ro kha/ zhu rjes bsil/ nus pas mkhris tshad dang/ mchin tshad/ pho tshad/ rims tshad sogs la phan/}
+lcags tig|{thang sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas mkhris tshad dang/ mchin tshad/ pho tshad/ rims tshad sogs la phan/}
 lcags tig dkar po|{tig ta rigs bdun gyi ya gyal zhig ste/ ro kha/ zhu rjes bsil/ nus pas mchin tshad dang/ mkhris tshad/ khrag tshad bcas la phan/}
 lcags tel|{lcags kyis bzos pa'i nad dmig sreg byed kyi tel pa ste/ de nad dmig steng brdegs na 'bras nad dang/ lhen skran sogs la phan/}
 lcags gtun|{lcags kyi gtun bu/}
@@ -12758,7 +12816,7 @@ lcog lcog|1) {dbyibs cog bu'i rnam pa/ ri sna lcog lcog rdo mkhar dmar po lcog l
 lcog lcog pu|{'bur 'bur ram tsog tsog grong khyer gyi nye 'dabs su khang pa lcog lcog pu zhig 'dug}
 lcog chung|{mkhar chung ngu/}
 lcog pu|{cog pu'am/ tsog pu/ ri rtse lcog pu/}
-lcog ce|{cog tse dang 'dra/}
+lcog tse|{cog tse dang 'dra/}
 lcog rtse|{cog tse dang 'dra/}
 lcog ri|{lha sa'i lho nub phyogs kyi lcags po ri'i ming gzhan/}
 lcog ring|{lcog tse dkyus ring ba/}
@@ -22247,7 +22305,7 @@ dros|{'dra ba'i skul tshig}
 dros chen|{(yul) nyin dgung ma zin gong/}
 dros pa|{dro ba'i 'das pa/}
 drwa mig|{yi ge po ti 'jug snod shing sgrom gyi drwa mig}
-dha du ra/(legs) snang ba dgu 'gyur te thang phrom dkar nag khra gsum gyi spyi ming zhig
+dha du ra|{(legs) snang ba dgu 'gyur te thang phrom dkar nag khra gsum gyi spyi ming zhig}
 dharma sing ha|{(legs) chos kyi seng ge /}
 dharma|{(legs) chos/}
 dharmap'la|{(legs) chos skyong ste bod du phebs myong ba'i rgya gar gyi slob dpon bod kyi pa'l rnam gsum gyi ya gyal zhig}
@@ -31252,7 +31310,7 @@ byi ba|1.{(tha mi dad pa) skra spu sogs rang bzhin gyis bud pa/ dud 'gro'i spu b
 byi ba nag po|{g.yi 'dra ba'i sems can zhig}
 byi ba'i dug dug can gyi byi ba'i mche bas rmugs pa'i dug sngar dgun dus su zhugs pa gsal bar myong ba med kyang phyis dpyid dus su 'brug sgra grags pa'i tshe dug ldang ba na byi bas reg pa dran pa las|{dug gis gos pa dran pa'o/}
 byi ba'i zas can|{(mngon) byi la/}
-byi bo|1. 1) {'chal po dang/ gzhan gyi chung mar log par g.yem pa'i 'phyon pa/} 2) {log g.yem/} 3) {skra med spyi ther/ }2.{rgyan dang bral ba dang/ gog po/ zlos gar ba byi bo/ mchod rten byi bo/ gandi byi bo/}
+byi bo|1. 1) {'chal po dang/ gzhan gyi chung mar log par g.yem pa'i 'phyon pa/} 2) {log g.yem/} 3) {skra med spyi ther/ }2.{rgyan dang bral ba dang/ gog po/ zlos gar ba byi bo/ mchod rten byi bo/ gaN+Di byi bo/}
 byi byad|{gad dar/}
 byi byas|{gzhan gyi chung mar spyad pa/}
 byi byas byi rin gyi zhal lce|{zhal lce bcu drug gi nang gses/ gna' rabs kyi khrims srol du gtso bo skyes pas gzhan gyi chung ma la log g.yem gyi byi byas na byi rin zhes pa'i nyes chad 'gel gcod kyi khrims shig}
@@ -35600,7 +35658,7 @@ dman cha bzung|{dma' sa bzung ba ste khengs skyung gi rnam 'gyur/}
 dman chung|{bu mo gzhon gzhon/}
 dman pa|1.{(tha mi dad pa) phongs pa dang/ med par 'gyur ba/ mthun rkyen gyis dman pa/ 'tsho ba'i rgyu dngos kyis mi dman pa/ blo gros kyis dman pa/ }2.{'phri rtsis/ }3. 1) {mchog gi ldog zla ste tha shal lam zhan pa/ shes yon dman pa/ nyams myong dman pa/ spus tshad mchog dman bar gsum/ming gi rnam grangs la mchog min dang/ tha ma/ tha shal/ phal pa/ 'og ma bcas so/} 2) {mtho ba'i ldog zla/ sa babs dman pa/ ri dman pa/ lta ba dman pa mchog tu 'dzin pa/ byas rjes dman pa dang/ khyad du 'phags pa/ lus stobs dman pa/}
 dman pa la sbyor ba'i le lo|{srog gcod pa la sogs pa mi dge ba'i las la brtson pa/}
-dman pa'i spyod pa lnga|{'dul ba las bshad pa'i chad las kyi bslab pa len pa'i gang zag gis dman pa'i spyod pa lnga dang du len dgos pa ste/ nangs par dge slong rang bzhin du gnas pa rnams las snga bar langs te gtsug lag khang gi sgo dbye ba sogs bya ba dang/ chos ston pa'i dus su bsil yab byed pa sogs 'os pa'i las bya ba dang/ dge 'dun 'du ba'i dus su gandi brdung ba dang gdan bshams pa/ bdug spos bzhag pa sogs bya ba dang/ dgong ka'i dus su mthun pa'i chus dge slong rnams kyi rkang pa bkru ba sogs bya ba dang/ dus dang rnam pa thams cad du dge ba'i phyogs las mi g.yel zhing dge 'dun gyi gral mthar 'dug pa sogs 'bad par bya ba ste lnga'o/}
+dman pa'i spyod pa lnga|{'dul ba las bshad pa'i chad las kyi bslab pa len pa'i gang zag gis dman pa'i spyod pa lnga dang du len dgos pa ste/ nangs par dge slong rang bzhin du gnas pa rnams las snga bar langs te gtsug lag khang gi sgo dbye ba sogs bya ba dang/ chos ston pa'i dus su bsil yab byed pa sogs 'os pa'i las bya ba dang/ dge 'dun 'du ba'i dus su gaN+Di brdung ba dang gdan bshams pa/ bdug spos bzhag pa sogs bya ba dang/ dgong ka'i dus su mthun pa'i chus dge slong rnams kyi rkang pa bkru ba sogs bya ba dang/ dus dang rnam pa thams cad du dge ba'i phyogs las mi g.yel zhing dge 'dun gyi gral mthar 'dug pa sogs 'bad par bya ba ste lnga'o/}
 dman po|{tha shal gyi don du go ba'i dman pa dang 'dra/}
 dman ma|{rnying pa'am lhag ro/ me tog dman ma/ kha zas dman ma/}
 dman mo|{tha shal gyi don du go ba'i dman pa dang 'dra/}
@@ -36176,7 +36234,7 @@ smig rgyu|{nyi ma tsha ba'i dus rgyang ring bye thang skya bo nas chu 'gro ba lt
 smig ma|{(rnying) smyig ma'i zur chag ste shing smyug ma/}
 smin grol|{smin byed kyi dbang dang/ grol byed kyi khrid/}
 smin grol gling dgon pa|{bod rang skyong ljongs grwa nang rdzong khongs su tA la'i bla ma sku phreng lnga pa'i bla ma gter bdag gling pas rab byung bcu gcig pa'i me 'brug lor btab pa'i rnying ma lho brgyud lugs kyi dgon pa'i gtso bo zhig rab byung bcu gnyis pa'i sa khyi lor sog po jun gar gyis mer bsregs btang yang rjes su zhig gso byas shing/ sngar dgon pa 'dir khams dang a mdo'i sa khul khag gi rnying ma pa'i grwa pa chos dang sman rtsis sogs sbyong bar yong mkhan shin tu mang/}
-smin drug rgyu skar nyi shu rtsa brgyad kyi ya gyal zhig ming gi rnam grangs la karti ka dang|{ma drug bu/ mang po skyes bcas so/}
+smin drug|{rgyu skar nyi shu rtsa brgyad kyi ya gyal zhig ming gi rnam grangs la karti ka dang/ ma drug bu/ mang po skyes bcas so/}
 smin drug zla ba|{hor zla dgu ba'i tshes bcu drug nas bcu pa'i bco lnga'i bar la smin drug zla ba zer/}
 smin bdun|{rgyu skar zhig}
 smin ldan|{(mngon) ru rta/}
@@ -36384,7 +36442,7 @@ smra ba'i lha|{(mngon) 'jam dpal/}
 smra ba'i lha mo|{(mngon) dbyangs can ma/}
 smra byed|{(mngon) kha/}
 smra bsam brjod med|{stong nyid/}
-smrag shirsha|{(legs) hor zla bcu gcig pa/}
+smrag shir+Sha|{(legs) hor zla bcu gcig pa/}
 smrang|{(rnying) rig byed dam ngag skad/}
 smrang 'don|{(rnying)} 1) {gsang tshig 'don pa/} 2) {lung 'don pa/}
 smrang ba|{(rnying) smra ba/}
@@ -36427,8 +36485,8 @@ tsag bcad mar|{bskol te tsag thag bcad pa'i mar khu/ tsag bcad mar de rgyun ring
 tsag tsig tsag gi tsig gi'i bsdus tshig tsag tsog tsag ge tsog ge'i bsdus tshig tsag bshags|{(yul) sha khog sogs dkyil nas bshags pa/ lug sha tsag bshags btang ba/ tshags sha tsag bshags/}
 tsang kun|{mi ma yin gyi bye brag cig}
 tsan dan|<{tsandan}:>{ dri bzang po'i shing rigs shig tsan dan la go g.yog dang/gos chen la thab phyis/ ming gi rnam grangs la gos sngon dang/ dri'i snying po/ dpal gyi dum bu/ ma la yar skyes/ tshim byed/ bzang po'i dpal bcas so/}
-tsan dan dkar po|{shing sman gyi rigs shig ste/ ro bska la tsha/ zhu rjes bsil/ nus pas glo snying 'khrugs tshad sel/ lus la byugs na sha pags kyi tsha ba 'joms/ ming gi rnam grangs la go shirsha dang/ til 'dab can/ te la pa rni/ dri zhim dkar po/ dri zhim btags/ ba lang mgo/ dpal gyi dum bu/ me'i srub shing/ sa mchog tsan dan/ sa 'dan ha sar/ ha ri tsan dan bcas so/}
-tsan dan go shirsha|{ri bo ma la yar skyes pa'i tsan dan dkar po'i rigs shig}
+tsan dan dkar po|{shing sman gyi rigs shig ste/ ro bska la tsha/ zhu rjes bsil/ nus pas glo snying 'khrugs tshad sel/ lus la byugs na sha pags kyi tsha ba 'joms/ ming gi rnam grangs la go shir+Sha dang/ til 'dab can/ te la pa rni/ dri zhim dkar po/ dri zhim btags/ ba lang mgo/ dpal gyi dum bu/ me'i srub shing/ sa mchog tsan dan/ sa 'dan ha sar/ ha ri tsan dan bcas so/}
+tsan dan go shir+Sha|{ri bo ma la yar skyes pa'i tsan dan dkar po'i rigs shig}
 tsan dan sgrol ma rang byung|{sku ngo mtshar can gsum gyi ya gyal zhig ste/ sngar gyi bshad srol ltar tsan dan gyi sdong po'i nang nas rang byung gi sku rten zhig ste/ bod rgyal srong btsan sgam po'i dus bal bza' khri btsun gyi rten skal du khyer yong ba phyis ra mo cher bzhugs pa'i rten ngo mtshar can zhig}
 tsan dan mchog|{(mngon) sbrul gyi snying po/}
 tsan dan jo bo|{'phags yul nas bzo skrun byas pa phyis rgya nag tu gdan drangs te rten gyi gtso bor bzhugs su gsol ba'i tsan dan gyi thub pa'i sku brnyan zhig}
@@ -51217,7 +51275,7 @@ hor pho|{hor pa skyes pa/ gtam a phas gtong rgyu a mas/ mda' hor phos rgyag rgyu
 hor sbub|{hor rgyal po'i skabs hor yul nas thon pa'i rol mo'i sbub chal/}
 hor mo|{bod byang thang gi 'brog pa'i bud med/ hor mo'i chas/}
 #hor mo'i pags rtsag hor mo'i dgun chas sram lpags dang ras 'ja' bsgrigs kyi rgyan can|
-hor zla|{hor lugs kyi lo zla brtsi stangs shig hor zla hor zla dang po'i ming gi rnam grangs la kam pa dang/ dka' thub zla ba/ cho 'phrul/ mchu zla/ rta zla/ 'du byed zla ba/ dpyid zla ra ba/ mA gha bcas so/ hor zla gnyis pa'i ming gi rnam grangs la khra zla dang/ rnam shes zla ba/ dpyid zla 'bring po/ phalku na/ dbo zla/ 'bras ldan/ sbo zla/ ro hi ta bcas so/ hor zla gsum pa'i ming gi rnam grangs la dri zhim ldan dang/ 'dod dus zla/ nag zla/ dpyid zla tha chung/ sbrang zla/ ming gzugs zla/ mo ha ti/ myos byed zla ba/ tsi tra/ yid srubs zla ba bcas so/ hor zla bzhi pa'i ming gi rnam grangs la skye mched zla ba dang/ sgrub byed/ be sha kha/ bha dra/ dbyar zla ra ba/ sbrang rtsi skyed/ me tog ldan/ sa ga zla ba bcas so/ hor zla lnga pa'i ming gi rnam grangs la nges sreg dang/ 'dod 'phel/ snron zla/ dbyar zla 'bring po bcas so/ hor zla drug pa'i ming gi rnam grangs la kurma dang/ chu stod zla ba/ bre'i zla ba/ dbyar zla tha chung/ gtsang ma'i zla ba/ tshor ba'i zla ba bcas so/ hor zla bdun pa'i ming gi rnam grangs la mkha' sprin can dang/ gro bzhin zla ba/ ston zla ra ba/ nam mkha'i thod ldan/ ma ka ra/ myos zla/ shra ba na/ sred pa'i zla ba bcas so/ hor zla brgyad pa'i ming gi rnam grangs la rkang pa dang/ khyu mchog can/ khrums zla/ ston zla 'bring po/ nor ldan/ sprin bzang/ ba glang rkang/ bha dra ba/ bzang po'i zla ba bcas so/ hor zla dgu pa'i ming gi rnam grangs la glu dbyangs zla ba dang/ rgod ma can/ ltad sbyor/ ltad mo'i zla ba/ston zla tha chung/ tha skar zla ba/ dbyug gu gcig pa/ mi ki ri/ rtsi thog zla ba/ srid pa'i zla ba/ gsal ba'i bu mo/ a shwa ni bcas so/ hor zla bcu pa'i ming gi rnam grangs la skye ba'i zla ba dang/ karti ka/ glu dbyangs can/ dgun zla ra ba/ mgo las skyes/ mang po 'dzin/ smin drug zla ba/ sa ga skyes bcas so/ hor zla bcu gcig pa'i ming gi rnam grangs la rga shi'i zla ba dang/ dgun zla 'bring po/ mgo zla/ smal po'i zla ba/ smrag shirsha/ tshim byed zla ba/ bzod ldan ma/ ri dwags mgo/ lo'i thog ma bcas so/ hor zla bcu gnyis pa'i ming gi rnam grangs la rgyal zla dang/ dgun zla tha chung/ nus zla/ poo sha/ ma rig zla ba/ me tog ldan/ tshim byed zla bcas so/}
+hor zla|{hor lugs kyi lo zla brtsi stangs shig hor zla hor zla dang po'i ming gi rnam grangs la kam pa dang/ dka' thub zla ba/ cho 'phrul/ mchu zla/ rta zla/ 'du byed zla ba/ dpyid zla ra ba/ mA gha bcas so/ hor zla gnyis pa'i ming gi rnam grangs la khra zla dang/ rnam shes zla ba/ dpyid zla 'bring po/ phalku na/ dbo zla/ 'bras ldan/ sbo zla/ ro hi ta bcas so/ hor zla gsum pa'i ming gi rnam grangs la dri zhim ldan dang/ 'dod dus zla/ nag zla/ dpyid zla tha chung/ sbrang zla/ ming gzugs zla/ mo ha ti/ myos byed zla ba/ tsi tra/ yid srubs zla ba bcas so/ hor zla bzhi pa'i ming gi rnam grangs la skye mched zla ba dang/ sgrub byed/ be sha kha/ bha dra/ dbyar zla ra ba/ sbrang rtsi skyed/ me tog ldan/ sa ga zla ba bcas so/ hor zla lnga pa'i ming gi rnam grangs la nges sreg dang/ 'dod 'phel/ snron zla/ dbyar zla 'bring po bcas so/ hor zla drug pa'i ming gi rnam grangs la kurma dang/ chu stod zla ba/ bre'i zla ba/ dbyar zla tha chung/ gtsang ma'i zla ba/ tshor ba'i zla ba bcas so/ hor zla bdun pa'i ming gi rnam grangs la mkha' sprin can dang/ gro bzhin zla ba/ ston zla ra ba/ nam mkha'i thod ldan/ ma ka ra/ myos zla/ shra ba na/ sred pa'i zla ba bcas so/ hor zla brgyad pa'i ming gi rnam grangs la rkang pa dang/ khyu mchog can/ khrums zla/ ston zla 'bring po/ nor ldan/ sprin bzang/ ba glang rkang/ bha dra ba/ bzang po'i zla ba bcas so/ hor zla dgu pa'i ming gi rnam grangs la glu dbyangs zla ba dang/ rgod ma can/ ltad sbyor/ ltad mo'i zla ba/ston zla tha chung/ tha skar zla ba/ dbyug gu gcig pa/ mi ki ri/ rtsi thog zla ba/ srid pa'i zla ba/ gsal ba'i bu mo/ a shwa ni bcas so/ hor zla bcu pa'i ming gi rnam grangs la skye ba'i zla ba dang/ karti ka/ glu dbyangs can/ dgun zla ra ba/ mgo las skyes/ mang po 'dzin/ smin drug zla ba/ sa ga skyes bcas so/ hor zla bcu gcig pa'i ming gi rnam grangs la rga shi'i zla ba dang/ dgun zla 'bring po/ mgo zla/ smal po'i zla ba/ smrag shir+Sha/ tshim byed zla ba/ bzod ldan ma/ ri dwags mgo/ lo'i thog ma bcas so/ hor zla bcu gnyis pa'i ming gi rnam grangs la rgyal zla dang/ dgun zla tha chung/ nus zla/ poo sha/ ma rig zla ba/ me tog ldan/ tshim byed zla bcas so/}
 hor zla ba|{rab byung bzhi pa'i me phag lor hor jing gir rgyal pos mi nyag gi lag nas rgyal sa thob pa'i zla bar bkra shis pa'i dga' ston byas pa mchu zla lo gsar du bzung ba dkyus su shor bas/ ming la'ang hor gyi zla ba dang por grags zhes rgyal dbang lnga pa'i rtsis dkar nag dris lan las gsungs shing/ dus 'khor rang lugs la nag zla sogs nya skar brtsi ba las/ dang po gnyis pa sogs ang grangs kyi sgo nas brtsi srol med do/ spyir dgun nyi ldog rjes kyi zla ba gnyis pa de lo gsar gyi zla ba dang po dang/ de nas gnyis pa gsum pa sogs brtsi ba ni rgya nag zhA rgyal rabs kyi rjes 'brangs yin kyang/ sog po la brgyud nas bod du dar ba'i rkyen gyis hor zla zhes grags/ de yang zla shol 'don tshul lugs gnyis mi 'dra bas skabs 'gar zla ba gcig gi snga phyi yod do/}
 #hor yig sog po'i yi ge|
 hor yig gsar pa|{bod kyi rab byung lnga pa'i sa sbrul lor yon rgyal rabs kyi gong ma se chen han gyis re 'dun bton pa ltar 'gro mgon 'phags pas bod yig dper blangs nas bzos pa'i sog yig gsar pa/ yig srol 'di bton pa nas bzung rgyal tham gyi kha yig dang/ bka' shog tshang ma yig ris 'di'i thog nas 'bri dgos zhes rgyal pos rgyal yongs la gtan 'bebs byas kyang slad yig ris 'di bzhin dar rgyun cher ma byung/ sog yig dang tham yig gsar pa bzos pa'i yig phud dang tham phud gcig bod sa gnas kyi gsang phu dgon par yod zer/}


### PR DESCRIPTION
This is a draft PR for another round of clean ups for the _tshig mdzod chen mo_ data.  I'm filing this early so that _SomeOne_ ™ can double check it.  I do verify this changes against my paper copy, but it's easy to make mistakes in this repetitive, mind-numbing task.  I plan to go letter by letter and this initial submission is for _KA_.

Some problematic lines are already commented out in the source data, but there are some that are not obviously invalid, but are misparsed.

The primary source of error I'm trying to fix here is entries with headwords that end in _ga bzhag_ and hence don't have a _shad_ after the headword.  The post-processing couldn't figure out the headword or identified it incorrectly, including the text up to the next _shad_ into the "headword".  Sometimes the body text ends with _ga bzhag_ itself and in that case the next headword will be sucked in too.  Though some such entries are are already ok, b/c there's some other indication that the body starts (a number for multiple meaning words, or markers like `(mngon)` etc).

The heuristic used is `awk -F'|'` with
```awk
length($1) > 20 && $1 ~ /[^n]g /
```
i.e. headwords (before the pipe) that are long'ish and have a _ga bzhag_ syllable in them.  I also looked at all the commented out entries.

Another source of error is page breaks in the middle of an entry.  Post-processing decides a new entry is started, but cannot make sense of a small torn out fragment and it either ends up being invalid (in which case it's usually commented out) or out of alphabetical order.

While here, doing the _KA_ section, I also fixed a few obvious systemic ORC errors that couldn't recognize very squished bold _skyu_ stacks and misparsed them as _skya_ (I was fixing a _ga bzhag_ entry inside a strech of such misparsed entries, so I just fixed them all)