### PR TITLE
tshig mdzod chen mo: miscellaneous fixes (part 2)

### DIFF
--- a/_input/dictionaries/public/25-tshig-mdzod-chen-mo-Tib
+++ b/_input/dictionaries/public/25-tshig-mdzod-chen-mo-Tib
@@ -281,8 +281,8 @@ kun nas 'khums|{(mngon) gur gum/}
 kun nas 'khyud|{(mngon) 'khri shing/}
 kun nas grags pa|1) {ming skad grags che ba/} 2) {byang sems shig gi mtshan/}
 kun nas 'gegs|{(mngon) btsun mo'i pho brang/}
-kun nas sgo'i le'u|{'phags pa kun nas sgo'i le'u bam po gcig pa/ sho lo ka nyis brgya drug cu pa/ rgya gar gyi mkhan po dzi na mi tra dang / su rendra bo dhi dang/ lo tsA ba ye shes sdes bsgyur cing zhus pa/}
-kun nas sgor 'jug pa'i 'od zer gtsug tor dri ma med par snang ba zhes bya ba'i gzungs|{rgya gar gyi mkhan po dzi na mi tra dang/ shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
+kun nas sgo'i le'u|{'phags pa kun nas sgo'i le'u bam po gcig pa/ sho lo ka nyis brgya drug cu pa/ rgya gar gyi mkhan po dzi na mi tra dang / su ren+d+ra bo dhi dang/ lo tsA ba ye shes sdes bsgyur cing zhus pa/}
+kun nas sgor 'jug pa'i 'od zer gtsug tor dri ma med par snang ba zhes bya ba'i gzungs|{rgya gar gyi mkhan po dzi na mi tra dang/ shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
 kun nas nyon mongs pa|{rtsa nyon drug dang nye nyon nyi shu ste rgyu dang kun slong ci rigs pa/}
 kun nas nyon mongs pa dang rnam par byang ba|{sdug kun gnyis kun nas nyon mongs pa'i phyogs dang/ 'gog lam gnyis rnam byang gi phyogs so/}
 kun nas nyon mongs pa dang rnam par byang ba dang ldang ba thams cad mkhyen pa'i stobs|{bsam gtan rnam thar ting 'dzin snyoms 'jug sogs mkhyen pa'i stobs dang don gcig}
@@ -352,7 +352,7 @@ kun la bkra shis ma|{(mngon) lha mo au mA:}
 kun las rgyal ba|1) {gzhan thams cad las rgyal ba/} 2) {sangs rgyas shig gi mtshan/}
 kun las btus pa|{kun btus dang don gcig}
 kun shes|{(AdznyAna:) ? yon tan thams cad khong du chub pa/}
-kun shes koondi n.ya|{? sangs rgyas shAkya thub pas bden bzhi'i chos 'khor skor skabs 'khor lnga sde bzang po'i nang tshan gcig}
+kun shes kooN+Di n+ya|{sangs rgyas shAkya thub pas bden bzhi'i chos 'khor skor skabs 'khor lnga sde bzang po'i nang tshan gcig}
 kun shes gcig rdugs|{mang po shes kyang gnad gcig tu 'dril ba la mi mkhas pa'am thogs pa/ kun shes gcig rdugs mkhas pa'i skyon/}
 kun shes ldan pa'i dbang po|{zag med kyi dbang po gsum gyi nang gses/ mi slob pa'i rgyud kyi dbang po dgu po de dag nyid mthong sgom gyi nyon mongs ma lus par spangs te zad mi skye ba'i ye shes dang ldan pa'o/}
 kun shes pa'i dbang po|{zag med kyi dbang po gsum gyi ya gyal/ sgom lam pa'i rgyud kyi dbang po dgu de dag nyid kyis mi mthun pa dang gnyen po'i phyogs gsal bar bye brag phyed pa ste kun shes pa'o}
@@ -496,7 +496,7 @@ kong lham|{kong po ba pho mo spyi'i lham/}
 kon pa|{kon pa gab skyes kyi bsdus tshig}
 kon pa gab skyes|{sngo sman kon pa gab skyes skye gnas dbang gis rigs gnyis su dbye bas klung skyes te/ ro kha/ zhu rjes bsil/ nus pas khrag shor gcod/}
 kob tse|{'brum bu dkar po'i nad rigs shig}
-ko'u di na ya|{kun shes koondi ? na-ya'i ? 'bri tshul gzhan/}
+ko'u di n+ya|{kun shes kooN+Di n+ya'i 'bri tshul gzhan/}
 kor|{skor skor dang nye 'dabs kyi don la 'jug pa'i skor dang mtshungs te rtags 'jug las/ pho yis pho yi ming mtha' drangs zhes pa'i rjes 'jug ga da ba'i rjes su sa mgo dor te kor zhes sbyar ba dang/ de min gzhan la brjod bde'i sgo nas skor yig sbyar dgos/ skor ga da ba skor sa / ? kor skor 0 ? dper na/ thig kor/ klad kor/ thab kor/ g.yas skor/ g.yon skor/ nye skor/ khrom skor/ mtha' skor/}
 kor kor|{zlum po'am/ sgor sgor/ nyi zla'i mtha' la 'ja' 'od kor kor 'khyil/}
 kor tshe|{(rnying)} 1) {nyi tshe/} 2) {phyogs ris/}
@@ -505,7 +505,7 @@ kos ko|{ma ne'am/ ma le ste/ ma mchu'i 'og gi rus 'bur/}
 kos ko'i gshong 'bur|{ma le'i kyong 'bur/}
 kos sko|{kos ko dang 'dra/}
 kos thag|{(rnying) nyam thag kos smyung/ma le'i rtse phra ba'am/ rno ba/}
-koon ndi na ya|{? kun shes koondi ? na-ya'i ? 'bri tshul gzhan/}
+kooN N+Di n+ya|{kun shes kooN+Di n+ya'i 'bri tshul gzhan/}
 kwa|{rang dang 'dra ba'am/ rang las dman par 'bod tshig kwa ye/ rang mnyam dang/ rang las dma' bar 'bod pa'i sgra zhig kwa ye grogs po rnam pa tsho/}
 kwa'i|{'bod pa'i brda zhig}
 kya re kyo re|{rang tshugs mi thub pa'i rnam pa/ byis pa lam la kya re kyo rer 'gro/}
@@ -917,7 +917,7 @@ dkar rtsis|{skar rtsis dang 'dra/}
 dkar rtsis pa|{thugs spro chen po gtong skabs dkar yol kho na bdag po rgyag khan/}
 dkar brtsegs|{khal phyugs kyi sga 'og tu rgyag bya'i re snam gyi rgyab ldan phying pa'i khebs shig}
 dkar mdzes|1) {kha mdog dkar zhing mdzes pa/} 2) {rdzong zhig sngar hor khog lnga'i nang gses da lta si khron zhing chen khongs dkar mdzes bod rigs rang skyong khul gyi byang ngos dang nyag chu'i stod rgyud du yod/}
-dkar mdzes bod rigs rang skyong khul|{si khron zhing chen khongs kyi nub rgyud du yod/ 1950 lo'i zla ba 12 tshes 25 nyin shis khams zhing chen bod rigs rang skyong ljongs btsugs shing/ 1955 lor dkar mdzes bod rigs rang skyong khul du bsgyur/ de'i khongs su dar mdo dang/ brag 'go / dkar mdzes/ nyag rong/ dpal yul/ sde dge/ ser shul/ gser thar/ lcad zam/ rong brag brgyad zur/ nyag chu/ rta'u/ li thang/ phyag phreng/ 'dab pa/ 'ba' thang/ sde rong bcas rdzong bco brgyad yod/ rang skyong khul mi dmangs srid gzhung de dar mdo la yod/}
+dkar mdzes bod rigs rang skyong khul|{si khron zhing chen khongs kyi nub rgyud du yod/ 1950 lo'i zla ba 12 tshes 25 nyin shis khams zhing chen bod rigs rang skyong ljongs btsugs shing/ 1955 lor dkar mdzes bod rigs rang skyong khul du bsgyur/ de'i khongs su dar mdo dang/ brag 'go / dkar mdzes/ nyag rong/ dpal yul/ sde dge/ ser shul/ gser thar/ lcags zam/ rong brag brgyad zur/ nyag chu/ rta'u/ li thang/ phyag phreng/ 'dab pa/ 'ba' thang/ sde rong bcas rdzong bco brgyad yod/ rang skyong khul mi dmangs srid gzhung de dar mdo la yod/}
 dkar 'dzin|{(mngon) nu ma/}
 dkar 'dzom la|{si khron zhing chen khongs dkar mdzes bod rigs rang skyong khul gyi sde rong rdzong gi la zhig}
 dkar zhod|{'o ma/}
@@ -972,7 +972,7 @@ dkon mchog|1) {rin po che lta bu 'jig rten na dkon zhing mchog tu gyur pa ste/bs
 dkon mchog kun 'dus|{dkon mchog gsum po gcig tu 'dus pa rang gi rtsa ba'i bla ma/}
 dkon mchog gi za ma tog|{mdo sde zhig ste/ bam po bzhi pa/ lo tsA ba bande ratna rakshi tas bsgyur cing skad gsar bcad kyis bcos pa/}
 dkon mchog mngon rtogs|{lhag pa'i lha'i sgrub thabs shig}
-dkon mchog ta la la'i gzungs|{'phags pa dkon mchog ta la la'i gzungs/ pandi ta su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
+dkon mchog ta la la'i gzungs|{'phags pa dkon mchog ta la la'i gzungs/ pandi ta su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba/}
 dkon mchog dpang btsugs|{mna' skyel ba'i tshig}
 dkon mchog sprin|{thu mi sam bho tas bod kyi yig srol btod nas thog mar bod du bsgyur pa'i mdo sde zhig}
 dkon mchog pho brang|{rten gsum gnas yul gtsug lag khang/}
@@ -1298,7 +1298,7 @@ bkra shis gling|{sa cha zhig si khron zhing chen khongs rnga ba bod rigs rang sk
 bkra shis dgu tshigs|1) {mgo bo'i rus chag gso ba dang/ chu ser skem pa/ klad skyon sel ba bcas kyi sngo sman zhig} 2) {rgya gling gtong stangs kyi sgra gdangs shig}
 bkra shis sgo mang|1) {mchod rten bkra shis sgo mang/} 2) {'bras spungs sgo mang grwa tshang/} 3) {bla brang bkra shis 'khyil dgon pa'i ming/}
 bkra shis sgor mo|1) {rten 'brel gyi bzhugs gral khyad par ba zhig} 2) {rten 'brel gyi ru sgrig khyad par ba zhig} 3) {bkras sgor te sngar bod sa gnas srid gzhung gi rten 'brel mdzad sgo'i skabs drung rigs ser skya la 'grems sprod byed pa'i kha zas kyi ming zhig}
-bkra shis brgyad pa|{'phags pa bkra shis brgyad pa zhes bya ba'i mdo/ sho lo ka lnga bcu rtsa gcig pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa/}
+bkra shis brgyad pa|{'phags pa bkra shis brgyad pa zhes bya ba'i mdo/ sho lo ka lnga bcu rtsa gcig pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa/}
 bkra shis mchog|{bkra shis tshal te dur khrod chen po brgyad kyi gras shig}
 bkra shis rtags brgyad|{dpal be'u dang/ pad ma/ gdugs/ dung/ 'khor lo/ rgyal mtshan/ bum pa/ gser nya ste brgyad/}
 bkra shis them pa yar 'dzegs|{gsham nas gong du rim bzhin 'go 'dzugs pa/}
@@ -1990,7 +1990,7 @@ sku 'dra|{gser zangs dang 'jim pa sogs las bzos pa'i 'dra brnyan/ ming gi rnam g
 sku rdo rje|{rdo rje gsum gyi nang gses/ gzugs rnam par dag pa snang stong gnyis su med pa'i sku rdo rje'i chos bdun gyi rang bzhin tshang ba/}
 sku lder|{'jim pa las bzos pa'i sku/}
 sku na|{lo tshod/ sku na bgres kyang thugs rig ha cang gsal/ yab yum gnyis gshegs pa dang sku na phra bas phyag rdzas rnams mi'i lag tu bcol/}
-sku n.ya gro ta ltar chu zheng gab pa'i mtshan bzang|{sangs rgyas kyi mtshan bzang po so gnyis kyi nang gses shig ste nags tshal dang kun dga' ra ba la sogs pa byed pa yang dag par len du bcug pas shing n.ya gro ta ltar chu zheng gab pa/}
+sku n+ya gro ta ltar chu zheng gab pa'i mtshan bzang|{sangs rgyas kyi mtshan bzang po so gnyis kyi nang gses shig ste nags tshal dang kun dga' ra ba la sogs pa byed pa yang dag par len du bcug pas shing n+ya gro ta ltar chu zheng gab pa/}
 sku pur|{shi ba'i ro/ sku pur zhugs 'bul byas/}
 sku spyi'i yon tan bcu|{dpe byad bzang po brgyad cu'i gras shig ste/ sku mnyen zhing 'gying legs pas 'khril bag chags pa dang/ ring thung sbom phra sogs ma 'chol bas rim par 'tshams pa dang/ mtshan rnams kyi cha shas mtha' dag gsal zhing rdzogs pa dang/ sku khyon che bas kho lag yangs shing bzang ba dang/ sku shin tu gzhon sha can du gyur pa dang/ sku la rtsub bag med pas 'jam pa dang/ sku rid pa sogs kyi skyon med pas zhum pa med pa dang/ sku sha rgyas pa dang/ sku mi lhod par shin tu grim pa dang/ sor mo dang yan lag sbom phra sogs kyi cha phyed pas shin tu rnam par 'byes pa bcas bcu'o/}
 sku phung|{phung po'am ro/}
@@ -2207,7 +2207,7 @@ skor|1. {skor ba'i skul tshig }2. 1) {rigs dang sde tshan/ zhing las skor/ 'brog
 skor kyog|{thad ka ma yin pa'am/ kha thug min pa/ lam skor kyog bsam slo skor kyog skad cha skor kyog}
 skor skad pa|{sngar lha ldan smon lam skabs lha sa'i bar skor mtshan 'khyongs bskor te chos sgra sgrog pa po/}
 skor skyod|{sa gnas ga sa ga la bskor te 'gro ba/ ga sa gar skor skyod byas nas ltad mo ston/ skor skyod sman bcos ru khag skor skyod tshong pa/}
-skor khang|{ma ni skor sa'i khang pa/}
+skor khang|{ma Ni skor sa'i khang pa/}
 skor 'go|{rtsis kyi skor 'go ste grangs brtsi sa'i thog ma'am gzhi/}
 skor rgyug|{phar skor tshur skor byas te 'gro ba/ yul grong nges med la skor rgyug byas/}
 skor 'chag pa|{sngar bod lha sa'i grong nang gi khrims khang snang rtse shag gi skor zhib byed mi'i gras/}
@@ -2467,7 +2467,7 @@ skyu|{mtheb tshigs dkyil ma nas mtheb rtse bar tshon gang gi tshad/}
 skyu gang|1) {mthe bong gis kong kong bzos pa'i spags kyi mtheb skyu/} 2) {gdong la byug rdzas/} 3) {mtheb tshigs dkyil ma nas mtheb rtse bar tshon gang gi tshad/}
 skyu tshe|{zan gyi mtheb skyu/ mar khu'i skyu tshe bzo ba/}
 skyu ru|{(amalakI) skyu ru ra ste tshad pa che ba'i yul du skye ba'i shing sdong lo ma che tsam yod pa'i 'bras bu zhig 'dis khrag mkhris kyi tsha ba sel/ ming gi rnam grangs la rgyal 'bras dang/ bcud gnas/ na tshod gnas/ zhi byed/ lang tsho brtan byed bcas so/}
-skyu ru ra|{shing sman gyi rigs shig ste/ ro skyur la mngar kha bska ba/ zhu rjes bsil/ nus pas bad mkhris dang khrag nad sel/ mig nad dang bcud len la bzang/ ming gi rnam grangs la skom sel dang/ khrag 'byed/ gya nom/ smin 'gas/ am ? bhi bcas so/}
+skyu ru ra|{shing sman gyi rigs shig ste/ ro skyur la mngar kha bska ba/ zhu rjes bsil/ nus pas bad mkhris dang khrag nad sel/ mig nad dang bcud len la bzang/ ming gi rnam grangs la skom sel dang/ khrag 'byed/ gya nom/ smin 'gas/ am bhi bcas so/}
 skyu ru ra rlon pa|{skyu ru ra'i 'bras bu gsar pa 'di ha cang dwangs pas phyi nang thams cad gsal po mthong/ shes bya'i chos rnams skyu ru ra rlon pa lag mthil du bzhag pa ltar gsal sgrib med par mthong/}
 skyu rum|{(rnying)} 1) {btung ba'i bye brag thug pa/} 2) {btsos nas skyur mor gyur pa'i sngo tshod/}
 skyu rum mkhan|{tshod ma bzo mkhan/}
@@ -5447,7 +5447,7 @@ mkhregs po|{gyong po dang/ sra ba'am mi zhig pa/ mkhred tshad/ mkhregs shing/ mk
 'khor sgyur gyi 'khor lo'i khyad chos drug|{myur du 'gro ba dang/ gzhan du 'gro ba/ ma rgyal ba las rgyal bar byed pa/ rgyal ba rnal du 'god pa/ mtho ba la 'phar ba/ dma' ba la 'bab pa/}
 'khor sgyur gyi nye ba'i rin chen bdun|{ral gri rin po che dang/ pags pa rin po che/ khyim rin po che/ tshal rin po che/ gos rin po che/ lham rin po che/ mal cha rin po che ste bdun/}
 'khor sgyur lnga|{'khor los sgyur ba'i rgyal po lnga ste/ nga las nu dang/ mdzes pa/ nye mdzes/ mdzes ldan/ nye mdzes ldan te lnga/}
-'khor lnga sde bzang po|{ston pa shAkya thub pas gnas wa ra Na sir dus chu stod zla ba'i tshes bzhi nas brtsams te/ chos bden pa bzhi'i 'khor lo bskor ba na/ thog mar ye shes khong chud kyis bsnyen par rdzogs nas dgra bcom thob pa'i 'khor lnga ste/ kun shes koondi n.ya dang/ rta thul/ rlangs pa/ ming chen/ bzang ldan rnams so/}
+'khor lnga sde bzang po|{ston pa shAkya thub pas gnas wa ra Na sir dus chu stod zla ba'i tshes bzhi nas brtsams te/ chos bden pa bzhi'i 'khor lo bskor ba na/ thog mar ye shes khong chud kyis bsnyen par rdzogs nas dgra bcom thob pa'i 'khor lnga ste/ kun shes kooN+Di n+ya dang/ rta thul/ rlangs pa/ ming chen/ bzang ldan rnams so/}
 'khor bcas|{'khor dang bcas pa ste/ ngo ma rjes 'brang dang bcas pa/}
 'khor chu|{klong 'khor te/ chu chen por rlabs sgor mor 'khor ba'i kong dong/}
 'khor nyan|{glu dbyangs kyi nges pa bdun gyi nang tshan zhig}
@@ -5828,7 +5828,7 @@ gag lhog|{gnyan nad lce la babs te gre ba 'gag pa gag pa'i nad dang/ sha la babs
 gang|1. 1) {spyi sgra dngos la 'jug pa'i spyi sgra gang/ yon tan gang goms pa rnams bed spyod byas pa/ sems la gang dran bshad pa/ 'bras bu gang 'dod byung ba/ dngos po che chung gang na ci yod/ thabs shes gang nas kyang dmigs yul legs sgrub byed pa/ rang 'dod gang bsam zol med du zhu ba/ gang dga' gang skyid/ bsam 'char gang dran dran bshad pa yin/ dus yun gang thung thung du btang ba/ sang zhogs gang snga snga byas nas 'gro dgos/ 'brel lam gang 'grig 'grig byed pa/ rogs ram gang thub thub byas pa/} 2) {bye brag la 'jug pa'i spyi sgra gang/ gang la snying stobs mchog mnga' ba/ byas rjes 'jog mkhan gang zhig bum pa gang zhig gang nyid kyi bka' slob/} 3) {dri ba'i don du 'jug pa'i spyi sgra gang/ las don gang yin/ mi gang dang su yin pa/ dpe cha gang du gsal ba/ khyed rang sa phyogs gang nas phebs pa yin/ }2. {grangs gcig rgya ma gang/ dkar yol gang/ gom pa gang/}
 gang ga|{thams cad dam tshang ma/ khong tsho gang ga phebs bzhag}
 gang ga chung|{sngo sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas dug tshad dang/ rma tshad/ tsha 'khru/ tsha bas skrangs pa sogs 'joms par byed/}
-gang gA|{(legs) ya gling gi chu bo chen po zhig yin pa 'di'i chu 'go ni rang rgyal bod rang skyong ljongs kyi glang chen kha 'bab yin zhing/ rgya gar dang bhangga la brgyud nas rgya mtshor 'bab/ bod kyi gnas yig rnying pa'i nang du mtsho ma dros ag ci drag byed pa/} 2) {'u thug glang po che'i kha 'dra ba nas dngul gyi bye ma 'dren zhing chu phran lnga rgya dang bcas pa mtsho ma dros pa la g.yas su bskor nas shar gyi rgya mtshor 'bab ces gsal/ming gi rnam grangs la skal ldan shing rta'i bu mo dang/ khyab 'jug rkang pa/ glang chen kha 'bab/ rgyun gsum pa/ bcud ring chu sbyin ma/ 'chi med chab/ 'jigs sde'i ma/ mtho ris klung/ drag po'i thod/ nam mkha'i chu bo/ yan lag brgyad ldan/ lam gsum pa/ sa ba ka/ gser ldan ma/ lha'i chu bo bcas so/}
+gang gA|{(legs) ya gling gi chu bo chen po zhig yin pa 'di'i chu 'go ni rang rgyal bod rang skyong ljongs kyi glang chen kha 'bab yin zhing/ rgya gar dang b+hang+ga la brgyud nas rgya mtshor 'bab/ bod kyi gnas yig rnying pa'i nang du mtsho ma dros pa'i shar phyogs nas dngul gyi brag glang po che'i kha 'dra ba nas dngul gyi bye ma 'dren zhing chu phran lnga brgya dang bcas pa mtsho ma dros pa la g.yas su bskor nas shar gyi rgya mtshor 'bab ces gsal/ming gi rnam grangs la skal ldan shing rta'i bu mo dang/ khyab 'jug rkang pa/ glang chen kha 'bab/ rgyun gsum pa/ bcud ring chu sbyin ma/ 'chi med chab/ 'jigs sde'i ma/ mtho ris klung/ drag po'i thod/ nam mkha'i chu bo/ yan lag brgyad ldan/ lam gsum pa/ sa ba ka/ gser ldan ma/ lha'i chu bo bcas so/}
 gang gA skyes|{(mngon)} 1) {gzhon nu gdong drug} 2) {gser/}
 gang gA 'dzin|{(mngon)} 1) {rgya mtsho/} 2) {lha dbang phyug chen po/}
 gang gA'i bye ma|{gang gA'i klung gi bye ma'ang zer/ chu bo gang gA zhes par yod pa'i bye ma ji snyed kyi grangs 'bor te sngar rgya gar lugs kyi grangs gnas chen po zhig ste ha cang mang ba'i dpe/}
@@ -7822,7 +7822,7 @@ dge slong sgrub pa'i cho ga|{gsol bzhi'i las kyi cho ga tshang la ma nor ma 'khr
 dge slong bde byed|{sngar rgya gar gyi nyan thos sde pa'i dge slong zhig yin pa des rig pa'i rgyan zhes bya ba'i gzhung 'bum phrag bcu gnyis pa zhig brtsams te theg chen sun 'byin byas pa/}
 dge slong rnam pa lnga|{slong ba'i dge slong dang/ ming gi dge slong/ khas 'ches pa'i dge slong/ bsnyen par rdzogs pa'i dge slong/ nyon mongs pa dang bral ba'i dge slong bcas lnga'o/}
 dge slong rnal 'byor pa|{sgrub pa nyams len byed mkhan gyi dge slong/}
-dge slong dpal ldan|{rgya gar na lendrara klu sgrub bsnyen par rdzogs nas thob pa'i mtshan/}
+dge slong dpal ldan|{rgya gar na len+d+rar klu sgrub bsnyen par rdzogs nas thob pa'i mtshan/}
 dge slong ma|{(bhikshuni:) so thar ris bdun gyi nang gses/ bslab khrims sum brgya drug cu rtsa bzhi bsrung bar khas blangs pa'i sdom ldan gyi bud med/}
 dge slong ma sgrub pa'i cho ga|{rten dge slob ma'i sdom pa blangs nas lo gnyis lon pa'i gang zag ste/ khyim so bzung na lo bcu gnyis/ ma bzung na nyi shu lon pa la/ dge slong ma'i dge 'dun bcu gnyis sam drug tshogs las mkhan mos chos gos rnam gsum gyi steng du rngul gzan dang shing nga dpung bcad gnyis bsnan pa'i chos gos lnga dang bcas pa'i rtags sbyin/ bar chad dris te tshangs spyod nyer gnas kyi sdom pa sbyin/ de nas dge 'dun pha'i tshogs bsnan te gnyis ka'i dge 'dun dang bcas pas gsol bzhi'i las chog gis bsnyen par rdzogs shing/ rjes gdams ngag brjod pa la'ang pham pa brgyad dang lci chos brgyad sogs 'phri bsnan byed dgos kyang bod yul 'dir dge slob ma dang dge slong ma sgrub pa'i srol thog ma nas ma byung ngo/}
 dge slong ma bsnyen par rdzogs pa'i las|{btsun ma la dge slong ma'i sdom pa 'bogs pa'i bya ba/}
@@ -7981,7 +7981,7 @@ dgra thabs|{dgra 'dul ba'i thabs jus/}
 dgra gdon|{dngos su gnod pa'i dgra dang/ mi mngon pa'i gdon 'dre/}
 dgra 'dul gnyen skyong|1) {dgra bo 'dul ba dang/ gnyen nye skyong ba/} 2) {phyogs lhung/}
 #dgra 'dul dpung 'jug dgra 'dul ba'i ched du dmag dpung 'dren pa|
-dgra 'ded|1) {dgra bo mthar skrod pa/} 2) {'byung rtsis nang grogs la brten nas dgra rtsi ba/ shing dgra lcad/ lcags dgra me/ me dgra chu/ chu dgra sa/ sa dgra shing/}
+dgra 'ded|1) {dgra bo mthar skrod pa/} 2) {'byung rtsis nang grogs la brten nas dgra rtsi ba/ shing dgra lcags/ lcags dgra me/ me dgra chu/ chu dgra sa/ sa dgra shing/}
 #dgra nag dgra bo'i dwangs ma'am dgra gtso bo|
 dgra nag gshin rje gshed|{bla med rgyud kyi yi dam dmar nag 'jigs gsum gyi nang gi gshin rje gshed dgra nag ces bya ba/}
 dgra phyogs|{dgra bo'i phyogs khag dmag ma brgyab gong nas rang phyogs kyi gnas tshul gsal por shes dgos par ma zad/ dgra phyogs kyi gnas tshul yang gsal por shes dgos/}
@@ -9229,7 +9229,7 @@ rgyan gos|{rgyan cha dang gyon pa/ rgyan gos gzab mchor/ rgyan gos 'ja' tshon sn
 rgyan gyi rdo rje|{rdo rje'i dbyibs can gyi ri mo'i bye brag cig}
 rgyan cha|{mdzes pa'i rgyan/}
 rgyan chas|{rgyan gyi yo byad/}
-rgyan stug po bkod pa'i mdo|{bam po bzhi dang le'u dgu gsham ma tshang bar bzhed pa/ dzi na mi tra dang/ shI lendra bo dhi dang/ bande ye shes sdes bsgrur ba'o/}
+rgyan stug po bkod pa'i mdo|{bam po bzhi dang le'u dgu gsham ma tshang bar bzhed pa/ dzi na mi tra dang/ shI len+d+ra bo dhi dang/ bande ye shes sdes bsgrur ba'o/}
 rgyan dor ba|1) {rgyal btsugs pa/} 2) {rgyan cha spangs pa/}
 rgyan drug 'dzam gling mdzes par byed pa'i rgyan drug ste|{dbu ma'i rgyan klu sgrub dang 'phags pa lha/ mngon pa'i rgyan thogs med dang dbyig gnyen/ tshad ma'i rgyan phyogs glang dang chos grags bcas sngar rgya gar du byon pa'i slob dpon chen po drug go /}
 rgyan drug mchog gnyis|{klu sgrub dang/ 'phags pa lha/ thogs med/ dbyig gnyen/ phyogs glang/ chos grags bcas rgyan drug dang/ bstan pa'i rtsa ba mchog tu gyur pa 'dul ba'i sde snod la shin tu mkhas pa'i slob dpon shAkya 'od dang yon tan 'od rnam gnyis ni mchog gnyis so/}
@@ -9312,7 +9312,7 @@ rgyal khams dper blangs kyi khrims|{srong btsan sgam pos bod du lag bstar byas p
 rgyal khongs|{rgyal khab kyi thob khongs/}
 rgyal khri|{rgyal po'i bzhugs khri ste/ rgyal po'i go 'phang/ sras rgan pa de lo na chung dus nas rgyal khrir 'khod pa/ phru gu bsam med cig rgyal khrir bskos pa/}
 rgyal khrims|{mi chos kyi khrims/ rgyal po byis pa yin kyang/ rgyal khrims rtsed mo min/ drang ldan tshad thub kyi rgyal khrims bca' ba/ rgyal khrims drang por srongs/ ming gi rnam grangs la khrims dang/ khrims lugs/ 'jig rten khrims/ yul chos/ lugs bcas so/}
-rgyal mkhar chos rdzong ba|{bod dmangs khrod kyi zlos gar lha mo ba'i tshogs pa zhig yin pa de thog mar 'dzugs yul gzhis ka rtse sa khul khongs rin spungs rdzong gi chos rdzong dgon pa yin zhing/ dgon pa de stod smad khag gnyis su phye ba'i stod gser skyems dgon nas yong mkhan lha mo ba tshos gtso cher lha mo 'khrab cing/ smad thub pa dgon nas yong mkhan tshos gtso cher sgrung dang/ bla ma ma ni'i shod srol 'dzin/}
+rgyal mkhar chos rdzong ba|{bod dmangs khrod kyi zlos gar lha mo ba'i tshogs pa zhig yin pa de thog mar 'dzugs yul gzhis ka rtse sa khul khongs rin spungs rdzong gi chos rdzong dgon pa yin zhing/ dgon pa de stod smad khag gnyis su phye ba'i stod gser skyems dgon nas yong mkhan lha mo ba tshos gtso cher lha mo 'khrab cing/ smad thub pa dgon nas yong mkhan tshos gtso cher sgrung dang/ bla ma ma Ni'i shod srol 'dzin/}
 rgyal mkhar gzhung chu|{bod rang skyong ljongs kyi pa snam rdzong khongs su yod/}
 rgyal glu|1) {rgyal khab kyis gtan la phab nas so so'i rgyal khab mtshon byed kyi glu/} 2) {rgyal kha'i glu/}
 rgyal 'gong|{gdon 'dre zhig}
@@ -9350,7 +9350,7 @@ rgyal po chen po|1) {mi'i rgyal po che rigs/} 2) {lha'am mi min 'byung po'i bye 
 rgyal po lta bu'i sems bskyed|1) {sems bskyed nyer gnyis kyi nang gses/ dag pa sa gsum la gnas pa'i sems dpa'i rgyud kyi mngon par shes pa dang ldan pa'i sems bskyed ni mthu thogs pa med pas gzhan gyi don sgrub pa'i rgyal po chen po lta bu/} 2) {sems bskyed gsum gyi nang gses/ rang thog mar sangs rgyas nas sems can rnams sgrol bar bya'o snyam pa'i sems bskyed do/}
 rgyal po do ha|{do ha gsum gyi ya gyal zhig}
 rgyal po mdo lnga|{bzang po spyod pa'i smon lam gyi mdo dang/ rdo rje rnam 'joms khrus kyi mdo/ shes rab snying po lta ba'i mdo/ 'da' ka ye shes sgom pa'i mdo/ bya ba ltung bshags bshags pa'i mdo bcas lnga'o/}
-rgyal po mdo bcu|{rgyal po mdo lnga'i steng du dpag tu med pa tshe ring mdo dang/ gos sngon can ni gzungs kyi mdo/ gtsug tor gdugs dkar bzlog pa'i mdo/ nor rgyun ma ni nor gyi mdo/ yi ge gcig ma snying po'i mdo bcas bsnan pas bcu'o/}
+rgyal po mdo bcu|{rgyal po mdo lnga'i steng du dpag tu med pa tshe ring mdo dang/ gos sngon can ni gzungs kyi mdo/ gtsug tor gdugs dkar bzlog pa'i mdo/ nor rgyun ma Ni nor gyi mdo/ yi ge gcig ma snying po'i mdo bcas bsnan pas bcu'o/}
 rgyal po lde brgyad|{sngar bod rgyal bcu drug pa za nam zin lde dang/ bcu bdun pa 'phrul nam gzhung btsan lde/ bco brgyad pa se snol gnam lde/ bcu dgu pa se snol po lde/ nyi shu pa lde snol nam/ nyer gcig pa lde snol po/ nyer gnyis pa lde rgyal po/ nyer gsum pa lde sprin btsan te rgyal rabs brgyad po spyi'i ming/ lde}
 rgyal po dbu gnyis pa|{spyan ras gzigs kyi rnam 'phrul bod rje srong btsan sgam po'i dbu gtsug tu rgyal ba 'od dpag med kyi dbu rang chas su yod pas rgyal po dbu gnyis par grags/}
 rgyal po mang pos bkur ba|{(sasmata:) sngar 'jig rten du thog mar byung ba'i rgyal po zhig}
@@ -9977,7 +9977,7 @@ sgo them|{sgo'i them pa/ sgo them spangs pa/}
 sgo thel|{sgo la brgyab pa'i thel tshe/ khyim gyi sgo la sgo thel brgyab pa/}
 sgo thod|{sgo klad/}
 sgo thod mdzes rgyan|{bod lugs kyi pho brang sogs khang bzang gi sgo thod nas rim bzhin gdung ma seng can/ bab khebs/ bab/ kha shing/ lcam bcas mdzes spros rnams/}
-sgo mtha' yas pa sgrub pa'i mdo|{sho lo ka nyis brgya dang bcu pa 'gyur byang med pa/ sgo mtha' yas pa rnam par sbyong ba bstan pa'i le'u/ bam po bzhi pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba rakshi tas bsgyur ba/}
+sgo mtha' yas pa sgrub pa'i mdo|{sho lo ka nyis brgya dang bcu pa 'gyur byang med pa/ sgo mtha' yas pa rnam par sbyong ba bstan pa'i le'u/ bam po bzhi pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba rakshi tas bsgyur ba/}
 sgo dar|1) {khang pa'i sgor btags pa'i kha btags/} 2) {sgo steng gi dar cha/}
 sgo deb|{them tho/}
 sgo drug pa'i gzungs|{'gyur byang med pa/}
@@ -10133,7 +10133,7 @@ sgyu ma mkhan|1) {sgyu rtsed shes mkhan/ ming gi rnam grangs la sgyu ma ba dang/
 sgyu ma mkhan bzang po lung bstan pa'i le'u|{bam po gcig pa/ rgya gar gyi mkhan po dzi na mi tra dang/ pradznyA warma dang/ lo tsA ba bande ye shes sde la sogs pas bsgyur cing zhus pa/}
 sgyu ma ngal gso|{chos thams cad sgyu ma'i dpe brgyad kyis ston pas bden zhen gyi 'ching ba gcod par byed pa'i bstan bcos le'u brgyad yod pa'i rtsa 'grel gnyis ldan gyi gzhung 'di ni/ dus rabs bcu bzhi par rnying ma'i slob dpon klong chen rab 'byams kyis mdzad pa'o/}
 sgyu ma chen po|{rnal 'byor ma'i rgyud sde las le'u gsum pa/ rgya gar gyi mkhan po dzi na pa ra dang/ lo tsA ba 'gos lhas btsas kyis bsgyur cing slar yang klog skya shes rab brtsegs kyis bsgyur pa/}
-sgyu ma lta bu'i ting nge 'dzin gyi mdo|{bam po phyed dang gnyis dang le'u dgu pa/ rgya gar gyi pandi ta su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur pa/}
+sgyu ma lta bu'i ting nge 'dzin gyi mdo|{bam po phyed dang gnyis dang le'u dgu pa/ rgya gar gyi pandi ta su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur pa/}
 sgyu ma bdun|{sgyu lus bdun dang don gcig}
 sgyu ma pa|{sgyu ma mkhan/}
 sgyu ma'i sku|{sgyu lus dang don gcig}
@@ -10202,7 +10202,7 @@ sgra gcan thebs pa|{gza' rA hu la'i gdong mjug gang rung gi grib gzer phog pa/}
 sgra gcan gdong|{sgra gcan gyi gdong dang sgra gcan rtsa ba gnyis don la khyad med kyang nyi zla gza' 'dzin shes pa'i ched du gza' gzhan rgyu skar la spyod tshul dang bstun nas sgra gcan gyi gdong zhes rtsa ba las logs su bshad/}
 sgra gcan rtsa ba|{sgra gcan rang 'gros g.yas bskor yin pas nam gru nas g.yas bskor du brtsis pa'i skar ma rjes 'brang dang bcas pa'i sgra gcan gyi nges pa la sgra gcan rtsa ba zer/ rtsa ba'i 'gros kyi dbang du byas pas so/}
 sgra gcan 'dzin|<{rAhula}:> 1) {rgyal rigs sgra gcan 'dzin shAkya thub pa'i nyan thos nye 'khor bcu'i gras kyi bslab pa la gus pa rnams kyi mchog tu gyur pa zhig yin pa de ni shAkya mu ne rab tu ma byung gong gi sras yin/} 2) {gnas brtan bcu drug las pri yang ku'i gling na bzhugs pa'i gnas brtan zhig}
-sgra gcan 'dzin bzang po|{sngar rgya gar nA lendra'i mkhan po slob dpon klu sgrub rab tu byung ba'i mkhan po/}
+sgra gcan 'dzin bzang po|{sngar rgya gar nA len+d+ra'i mkhan po slob dpon klu sgrub rab tu byung ba'i mkhan po/}
 sgra gcan zhag gsum|{sgra gcan zhag gsum la slebs tshul/}
 sgra ji bzhin pa|{brjod pa dang don gnyis gcig mthun yin pa/}
 sgra ji bzhin ma yin pa|{brjod pa dang don gnyis tha dad yin pa/}
@@ -10222,7 +10222,7 @@ sgra don gnyis ka snang ba'i rtog pa|{sgra spyi dang don spyi gnyis ka snang ba'
 sgra drag pa|1) {pho yig gi sgra gdangs/} 2) {skad gdangs che ba/}
 sgra gdangs|{dbyangs kyi 'gyur khug}
 sgra mdo bzhi|{ka lA pa/ tsandra pa/ dbyangs can ma/ pA nipa dang bzhi/}
-sgra ldan|1) {yi ge rnams rang rang gi skye gnas nas byung ba'i sgra phyir thon pa'i rtsol ba che chung gi dbang gis dbye bas bod yig gi ga nga ja nya da na ba ma dza wa 'a ya ra la ha a i au e o ste nyi shu dang/ legs sbyar skad kyi ha ba bsdu ba'am ha ya wa ra la nya na na nga ma dzha dha dha gha bha dza ta da ga ba ste nyi shu bcas la sgra ldan zer/ ga ha ba} 2) {srog ldan/} 3) {(mngon) }1.{sprin pa/ }2.{shing rta/}
+sgra ldan|1) {yi ge rnams rang rang gi skye gnas nas byung ba'i sgra phyir thon pa'i rtsol ba che chung gi dbang gis dbye bas bod yig gi ga nga ja nya da na ba ma dza wa 'a ya ra la ha a i u e o ste nyi shu dang/ legs sbyar skad kyi ha ba bsdu ba'am ha ya wa ra la nya Na na nga ma dzha Dha dha gha bha dza Da da ga ba ste nyi shu bcas la sgra ldan zer/} 2) {srog ldan/} 3) {(mngon) }1.{sprin pa/ }2.{shing rta/}
 sgra ldan can|{(mngon) khrims khang/}
 sgra ldan lha|{(mngon) dbyangs can ma/}
 sgra sdeb|{yi ge'i brda sbyor/ dbyangs gsal 'phul rten mgo 'dogs sogs kyi sbyor ba ma nor ba'i sgra sdeb gsal ba/}
@@ -10474,8 +10474,8 @@ sgrol 'don|{ko ba dang gru la brten nas chu las sgrol zhing 'don pa/}
 sgrol ba|{(tha dad pa) bsgral ba/ bsgral ba/ sgrol//}1) {thar bar byed pa'am 'don par byed pa/ srog gi 'dzid pa las sgrol bar byed/ btson khang las sgrol ba/ chu bo las bsgral te 'gram ngogs su bton/} 2) {gsod khrims bcod pa'am gsod par byed pa/ gnod byed thams cad sgrol bar byed/} 3) {ring du skrod pa'i 'bud par byed pa/ dgra bo rnams pha rol tu sgrol ba/} 4) {(rnying) }1. {skol ba/ }2. {zhu ba/}
 sgrol ba'i shing rta|{(mngon) gru'i skya ba/}
 sgrol byed|{(mngon) nyi ma/}
-sgrol ma|{(tArA) 'jigs pa brgyad las sgrol ba'i cha nas btags pa'i yi dam lha mo'i rigs shig ste/ nang gses su sku mdog dang phyag mtshan mi 'dra ba brten nas dbe a nyer gcig sogs phye yod/ ming gi rnam grangs la rgyal yum dang/ chos kyi dpal mo/ mchog gi ma/ 'jig rten dbang phyug sras mo/ myur skyob/ phongs skyob/ zhi ma legs byin ma/ om mdzad bcas so/}
-sgrol ma 'jigs pa brgyad skyob|{seng ge dang/ glang chen/ me sburul/ rkun po/ lcad sgrog chu/ sha za bcas kyi 'jigs pa brgyad las skyob pa'i sgrol ma/}
+sgrol ma|{(tArA) 'jigs pa brgyad las sgrol ba'i cha nas btags pa'i yi dam lha mo'i rigs shig ste/ nang gses su sku mdog dang phyag mtshan mi 'dra ba brten nas dbye ba nyer gcig sogs phye yod/ ming gi rnam grangs la rgyal yum dang/ chos kyi dpal mo/ mchog gi ma/ 'jig rten dbang phyug sras mo/ myur skyob/ phongs skyob/ zhi ma legs byin ma/ oM mdzad bcas so/}
+sgrol ma 'jigs pa brgyad skyob|{seng ge dang/ glang chen/ me sburul/ rkun po/ lcags sgrog chu/ sha za bcas kyi 'jigs pa brgyad las skyob pa'i sgrol ma/}
 sgrol ma nyi shu rtsa gcig myur dpa' ma dang|{g khro ba dkar ma/ gser mdog can ma/ gtsug tor rnam rgyal ma/ hUm sgrogs ma/ 'jig rten gsum rgyal ma/ gzhan 'joms ma bdud ga 'joms ma/dkon mchog gsum mchod ma/ bdud dbang sdud ma/ phongs pa kun sel ma/ me ltar 'bar ma/ khro gnyer can ma/ bkres 'byin ma/ zhi ba chen mo/ rims nad kun sel ma/ dngos grub kun stsol ma/ dug gsel ma/ sdug bsngal kun sel ma/ rig pa hUm sgrol ma/ 'jig rten gsum g.yo ma bcas nyer gcig go /}
 #sgrol ma g.yul zlog rje btsun sgrol ma la brten nas bar chad kyi g.yul ngo lzog pa'i chos ga|
 sgrol sher|{sgrol chog dang shes rab snying po gnyis kyi bsdus tshig}
@@ -12407,7 +12407,7 @@ bcad lhag 'breg gcod byas pa'i lhag 'phro|{gos chen bcad lhag shing tog bcad lha
 bcad lhug|{tshigs bcad dang tshig lhug}
 bcad lhug spel ma|{tshigs bcad tshig lhug 'dres ma/}
 bcad lhug spel ma'i snyan tshig|{tshigs bcad dang tshig lhug 'dres ma'am rim bzhin spel ba'i snyan ngag gi tshig rgyan/}
-bcad lhug spel gsum|{tshigs bcad tshig lhug so so dang de gnyis ad lhug spel gsum/}
+bcad lhug spel gsum|{tshigs bcad tshig lhug so so dang de gnyis spel ba ste gsum/}
 bcab pa|{'cab pa'i ma 'ogns pa/}
 bcab pa'i bsam pa|{byas nyes sogs gzhan la gsang ste sba ba'i bsam pa/}
 bcabs pa|{bchab pa'i 'das pa/}
@@ -12925,10 +12925,10 @@ chag pa|1. {(tha mi dad pa)} 1) {dum bur zhig pa dang/ sil bur gyur pa/ dkar yol
 chag po|{dngos rigs chag nas byung ba'i dum bu/}
 chag phad|{rta drel la chag ster snod/}
 chag med 'bad sgrub|{rgyun mi 'chad par 'bad brtson chen pos sgrub pa/}
-chag ce|{chag tshe dang 'dra/}
+chag tse|{chag tshe dang 'dra/}
 chag tshang ku ba|{ka ped pho rigs kyi ming gi rnam grangs shig}
 chag tshad|{ring thung gi cha tshad dam phyag tshad/}
-chag che|{(rnying) tshwa dang sdor med pa'i thug pa sla po/}
+chag tshe|{(rnying) tshwa dang sdor med pa'i thug pa sla po/}
 chag gzhong|{rta la chag ster sa'i gzhong pa/}
 chag bzhag|1) {nges pa can/} 2) {dper mtshon pa/}
 chag yang|{'khri cha'i grangs 'bor nyung du gtong ba'i ming/ skyed kha chag yang gtong ba/ khral 'bab chag yang gtong ba/ nyes chad chag yang gtong ba/}
@@ -13000,7 +13000,7 @@ chang dod|{chang gi tshab dngul/}
 chang dregs|{chang gis myos pa/ glang chen chang drengs can/}
 chang 'dan|{(yul) bskol ldan/}
 chang nad|{chang btung drags pa'i nad/ chang nad chang gis gso/}
-chag snod|{chang blug snod/}
+chang snod|{chang blug snod/}
 chang pa|{chang la dga' mkhan/}
 chang spags|1) {chang gis brdzis pa'i zan/} 2) {chang dang sbrags nas za ba'i kha zas sha tshal sogs/}
 chang phabs|{chang rtsi/}
@@ -13141,7 +13141,6 @@ char rdo|{bon gyi lugs srol char 'bebs la dgos pa'i rdzas dud 'gro bsad pa'i rdo
 char ldan|{(mngon)} 1) {sprin/} 2) {dbyar dus/}
 char sdod byi'u|{khug rta'am 'dag byi'u/ char sdod byi'u skom na yang/ sa la 'bab pa'i chu mi 'thung/}
 char sne rlung khrid|{bya spyod ngan pa'am rkyen ngan gyi sne 'khrid byed pa'i dpe/}
-char sne rlung khrid|{bya spyod ngan pa'am rkyen ngan gyi sne 'khrid byed pa'i dpe/}
 char pa|{chu rlangs grang mo chags shing zil bur gyur te gnam nas mar 'bab pa'i thigs pa/ zhod char/ sbrang char/ drag char/ zim char/ char pa bab tshad/ char pas gos bngas pa/ ming gi rnam grangs la mkha' las bab dang/ gru char/ dgung char/ rgyun bab/ chu'i sa bon/ sprin gyi me tog sprin bcud/ sbrang char/ rlung gi 'bras bu/ lo tog gnyen bcas so/}
 char pa chu grogs|{char pa chu'i grogs po'm/ chu yar 'phel ba'i mthun rkyen du 'gyur ba ste gcig grogs gcig phan gyi dpe/ zhing 'brog phan tshun brje tshong byas na char pa chu grogs bzhin du phan thogs yong/}
 char sprin|{char pa 'bab rgyu yod pa'i sprin/}
@@ -13279,7 +13278,7 @@ chu khebs|{sge khung gi steng nas btang ba'i char khebs/}
 chu khol|{bskol zin pa'i chu khol ma/}
 chu mkhris|{(mngon) rgod ma kha'am rta gdong gi me/}
 chu mkhregs|{(mngon) ser ba/}
-chu 'khor|1) {chus skor ba'i rang 'thag} 2) {chus skor ba'i ma ni'i 'khor lo/} 3) {chu bo'i klong 'khor/ ming gi rnam grangs la 'khor chu dang/ 'khyil pa/ chu'i 'khor lo/ zegs ma'i sde bcas so/}
+chu 'khor|1) {chus skor ba'i rang 'thag} 2) {chus skor ba'i ma Ni'i 'khor lo/} 3) {chu bo'i klong 'khor/ ming gi rnam grangs la 'khor chu dang/ 'khyil pa/ chu'i 'khor lo/ zegs ma'i sde bcas so/}
 chu 'khrug|{(mngon) chu'i rba rlabs/}
 chu gang|{(rnying)} 1) {snying stobs/} 2) {legs pa/}
 chu gar|{sa ming zhig si khron zhing chen rnga ba bod rigs rang skyong khul khongs btsan lha rdzong gi byang rgyud na yod/ 1935 lo'i zla ba drug par krung go'i bzo zhing dmar dmag rgyang skyod byed skabs kyi lam bar sa cha 'dir krung gung krung dbyang gis chab srid cus kyi gros tshogs shig 'tshogs nas krang go tha'o yi bros byol ring lugs dang phyir shig lam phyogs la dgag pa brgyab cing/ dmar dmag mu mthud nas byang phyogs su bskyod rgyu'i gros thag bcad pa red/}
@@ -13446,7 +13445,7 @@ chu sbyin ma|{(mngon) chu bo ganggA/}
 chu sbrul|1) {lo rgan drug cu'i ya gyal zhig} 2) {chu'i nang du gnas thub pa'i sbrul rigs shig}
 chu ma|1) {chu 'dren sa yod pa'i zhing ga / gshong gsum chu ma zhing gi sa/ zhing la 'bras drug smin pa'i sa/} 2) {chu len mkhan/} 3) {(mngon) }1. {mo mtshan/ }2. {chang/}
 chu ma lcags|{rtsis kyi ma bu dgra grogs kyi ya gyal zhig}
-chu ma ni|{chu rgyug rgyug dang/ ma ni 'dren 'dren te skad cha thags thogs med par shod tshul/}
+chu ma Ni|{chu rgyug rgyug dang/ ma Ni 'dren 'dren te skad cha thags thogs med par shod tshul/}
 chu ma rtsi|{thang sman gyi rigs te/ ro skyur la bska ba/ zhu rjes drod/ nus pas bshal gyi sna 'dren zhing skyug pa srung ba dang/ dmu chu'i nad sbyong bar byed/}
 chu mang ldan pa|{(mngon) rgya mtsho/}
 chu mig|1) {sa nas rdol ba'i chu 'go/ chu mig rang nyid ma skam na/ sa yis mnan pas ga la thub/} 2) {bod rang skyong ljongs rnam gling rdzong gi sa cha sngar bod khri skor bcu gsum gyi ya gyal zhig}
@@ -13633,7 +13632,7 @@ chu'i bud shing can|{(mngon) rgod ma kha'i me/}
 chu'i byi ba|{(mngon) sram/}
 chu'i zhal ta|{(mngon) chu'i do dam pa/}
 chu'i zegs ma|{(mngon) char zil/}
-chu'o ro|{(mngon) tshwa/}
+chu'i ro|{(mngon) tshwa/}
 chu'i lang tsho|{(mngon) me tog gpad ma/}
 chu'i sa bon|{(mngon) char pa/}
 chu'i srin po'i grong khyer|{(mngon) rgya mtsho/}
@@ -13708,7 +13707,7 @@ ched brjod|{ched du dmigs nas bshad pa'am dmigs su bkar nas bshad pa/}
 ched gtad|{dmigs bkar/ ched gtad du kha lan gtong ba/ ched gtad kyis 'phral du thag gcod byas pa/ ched gtad las 'gan gzab nan gyis byed dgos/}
 ched gtong|{dmigs bkar gyis gtong ba/}
 ched du brjod pa'i sde|{(audInam) gsung rab yan lag bcu gnyis kyi nang gses/ gang zag 'ga' zhig gi phyir gsung ba min par/sangs rgyas kyi bstan pa yun ring du bzhag pa'i phyir gzhan gyis ma bskul bar thugs dgyes pa'i tshul gyis ched du gsungs pa'o/}
-ched du brjod pa'i choms|{sangs rgyas kyis thor bur gsungs pa rnams dgra bcom pa chos skyob kyis phyogs gcig tu bsdus pa la bam po bzhi dang mi rtag pa'i tshoms nas bram ze'i tshoms kyi bar du le'u sum cu rtsa gsum yod pa zhig}
+ched du brjod pa'i tshoms|{sangs rgyas kyis thor bur gsungs pa rnams dgra bcom pa chos skyob kyis phyogs gcig tu bsdus pa la bam po bzhi dang mi rtag pa'i tshoms nas bram ze'i tshoms kyi bar du le'u sum cu rtsa gsum yod pa zhig}
 ched du bya ba|1) {thun mong ma yin pa'i dmid yul can gyi bsgrub bya/ dus gcig la las ched du bya ba mang po byed mi rung/} 2) {rnam dbye bzhi pa dgos ched/}
 ched don|{rkang btsugs nas brjod pa'i don te/ sngar gzhung yig gong nas 'og la btang ba'i bka' shog sogs kyi 'gor 'god pa'i tshig cig sa gnas las byed thun mong la/ ched don/}
 ched 'bul|{ched du 'bul ba ste gtong yig gi 'gor 'god pa'i tshig cig 'thus mi lhan 'dzoms kyi drung du/ ched 'bul/}
@@ -13737,8 +13736,7 @@ cher 'jig|{(mngon) 'jig pa'i bskal pa/}
 ches|{ha cang ngam shin tu/ ches mtho/ ches mang ba/ stobs shugs ches che ba/ ches stobs chung ba/ ches mchog tu gyur pa/ ches myur ba/ ches gsang ba/ ches khyad par du 'phags pa/ ches yid du 'ong ba/ ston mo ches gya nom pa zhig bshams pa/ glog zhu'i 'od ches gsal ba/ bslab pa ches cher rgan pa/ nad kyis yun ring mnar ba'i mi kho'i gdong gi kha stabs sngar las ches rgas par gyur 'dug}
 ches pa|{(tha mi dad pa) blo 'khel ba/ mang tshogs kyis yid ches pa/}
 cho|{(yul) snying po'am 'bras bu/ las ka der cho mi 'dug gtam cho yod pa la nyon/ cho med pa'i bya ba ma byed/ kho tsho'i bzo cho gang la brtat kyang tha chad ngan sdug kho na 'dug}
-cho ga|{las don sgrub thabs dang/ bya ba byed stangs sam/ go rim/ sman bcos kyi cho ga / mchod pa'i cho ga / dkyil 'khor gyi}
-cho ga|{cho ga nyams pa/ ji ltar cho ga ltar byed pa/ cho ga'i spyi chings/ dga' ston gyi cho ga / bgod pa'i don ni bgod byed kyi/ grangs su sdud pa'i cho ga yin/ cho ga 'di yis 'khrul med shes/}
+cho ga|{las don sgrub thabs dang/ bya ba byed stangs sam/ go rim/ sman bcos kyi cho ga / mchod pa'i cho ga / dkyil 'khor gyi cho ga/ cho ga nyams pa/ ji ltar cho ga ltar byed pa/ cho ga'i spyi chings/ dga' ston gyi cho ga / bgod pa'i don ni bgod byed kyi/ grangs su sdud pa'i cho ga yin/ cho ga 'di yis 'khrul med shes/}
 cho ga gsum bskyed|{lha bskyed pa'i tshul zhig ste/ pad nyi la sogs pa'i gdan gyi steng du lha'i sa bon las byung ba'i phyag mtshan sa bon gyis mtshan pa yongs su gyur pa las lha'i sku rdzogs par bskyed pa/}
 cho nge|{smre sngags te sdug skad dang 'o dod 'bod bzhin du ngu ba/ mya ngan ma bzod par cho nge 'bod pa/ sems sdug chen pos cho nge 'debs pa/ cho nge bton nas skad 'gags pa/ snga dus srang lam zhig na dwa phrug mang pos cho nge 'don bzhin du phyogs mtshams kun tu rgyu ba/}
 cho nge 'o dod|{ngu ba'am mya ngan gyi 'bod skad/ sems sdug yi mug gis cho nge 'o dod 'bod pa/}
@@ -13780,7 +13778,7 @@ chod don|{rtsod gzhi 'dum 'grig gi don gnad/}
 chod 'doms|{thag chod pa'i 'jug 'doms/}
 chod pa|{(tha mi dad pa) bar mtshams chod pa/ lung pa phan tshun ri klung gis bar du chod pa/ le dbar khri phrag gis chod pa/ kha bas 'gro lam chod pa/ 'brel thag rbad de chod pa/}
 chod ma|{(yul) zhing la chu gtong ched khag chung ngu byas pa'i khag re'i ming/}
-chod yig rtsod gzhi 'dum 'grig byung ba'i yi ge|{dmag mtshams 'jog rgyu'i chod yig}
+chod yig|{rtsod gzhi 'dum 'grig byung ba'i yi ge/ dmag mtshams 'jog rgyu'i chod yig}
 chod yig 'ba' can|{kha dan gyi gan rgya 'ba' can nam/'ba' bzhag pa'i chod yig}
 chon|1) {gos kyi sgab gsham mam mtha'/ phyi chon/ nang chon/} 2) {gur gyi zur ram mtha'/}
 chon chung|{(yul) sbra 'bubs byed chon thag thung ba/}
@@ -13924,7 +13922,7 @@ chos gcod|{(mngon) rigs dman pa/}
 chos bcas ma|{(mngon) bag ma'am khyim bdag mo/}
 chos bcu pa'i mdo|{'phags pa chos bcu pa'i le'u bam po gnyis pa/ shlo ka lnga bcu rtsa gcig pa/ rgya gar gyi mkhan po dzi na mi tra sogs dang/ lo tsA ba bnde ye shes sde la sogs pas bsgyur cing zhus pa/}
 chos chas|1) {chos kyi cha lugs/} 2) {chos kyi yo byad/}
-chos mchog sbyor lam nges 'byed cha bzhi'i nang gses|{so so rang rig pa'i ye shes kyis bden pa rnams la dmigs te sgom pa na de ma thag pa'i rjes su mthong lam skyes pas 'dzin pa rang bzhin med par rtogs pa'i gsal snang 'bring po thob pa'i ting 'dzin shes rab mtshungs ldan dang bcas pa ste/'jig rten pa'i chos kyi nang nas mchog tu gyur pa'o/}
+chos mchog|{sbyor lam nges 'byed cha bzhi'i nang gses/ so so rang rig pa'i ye shes kyis bden pa rnams la dmigs te sgom pa na de ma thag pa'i rjes su mthong lam skyes pas 'dzin pa rang bzhin med par rtogs pa'i gsal snang 'bring po thob pa'i ting 'dzin shes rab mtshungs ldan dang bcas pa ste/'jig rten pa'i chos kyi nang nas mchog tu gyur pa'o/}
 chos mchog gi rtse sbyor|{sher phyin don bdun cu'i nang gses/ mthong lam skyed pa'i nus ldan gyi ting nge 'dzin mtha' yas pas sems kun tu gnas pa thob pa'i rtse mo gang zhig sbyor lam chos mchog gis bsdus pa'o/}
 chos mchog pa|{nyan thos gos dmar ba'i sde pa'i khongs gtogs shig}
 chos 'chad pa|1) {chos shod pa/} 2) {chos kyi tshig don shod mkhan/}
@@ -13940,11 +13938,11 @@ chos nyid zad pa'i snang ba|{chos zad blo 'das kyi snang ba dang don gcig chos m
 chos gtong ba|{chos blos gtong ba'am/ spong ba/}
 chos stegs|{glegs bam 'jog sa'i khri stegs/}
 chos ston|1) {chos kyi dus ston nam/ dga' ston/} 2) {bsod snyoms/}
-chos ston sogs kyi sde tshan|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ bcu tshan dgu pa la/ grong du rgyu ba'i ltung byed dang/ rgyal po'i pho brang du 'dug pa'i ltung byed dang/ khyad du gsod pa'i ltung byed dang/ khab ral byed pa'i ltung byed dang/ khri rkang 'chos pa'i ltung byed dang/ shing bal bgos pa'i ltung byed dang/ gding ba tshad lhag byed pa'i ltung byed dang/ g.yan dgab tshad las lhag pa'i ltung byed dang/ ras chen tshad las lhag pa'i ltung byed dang/ chos gos tshad las lhag pa'i ltung byed de bcu'o/}
 chos ston pa|1) {chos kyi lam ston mkhan/} 2) {chos 'chad pa/}
-chos ston tshul nyer drug nyes byas kyi sde tshan bdun pa chos ston tshul gyi sde la|{nyan po mi na bzhin du 'dug pa la rang nyid 'grengs te chos 'chad pa dang/ de bzhin du nyal ba dang/ khri stan che mthor 'dug pa dang/ mdun du 'gro ba la rgyab nas chos 'chad pa dang/ lam gyi dbus nas 'gro ba la lam po'i 'gram nas chos 'chad pa dang/ mi na bar mgo g.yogs pa dang/ gos brdzes pa dang/ bla gos phrag par gzar ba dang/ lag pa gnya' gong du bsnol ba dang/ ltag par bsnol ba dang/ skra spyi bor bsdus te do ker can dang/ zhwa gyon pa dang/ cod pan btags pa dang/ me tog gi phreng ba bcings pa dang/ la thod dkris pa dang/ glang chen la zhon pa dang/ rta la zhon pa dang/ khyogs kyi steng na 'dug pa dang/ shing rta'i steng na 'dug pa dang/ mchil lham gyon pa dang/ 'khar ba thogs pa dang/ gdugs thogs pa dang/ mtshon cha thogs pa dang/ ral gri thogs pa dang/ mda' gzhu thogs pa dang/ go cha gyon pa bcas la chos bshad pa ste nyer drug go /}
+chos ston tshul nyer drug|{nyes byas kyi sde tshan bdun pa chos ston tshul gyi sde la/ nyan po mi na bzhin du 'dug pa la rang nyid 'grengs te chos 'chad pa dang/ de bzhin du nyal ba dang/ khri stan che mthor 'dug pa dang/ mdun du 'gro ba la rgyab nas chos 'chad pa dang/ lam gyi dbus nas 'gro ba la lam po'i 'gram nas chos 'chad pa dang/ mi na bar mgo g.yogs pa dang/ gos brdzes pa dang/ bla gos phrag par gzar ba dang/ lag pa gnya' gong du bsnol ba dang/ ltag par bsnol ba dang/ skra spyi bor bsdus te do ker can dang/ zhwa gyon pa dang/ cod pan btags pa dang/ me tog gi phreng ba bcings pa dang/ la thod dkris pa dang/ glang chen la zhon pa dang/ rta la zhon pa dang/ khyogs kyi steng na 'dug pa dang/ shing rta'i steng na 'dug pa dang/ mchil lham gyon pa dang/ 'khar ba thogs pa dang/ gdugs thogs pa dang/ mtshon cha thogs pa dang/ ral gri thogs pa dang/ mda' gzhu thogs pa dang/ go cha gyon pa bcas la chos bshad pa ste nyer drug go /}
+chos ston sogs kyi sde tshan|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ bcu tshan dgu pa la/ grong du rgyu ba'i ltung byed dang/ rgyal po'i pho brang du 'dug pa'i ltung byed dang/ khyad du gsod pa'i ltung byed dang/ khab ral byed pa'i ltung byed dang/ khri rkang 'chos pa'i ltung byed dang/ shing bal bgos pa'i ltung byed dang/ gding ba tshad lhag byed pa'i ltung byed dang/ g.yan dgab tshad las lhag pa'i ltung byed dang/ ras chen tshad las lhag pa'i ltung byed dang/ chos gos tshad las lhag pa'i ltung byed de bcu'o/}
 chos thag chos po ti'i sked chings te glegs thag chos thams cad kyi yon tan bkod pa'i rgyal po'i mdo|{pandi ta pradznyA warma dang/ lo tsA ba ye shes sdes bsgyur cing zhus pa/}
-chos thams cad kyi rang bzhin mnyam nyid rnam par spros pa ting nge 'dzin gyi rgyal po'i mdo|{mdo bam po bco lnga dang le'u so dgu pa/ pandi ta shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa/}
+chos thams cad kyi rang bzhin mnyam nyid rnam par spros pa ting nge 'dzin gyi rgyal po'i mdo|{mdo bam po bco lnga dang le'u so dgu pa/ pandi ta shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa/}
 chos thams cad mngon par byang chub pa la mi 'jigs pa|{rtogs pa phun tshogs la mi 'jigs pa dang don gcig}
 chos thams cad stong pa nyid|{phyi nang gi chos rnams kyi spyi'i mtshan nyid mi rtag pa dang/ sdug bsngal ba/ stong pa/ bdag med pa zhes pa de la don dam par chos thams cad ngo bo nyid med pa ste stong nyid bcu drug gi ya gyal zhig}
 chos thams cad 'byung ba med par bstan pa'i mdo|{mdo bam po gsum pa/ lo tsA ba bande rin chen 'tshos bsgyur/}
@@ -14017,7 +14015,7 @@ chos mdzad|1) {chos byed pa/} 2) {grwa pas tshogs yongs la gtong sgo btang nas l
 chos rdzong|{sa ming zhig bod rang skyong ljongs kyi spo mes rdzong khongs kyi sde zhig}
 chos gzhis|{sngar dgon pa grwa tshang khag gis bdag tu 'dzin pa'i gzhis ka/}
 chos gzhis mi rtsa|{sngar dgon pa khag gi gzhis kas bdag tu bzung ba'i mi ser/}
-chos bzhi pa'i mdo|{'phags pa chos bzhi bstan pa zhes bya ba'i mdo/ shlo ka bcu gsum pa pandi ta su rendra bo dhi dang/ bande ye shes sdes bsgyur cing zhus pa'o/}
+chos bzhi pa'i mdo|{'phags pa chos bzhi bstan pa zhes bya ba'i mdo/ shlo ka bcu gsum pa pandi ta su ren+d+ra bo dhi dang/ bande ye shes sdes bsgyur cing zhus pa'o/}
 chos bzhin|{chos dang mthun pa/ sdig ltung thams cad chos bzhin du phyir bcos pa/ chos bzhin ma yin pa/}
 chos zad blo 'das kyi snang ba|{snang ba bzhi'i nang gses/ snang ba thams cad thig le chen po gcig gi dkyil 'khor du dag nas blos btags pa'i chos so cog thams cad chos nyid kyi klong du zad cing chos nyid du 'dzin pa tsam yang med pas zad pa'i mthar phyin pa chos sku'i snang ba mthong ba'o/}
 #chos zog rnyed bkur gyi don du 'tshong ba'i chos|
@@ -14665,7 +14663,7 @@ mjug brtul|{mjug bsdus pa/ bya ba ngan pa'i mjug brtul te bya ba bzang po la 'ju
 mjug thogs|{de ma thag gam de 'phral/ 'char gzhi bkod pa'i mjug thod su las grwa btsugs/ glog 'od mthong ba'i mjug thogs su 'brug sgra thos/}
 mjug thogs kyi skad cig ma|{skad cig dang po 'das ma thag pa'i skad cig gnyis pa/}
 mjug thon|{mthar thon pa'am mthar phyin pa/ shes rig slob sbyong gi mjug thon pa byed dgos/}
-mjug thud|{mu 'thud pa'am 'phro mthud pa/ snga mjug phyi mthud/ las don snga ma'i mjug mthud nas las don rjes ma'i 'go brtsugs pa/}
+mjug mthud|{mu 'thud pa'am 'phro mthud pa/ snga mjug phyi mthud/ las don snga ma'i mjug mthud nas las don rjes ma'i 'go brtsugs pa/}
 mjug rdum|1) {a gsar tsha po'i dpe/} 2) {gzhug gu thung ngu'am rnga mdum pa/ rta drel mjug rdum/}
 mjug sdud|1) {las mjug sgril thabs byed pa/} 2) {rgyas bshad kyi mthar snying po bsdu ba/}
 mjug sdom|{mtha' ma'i don bsdu/ mjug bsdoms snying don/}
@@ -14721,13 +14719,13 @@ mjol|{mjal ba'i skul tshig}
 'jab bu|1. {rkun ma/ }2. {mngon chung dang/ mngon mtsham med pa/ 'jab bus mda' 'phen/ 'jab bus skyon 'tshol/ mngon sum du 'phrog bcom dang 'jab bus rku ba/}
 'jab bu ba|{rkun ma/}
 'jab myul ba|1) {mngon chung gis so lta byed pa/} 2) {'jab cing myul ba po/}
-'jab dmag 'jabs nas dmag rgyag mkhan|{dgra bos ma tshor bar 'jab dmag rgyag pa/}
-'jab ce|{(rgya) kha spu 'thog byed dang tsher ma 'don pa'i yo byad cig}
+'jab dmag|{'jabs nas dmag rgyag mkhan/ dgra bos ma tshor bar 'jab dmag rgyag pa/}
+'jab tse|{(rgya) kha spu 'thog byed dang tsher ma 'don pa'i yo byad cig}
 'jab rtse|{'jab tse dang 'dra/}
 'jab rtse kha|{(yul) kha'i mchu srab mo leb leb can gyi ngan ming/}
 'jab tshe|{'jab tse dang 'dra/}
 'jab len|{'jabs nas len pa'am/ rku ba/}
-'jab pa|{'jab pa'i 'das pa/}
+'jabs pa|{'jab pa'i 'das pa/}
 'jam|{thug pa/ 'o ma'i 'jam/}
 'jam skyugs|{skyugs sman gyi sbyor sde thang bskol nas khu ba btang ste 'jam pa'i sgo nas nad gyen du skyug par byed pa'i thabs shig}
 'jam khrid|{'jam po'i sgo nas bzang lam du khrid pa/}
@@ -14739,7 +14737,6 @@ mjol|{mjal ba'i skul tshig}
 'jam mgon bla ma|{bstod yul 'jam dbyangs su mos pa'i che brjod/}
 'jam cag ge ba|{'jam chag ge ba dang 'dra/}
 'jam chag ge ba|{'jam thing nge/ lhod cing 'jam chag ger gnas/}
-'jam char|{char pa sil sil/}
 'jam char|{char pa sil sil/}
 'jam 'chags|{lhing 'jags/ rgyal khams 'jam 'chags su 'jug pa/}
 'jam ljang|{(mngon) ne rtso/}
@@ -14767,15 +14764,15 @@ mjol|{mjal ba'i skul tshig}
 'jam dpal|{'jam dpal dbyangs kyi bsdus tshig}
 'jam dpal khro bo|{rdo rje 'jigs byed dang/ dgra nag gdong drug gshed dmar sogs 'jam dpal drag po'i rnam 'gyur can/}
 'jam dpal gyi mtshan brgya rtsa brgyad pa|{'gyur byang med pa rgyud kyi glegs bam zhig}
-'jam dpal gyi sangs rgyas kyi zhing gi yon tan bkod pa|{'jam dpal gyi sangs rgyas kyi zhing gi yon tan bkod pa bstan pa'i le'u bam po bzhi pa/ rgya gar gyi mkhan po shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus te skad gsar bcad kyis bcos pa zhig}
-'jam dpal gyis bstan pa'i mdo|{shlo ka phyed dang bco lnga pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba zhig}
+'jam dpal gyi sangs rgyas kyi zhing gi yon tan bkod pa|{'jam dpal gyi sangs rgyas kyi zhing gi yon tan bkod pa bstan pa'i le'u bam po bzhi pa/ rgya gar gyi mkhan po shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus te skad gsar bcad kyis bcos pa zhig}
+'jam dpal gyis bstan pa'i mdo|{shlo ka phyed dang bco lnga pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba zhig}
 'jam dpal gyis dris pa'i mdo|{'phags pa 'jam dpal gyis dris pa'i mdo shlo ka dgu bcu bam po gcig tu byas pa 'gyur byang med pa zhig}
 'jam dpal rgya mtsho|{tA la'i bla ma sku phreng brgyad pa 'di rab byung bcu gsum pa'i sa stag lor 'khrungs/ lcags glang lor gong ma chan lung gi bka' 'brel rgyal srid dang chos srid bzhes/ shing byi lor gshegs/ (1758-}1804)
 'jam dpal ngag gi dbang phyug la bu mo brgyad kyis bstod pa|{de bzhin gshegs pa'i rigs kyi 'khor los bsgyur ba'i rgyud kyi gras shig}
 'jam dpal rdo rje|{'jam dpal dbyangs kyi bye brag cig ste gsang 'dus 'jam dpal rdo rjes zhes bya'o/}
-'jam dpal gnas pa'i mdo|{shlo ka brgya bzhi bcu pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba zhig}
-'jam dpal rnam par 'phrul pa'i le'u|{bam po gcig dang shlo ka go bzhi pa/ rgya gar gyi mkhan po shi lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa zhig}
-'jam dpal rnam par rol pa'i mdo|{bam po gnyis pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa zhig}
+'jam dpal gnas pa'i mdo|{shlo ka brgya bzhi bcu pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur ba zhig}
+'jam dpal rnam par 'phrul pa'i le'u|{bam po gcig dang shlo ka go bzhi pa/ rgya gar gyi mkhan po shi len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa zhig}
+'jam dpal rnam par rol pa'i mdo|{bam po gnyis pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa zhig}
 'jam dpal dbyangs|<{mnydzushrIgrhosha}>{ rje btsun 'jam pa'i dbyangs/ ming gi rnam grangs la ngag gi rgyal po dang/ ngag gi dbang phyug 'jam dpal/ brtan pa'i 'khor lo/ rdo rje rnon po/ blo yi gter/ smra ba'i rgyal/ smra ba'i seng ge/ smra ba'i lha/ zur phud lnga pa/ ye shes sku/ ye shes me long/ ral gri can/ shes rab sku/ shes rab 'khor lo/ seng ge rtsen bcas so/}
 'jam dpal rtsa rgyud|{le'u sum cu so drug can/ dus rabs bcu gcig pa'i 'gor lo tsA ba shAkya blo gros kyis bsgyur pa'o/}
 'jam dpal gzhon nur gyur pa|{nyes pa'i rtsub reg yongs su spangs shing 'jam pa'i yon tan mchog tu ldan pas phyogs dus thams cad du bcu drug gzhon nu'i lang tsho'i dpal 'dzin pa kho nar bzhugs pas na gzhon nur gyur pa'o/ 'jam dbyangs kyi mtshan gyi rnam grangs shig}
@@ -15341,7 +15338,7 @@ ljon dmar|{(mngon) zangs/}
 ljon shing|{skye shing spyi'i ming/ ming gi rnam grangs la rkang 'thung dang/ rkang pas 'thung/ mgo lding can/ 'gro 'gog 'gro med/ chur mi lhung/ ljon pa/ steng skye ba/ 'dab ldan/ 'dab ma yangs ldan/ sdong po/ rnam rgyas/ phung po can/ rtse mo can/ yal ga can/ yal ga bres/ yal ga 'dzin/ yal 'dab can/ rlan las skyes/ lo ma can/ sa skyes bcas so/}
 ljon shing ldum ra|{skye shing sna tshogs kyi skyed tshal lam gling ga /}
 ljob po|{mdog sna 'dres nas mi gsal ba'i rnam pa/ kha dog ljob ljob/ lud pa sngo ljob tu lu ba/}
-brjod rngams|{gzi brjid dang 'jigs rngams/}
+brjid rngams|{gzi brjid dang 'jigs rngams/}
 brjid chags pa|{rdzig po'am bab chags pa/ gzugs po brjid chags pa/ pho brang brjid chags pa/ brjid chags mdzes sdug dang ldan pa'i tshogs khang chen po/}
 brjid nyams gzi brjid kyi rnam 'gyur|{brjid nyams dod po/ btsan shed 'jigs skul la zhum pa med par brjid nyams dang ldan pa'i ngang nas yar langs pa/}
 brjid non|{gzi brjid kyis pha rol po rang shugs su non pa/ dgra bo rnams rang dmag gi brjid non ma bzod par bros song/}
@@ -15617,7 +15614,7 @@ nyams myong mngon rtogs|{mngon sum myong grub tu byung ba'i shes tshor/ de'i khy
 nyams smad pa|1) {nyams smod pa dang 'dra/} 2) {nyams gud du song ba/}
 nyams smod pa|{che ba'i rnam 'gyur dma' bar byed pa/ drag po'i stobs shugs la brtan nas dgra bo'i nyams smod pa/}
 nyams rtsal|{sbyangs pa las byung ba'i yon tan gyi nus shugs/}
-nyams tshod|{skabs bas gnas tshul ci 'dug gi tshod/ mngon chung thabs mkhas kyi sgo nas gnas tshul gyi nyams tshod len pa/ gzhan agyi yon tan che chung nyams tshod len pa/ son bzang btab ste skye min gyi nyams tshod lta ba/}
+nyams tshod|{skabs bas gnas tshul ci 'dug gi tshod/ mngon chung thabs mkhas kyi sgo nas gnas tshul gyi nyams tshod len pa/ gzhan gyi yon tan che chung nyams tshod len pa/ son bzang btab ste skye min gyi nyams tshod lta ba/}
 nyams mtshar ba|{ngo mtshar ba'am khyad mtshar ba/ nyams mtshar ba'i ltad mo rnams la bltas pa/}
 nyams zhan|{stobs dman pa/ sha nyams zhan pa'i rta drel thag ring du 'gro mi thub/}
 nyams zhib|{brtag dpyad zhib 'jug ngo phebs kyis nyams zhib gnang ba/ nyams zhib gsal por byed pa/ rim gyis nyams zhib byed/}
@@ -15721,8 +15718,8 @@ nyi ma dge ba|{gza' skar legs pa'i dus tshes/}
 nyi ma rgas pa|{nyi ma nub ri'i rgyab tu bzhud pa/}
 nyi ma ngan pa|{gza' skar mi legs pa'i dus tshes/}
 nyi ma snga dro|{nyin mo'i snga dro'i cha/}
-nyi ma cha 'dzin|{nyi ma'i dkyil 'khor gyi cha shas shig bsgribs pa'i nyi 'dzin/}
 nyi ma bcu gnyis|{lha sum cu rtsa gsum gyi nang gses nyi ma'i lha bcu gnyis te/ dbang po dang/ byed po dang/ lam pa dang/ char 'bebs dang/ bstod byed dang/ sngon min dang/ sngon 'phags dang/ mi gzugs dang/ khyab 'jug dang/ 'od can dang/ chu bdag dang/ gshin rje ste bcu gnyis so/}
+nyi ma cha 'dzin|{nyi ma'i dkyil 'khor gyi cha shas shig bsgribs pa'i nyi 'dzin/}
 nyi ma rjes ma|{nyin phyi ma/}
 nyi ma rtag pa re bzhin|{nyi ma rnam shar gyi dus/ nyi ma rtag pa re bzhin shar nas shar/ nyi ma rtag pa re bzhin nub tu nub/ mi tshe lo brgya yud tsam rdzogs 'gro bas/ tshang mas mi tshe 'di nyid gces spras gyis/}
 nyi ma rting ma|{nyin phyi ma/}
@@ -15869,7 +15866,7 @@ nyin byed|{(mngon) nyi ma/}
 nyin sbrel|{nyin mang po mthud pa/}
 nyin mi gsal|{(mngon) srin bu me khyer/}
 nyin med mtshan med|{nyin mtshan ltos med/}
-nyon mo|{nam langs te lag ris mngon pa nas nyi nub lag ris mi mngon par gyur pa'i bar/ ming gi rnam grangs la gdugs dang/ bdud 'joms/ mdangs gsar/ gnas 'jug snang ba ldan/ padma bzhad/ mun bsal/ rtsen dus/ gsal snang bcas so/}
+nyin mo|{nam langs te lag ris mngon pa nas nyi nub lag ris mi mngon par gyur pa'i bar/ ming gi rnam grangs la gdugs dang/ bdud 'joms/ mdangs gsar/ gnas 'jug snang ba ldan/ padma bzhad/ mun bsal/ rtsen dus/ gsal snang bcas so/}
 nyin mo 'jigs|{(mngon) 'ug pa/}
 nyin mo bde legs|{kha btags nang mdzod kyi bye brag cig kha btags nang mdzod las rtags brgyad ma/ srid zhi bde skyid/ nyin mo bde legs/ tshe lha ma bcas rigs mi 'dra ba bzhi yod pa'i gsum par tshigs bcad sho lo ka bkod pa 'di lta ste/ nyin mo bde legs mtshan bde legs/ nyi ma'i gung yang bde legs shing/ nyin mtshan ku tu bden legs pa/ dkon mchog gsum gyi bde legs shog ces gsal yod/}
 nyin mo yib|{(mngon)srin bya/}
@@ -15985,7 +15982,7 @@ nye dga' bo|<{aupanda:a}>{ shAkya thub pa'i nyan thos drug sde'i ya gyal zhig .}
 nye mgon|{brtse sems kyis rogs ram byed pa/ phru gu rnams la bsam blo dang 'tsho ba sogs gang ci'i nye mgon byed pa/}
 nye 'gram|{gzhogs sam 'khris/}
 nye rgyal|<{aupatishya}>{ 'phags pa sha' ri'i bu/}
-nyi rgyud|1) {gnyen nye ba'i rigs rgyud/ pha mes kyi nye rgyud du bu dang bu mo mang po byung yod/} 2) {thag nye'i sa cha/ grong khyer nye rgyud du rtsa' thang rgya chen po yod/}
+nye rgyud|1) {gnyen nye ba'i rigs rgyud/ pha mes kyi nye rgyud du bu dang bu mo mang po byung yod/} 2) {thag nye'i sa cha/ grong khyer nye rgyud du rtsa' thang rgya chen po yod/}
 #nye sgrig gnyen sdeb byed pa|
 nye brgyud ring brgyud|1) {'brel thag nye ring gang rung brgyud pa/ bsam don 'grub ched du nye brgyud ring brgyud kyis thabs shes byed pa/} 2) {pha rgyud ma rgyud kyi brgyud pa ring thung/} 3) {chos kyi dbang lung man ngag gi brgyud pa ring thung/}
 nye sngon|{ring min gyi sngon nam dus yun nye tsam gyi snga rol/}
@@ -16003,7 +16000,7 @@ nye dus|{dus tshod mi ring ba'i snga rol/}
 nye drung|{mdun nam 'khris/ phru gu ma'i nye drung du bsdad pa/}
 nye 'dabs|{thag nye ba'i sa rgyud/ grong gi nye 'dabs su shing sna yod pa/}
 nye sde|{nye ba'i drug sde ste/ sangs rgyas sha'kya thub pa'i 'khor drug sde dang 'dra ba'i nyan thos kyi sde zhig}
-nye po|1) {slob ma'am slob phrug/} 2) {drung na sdod mkhan nam gyog po/}
+nye gnas|1) {slob ma'am slob phrug/} 2) {drung na sdod mkhan nam gyog po/}
 nye po|1) {thag ring min pa/ grogs po bzhugs sa thag nye por yod/} 2) {blo nye ba/ dhong dang nga rang sngar nas dga' po nye po/ yin/}
 nye spun|{spun zla nye rigs/}
 nye ba|1.{nye du gnyen grogs/ }2. 1) {thag mi ring ba/ shi la nye ba/} 2) {mthun pa'am 'dra ba/ blo nye ba/ }3.{'di'i mthar ra sbyar na tshig gi rgyan du 'gro ba'i rab tu dang shin tu sogs ha cang gi don zhig ra nye bar nyer nye bar lta ba/ nye bar brtag pa/ nye bar bstan pa/ nye bar bsten pa/ nye bar mdzes pa/}
@@ -16785,10 +16782,10 @@ snying med|1) {blo khog med pa/} 2) {legs nyes sam bzang ngan mi shes pa'i blo/}
 snying rtsa|{nad pa'i lag pa g.yon pa'i tshon 'og nas blta rgyu'i nang khrol snying gi rtsa 'phar stangs/}
 snying brtse|{sdug bsngal can thams cad sdug bsngal dang 'bral 'dod kyi sems/}
 snying brtse ba|{sdug bsngal 'bral 'dod kyi brtse sems sam byams sems byed pa/ smyon par khong mi khro la/ dgra bor snying mi brtse ba/}
-snying brte ba'i zhing|{snying rje skye yul/}
-snying brte med pa'i stan bcos|{thar pa 'thob byed ma yin pa'i bstan bcos/}
+snying brtse ba'i zhing|{snying rje skye yul/}
+snying brtse med pa'i stan bcos|{thar pa 'thob byed ma yin pa'i bstan bcos/}
 snying brtse zhing byams pa|{sdug bsngal 'bral 'dod kyi sems brtse zhing/ phan 'dod kyi byams sems/}
-snying cha skyu ru ru|{'jigs zhum zhum/ dgra mthong ba'i tshe snying tsha skyu ru ru ma byed/}
+snying tsha skyu ru ru|{'jigs zhum zhum/ dgra mthong ba'i tshe snying tsha skyu ru ru ma byed/}
 snying tsha ba|{sems nyams mi bde ba/}
 snying tshad|{snying nad bdun gyi nang gses shig tsha ba snying la zhugs pa'i nad/}
 snying tshabs|{mo nad snying la byer ba'i nad de/ nang gses su dbye na snying gi khrag tshabs dang/ snying gi rlung tshabs gnyis mchis/}
@@ -16832,10 +16829,12 @@ snyim bu|{byis pa'i khyor ba sbyar ba'i snyim pa chung ngu/}
 snyil|{snyil ba'i skul tshig}
 snyil ba|{(tha dad pa) bsnyil ba/ bsnyil ba/ snyil//} 1) {rdal ba'am sil bur gtong ba/ ri bo bsnyil te thang du bsgyur/ lcags ri bsnyil ba/ phye mar snyil ba/} 2) {skrod pa/ dgra bo phyi rol tu bsnyil ba/ tshul khrims 'chal po gtsug lag khang nas bsnyil ba/}
 snyu gu|{(rnying) yi ge 'bri byed/}
-snyug snyu gu'i bsdus yig snyug kha|1) {smyu gu'i kha/} 2) {kha dog ljang ser/}
-#snyu khrog smyu gu blug na khrog khrog zer ba'i sgra sgrog pa la brten nas ming btags pa'i snyug snod|
+snyug|{snyu gu'i bsdus yig}
+snyug kha|1) {smyu gu'i kha/} 2) {kha dog ljang ser/}
+snyu khrog|{smyu gu blug na khrog khrog zer ba'i sgra sgrog pa la brten nas ming btags pa'i snyug snod/}
 snyug cu gang|{smyug cu gang dang 'dra/}
-snyug lcag bkug nas 'gram par gzhu byed snyug leb cig snyug ljang|{kha dog ser po ljang shas che ba/}
+snyug lcag|{bkug nas 'gram par gzhu byed snyug leb cig}
+snyug ljang|{kha dog ser po ljang shas che ba/}
 snyug ldong|{smyug ma'i sdong po/}
 snyug pa|{(tha dad pa) bsnyugs pa/ bsnyug pa/ snyugs//} 1) {'byug pa/ gdong la dkar po dmar po bsnyugs nas mdzes cha bzos/} 2) {skyug pa/ lto ba 'khyags pa'i thog kha zas za tshod ma zin pas bsnyugs song/} 3) {gting du skyur ba/ gru gzings thog nas rgya mtshor gting rdo snyug pa/}
 snyug bya|{smyug bya dang 'dra/}
@@ -17043,7 +17042,7 @@ bsnyon dor gyi gzugs can|{gzugs can gyi rgyan gyi nang gses shig ste/ dpe can do
 bsnyon 'ding ba|{ma byas par byas pa'am min pa la yin zer ba'i ham bsnyon byed pa/ rang nongs rang gis ngos len byed dgos pa las gzhan la bsnyon 'ding ba mi chog bsnyon pa/snyon pa'i 'das pa dang ma 'ongs pa/}
 bsnyon pas thob pa|{ham spobs kyis byung ba/ mi khram pa'i nor rdzas tshang ma bsnyon pas thob pa sha stag las/ bden pas thob pa med/}
 bsnyon med|{rtsod pa med pa'am nor 'khrul med pa/ gang ci'i sgo nas bsam blo btang yang bsnyon med red/}
-bsnyon 'jugs|{yod la med dang/ yin la min pa'i skyon 'dogs pa'am ya la dkri ba/}
+bsnyon 'dzugs|{yod la med dang/ yin la min pa'i skyon 'dogs pa'am ya la dkri ba/}
 bsnyon ham|{skyon 'dogs kyi ham pa/ nam rgyun mi la bsnyon ham sna tshogs byed pa/}
 bsnyon ham mna' dag gi zhal lce|{zhal lce bcu drug gi ya gyal zhig ste/ yin pa la min dang/ min pa la yin zhes ham 'dzugs kyi bsnyon byung na lha srung dpang du btsugs nas mna' bkar bden rdzun 'byed pa'i khrims/}
 bsnyor ba|{snyor ba'i 'das pa dang ma 'ongs pa/ snyol ba/(rnying) 'jigs pa/}
@@ -17118,7 +17117,7 @@ ti shri kun dga' blo gros|{rab byung lnga pa'i sa phag lor sa skya bdag nyid che
 ti shri rin chen rgyal mtshan|{'gro mgon chos rgyal gyi gcung po rin chen rgyal mtshan/ 'phags pa rab byung lnga pa'i me bya lor rgyal sa nas bod la log pa'i shul du rgyal po'i dbu bla ti shri lo gsum mdzad/ sa yos la 'das/}
 ti sa|{ti se dang 'dra/}
 ti se|{(legs) gangs ri/ ti se gangs ri/}
-tig snying po bsdus pa|{man ngag gi yang tig gzhung lugs kyi yang tig}
+tig|{snying po bsdus pa/ man ngag gi yang tig _gzhung lugs kyi yang tig}
 tig gu|{(yul) chang snod/}
 tig ta|{(legs) kha ba ste sngo sman gyi rigs shig ro kha/ zhu rjes bsil/ nus pas khrag dang mkhris pa'i tsha ba dang/ mchin tshad sogs la phan/ ming gi rnam grangs la 'joms byed dang/ sdig pa'i bran mo/ sdong bu gcig gnas gcig 'dzin/ rig pa'i rna ba/ ro ldan/ legs ldan bcas so/}
 tig ta gsum|{rgya tig dang/ bal tig sum cu tig gam lcags tig gsum/}
@@ -17222,19 +17221,20 @@ tob tob smra ba|{bab col smra ba/ rtog dpyod med par skad cha tob tob smra/}
 tor pang|{bu ga che ru gtong byed kyi lag cha zhig}
 tol|{glo bur dang thol byung/ kho cang mi smra bar tol gyis phyin song/}
 tol shes|{thogs med du shes pa/}
-ta sde|{legs sbyar skad kyi gsal byed kyi sde pa gsum pa ste/ ta tha da dha na/ ta tha da dha na/}
-tam khab|{(yul) sngar bod kyi tam gcig ri ba'i khab/}
-tam ltir|{(yul) sngar bod kyi tam gcig ri ba'i chang blug snod khog ltir/}
-tam rdo|{(yul) sngar bod kyi dngul gyi rtsis gzhi zhig ste tam rdo re la dngul srang lnga bcu yin/}
-ti'u gung gi rtsis|{(rgya) spor thang gi rtsis/}
-tIka|{tIkka dang 'dra/}
-tIka chen|{'grel chen/ gzhung don gsal bar byed pa'i tIka chen/}
-tIka chen de nyid snang ba|{mkhas grub rjes rab byung bdun pa'i shing stag lor brtsams pa'i 'grel chen dri med 'od kyi rgya cher 'grel/}
-tIka chen rigs pa'i rgya mtsho|{mkhas grub rjes mdzad pa'i tshad ma rnam 'grel gyi 'grel pa/}
-tIkka|{(legs) dpe gzhung rtsa ba gang yin gyi 'grel bshad dam/ 'grel pa/}
+Ta sde|{legs sbyar skad kyi gsal byed kyi sde pa gsum pa ste/ Ta Tha Da Dha Na/}
+Tam khab|{(yul) sngar bod kyi Tam gcig ri ba'i khab/}
+Tam ltir|{(yul) sngar bod kyi Tam gcig ri ba'i chang blug snod khog ltir/}
+Tam rdo|{(yul) sngar bod kyi dngul gyi rtsis gzhi zhig ste Tam rdo re la dngul srang lnga bcu yin/}
+Ti'u gung gi rtsis|{(rgya) spor thang gi rtsis/}
+TIka|{TIk+ka dang 'dra/}
+TIka chen|{'grel chen/ gzhung don gsal bar byed pa'i TIka chen/}
+TIka chen de nyid snang ba|{mkhas grub rjes rab byung bdun pa'i shing stag lor brtsams pa'i 'grel chen dri med 'od kyi rgya cher 'grel/}
+TIka chen rigs pa'i rgya mtsho|{mkhas grub rjes mdzad pa'i tshad ma rnam 'grel gyi 'grel pa/}
+TIk+ka|{(legs) dpe gzhung rtsa ba gang yin gyi 'grel bshad dam/ 'grel pa/}
 twon mun|{(rgya) cig car ba ste/ sngar krung go'i nang du dar ba'i nang pa'i grub mtha' zhig}
 tri shu la|{(legs) rtse gsum yod pa'i mtshon cha zhig}
-tri e sang|{bon lugs kyi tha snyad cig ste nang pa'i yum chen mo'am sher phyin dang 'dra/ tre tre ho/ (legs) rims smyon pa ste nag po sum sgril gyi ming gzhan zhig}
+tri e sang|{bon lugs kyi tha snyad cig ste nang pa'i yum chen mo'am sher phyin dang 'dra/}
+tre tre ho|{(legs) rims smyon pa ste nag po sum sgril gyi ming gzhan zhig}
 tre bo|{si khron zhing chen dkar mdzes bod rigs rang skyong khul brag 'go rdzong gi sa cha zhig}
 tre ma|{(legs)} 1) {sbrang rgod mdung gsum pa/} 2) {sre mong/}
 tre ma bu ga|{(legs) sbrang chung/}
@@ -17299,8 +17299,8 @@ gtan tshigs ltar snang|{tshul gsum ma tshang ba ste/ 'gal ma nges ma grub gsum g
 gtan tshigs ltar snang gsum|{'gal ba'i gtan tshigs dang/ ma nges pa'i gtan tshigs dang/ ma grub pa'i gtan tshigs te gsum mo/}
 gtan tshigs thigs pa|{gtan tshigs kyi thigs pa'i rab tu byed pa zhes pa/ phyogs chos dang khyab pa spyir gtan la 'bebs pa'i gzhung/ slob dpon chos kyi grags pas mdzad pa'i tshad ma sde bdun las 'phros pa yan lag lta bu'i bstan bcos bzhi'i gras shig}
 gtan tshigs 'dren pa|{dam bcas pa'i tshig snga mar rgyu mtshan 'dren pa'i lhag bcas kyi sgra zhig me yod de du ba yod pa'i phyir/}
-gtan tshigs yang dag sgrub byed kyi rtags yang dag gtan tshigs rig pa|{rig pa'i gnas lnga'i ya}
-gyal|{don gyi 'khrul ba tshar gcod par byed pa tshad ma rig pa'o/}
+gtan tshigs yang dag|{sgrub byed kyi rtags yang dag}
+gtan tshigs rig pa|{rig pa'i gnas lnga'i ya gyal/ don gyi 'khrul ba tshar gcod par byed pa tshad ma rig pa'o/}
 gtan tshigs rigs pa|{yul lkog gyur 'jal byed rjes dpag gi gzhi'am rten du gyur pa'i rtags kyi rigs pa'o/}
 gtan tshigs sa bon|{bka' shog gi 'char gzhi'am zin bris/}
 gtan tshigs gsum|{'bras bu'i rtags dang/ rang bzhin gyi rtags dang/ ma dmigs pa'i rtags te gsum mo/}
@@ -17386,7 +17386,7 @@ gtar bsreg khrag rtsa'i gtar dmigs steng gtar ba dang|{me btsa'i gsang dmigs ste
 gtal po|{(yul) ba lang gi lci ba brdzis nas rtsig ldebs dang brag rdo sogs kyi thog leb mor sbyar te bskams nas me shing byed pa/}
 gti thug|1) {blo rgya chung ba/ blo chung gti thug dbang gis bya ba gang yang byed mi phod/} 2) {(yul) 1/ au tshugs/ 2/ ser sna can/}
 gti ba|{(rnying) smra ba/}
-gti mug ma rig pa ste|{chos kyi tshul yang dag par ma rtogs pa'am phyin ci log tu rtog pa'i rmongs pa/ gti mug bdo ba/ gti mug mun pa'i khung bur 'jog mi rung/}
+gti mug|{ma rig pa ste/ chos kyi tshul yang dag par ma rtogs pa'am phyin ci log tu rtog pa'i rmongs pa/ gti mug bdo ba/ gti mug mun pa'i khung bur 'jog mi rung/}
 gti mug 'khor lo|1) {phag gi sna'i gab ming ste/ nus pas gnyan nad dang lhog pa'i nad la phan/} 2) {(mngon) phag pa/}
 gti mug gi dur phag nag po|{ma rig pa'i gti mug de phag pa nag po'i gzugs su bkod pa/}
 gti mug med pa|{so sor brtags pa'i sgo nas don la ma rmongs pa dang nyes pa la mi 'jug par byed pa/ dge ba'i sems byung bcu gcig gi ya gyal zhig}
@@ -17565,7 +17565,7 @@ btag thags mkhan gyi yo spyad cig btag pa|{tha dad par 'jug pa'i 'thag pa'i ma '
 btag so|{'thag chas 'thag sha'i so/}
 btags chos|{btags pa'i dngos po/}
 btags pa|1.1) {tha dad par 'jug pa'i 'thag pa'i 'das pa/} 2) {'dogs pa'i 'das pa/ }2.{rdzas med rdzas su grub par smra ba/ }3.{(rnying)} 1) {khrims bsgrags pa/} 2) {phal pa/}
-gtags par smra ba'i sde|{nyan thos sde pa bco brgyad kyi nang tshan zhig}
+btags par smra ba'i sde|{nyan thos sde pa bco brgyad kyi nang tshan zhig}
 btags ma|1) {(yul) 'thag chas 'thag sha/} 2) {thags grub kyi gos dar sogs/}
 btags ming|{ming 'dogs tshul gyi bye brag cig ste/ 'dra 'brel gang rung gi rgyu mtshan la brten nas rjes grub tu brda sbyar nas btags pa'i ming/ dper na/ mi blun po la ba lang zhes brjod pa lta bu'o/}
 btags yod|{rang 'dzin sgra dang rtog pas btags pa tsam du grub pa'i chos/ dus dang/ gang zag lta bu ldan min 'du byed dang/ kun btags kyi chos rnams so/}
@@ -17649,7 +17649,7 @@ rta rgod|{ma dul ba'i rta gyong po/ sems rta rgod 'phyo 'phyo/}
 rta rgod dkyus 'dzud|{rta rgod lam gzhung la 'jug pa ste/ mi rgod khrims gzhung la 'jur ba'i dpe/ tshul min log zhugs kyi mi rnams la slob gso btang ste rta rgod dkyus 'dzud byed pa/}
 rta rgod ma|{mo rta/}
 rta rgyab|1) {rta'i sgal pa/} 2) {rta la 'gel rgyu'i khal/}
-rta rgyug rta bang rgyug pa|{gnam gang nyin mor rta gsos nas/ tshes pa gcig la rta rgyug byed/}
+rta rgyug|{rta bang rgyug pa/ gnam gang nyin mor rta gsos nas/ tshes pa gcig la rta rgyug byed/}
 rta rgyug 'gran bsdur|{rta rgyug btang ba'i bang rtsal 'gran bsdur/}
 rta rgyug mi rgyug sngar hor zla dang po'i tshes nyer lnga nyin lha sar mi rta ring rgyug gi bang rtsal 'gran pa'i dus ston rtsed sna zhig rta rgyug zhar 'phen|{bod phyogs kyi yul lung phal cher dbyar dus 'ong skor sogs rten 'brel dus ston dang 'brel rtsal ldan rnams kyis rta'i bang rtsal rgyug pa'i zhor la mda' rtsal 'gran bsdur byed pa'i rtsed sna zhig}
 rta rgyud|1) {rta'i gshis ka/} 2) {rta'i rigs rgyud/}
@@ -17667,7 +17667,7 @@ rta lcags|1) {rta'i rmig pa skyob byed kyi lcags/} 2) {rta'i rkang lag la rgyag 
 #rta chag rta'i bza' chas nas sran sogs|
 rta chas|{rta sga glo rmed srab mthur sogs rta la rgyag rgyu'i yo byad/}
 rta chung|1) {skar ma gre/} 2) {rta chung chung/ mi chung skul bde/ rta chung zhon bde/}
-rta mchog rta mgyogs shing gzugs bzang ba|{ming gi rnam grangs la gyi ling dang/ rta cang shes/ rnam par dul/ rigs ldan/ rlung las rgyal/ rlung gshog can/ legs 'gro bcas so/}
+rta mchog|{rta mgyogs shing gzugs bzang ba/ ming gi rnam grangs la gyi ling dang/ rta cang shes/ rnam par dul/ rigs ldan/ rlung las rgyal/ rlung gshog can/ legs 'gro bcas so/}
 rta mchog kha 'bab|{kha 'bab bzhi'i nang gses/ bod rang skyong ljongs khongs gangs te se'i lho ngos nas byung zhing/ 'brong pa rdzong brgyud nas 'bab pa'i chu zhig ste/ yar klungs gtsang po'i chu 'go'am stod rgyud de/ rta mchog gtsang po yang zer/}
 rta mchog cang shes|{rta bzang po ci yang shes pa/}
 rta mchog gtsang po|{rta mchog kha 'bab dang don gcig}
@@ -17704,8 +17704,8 @@ rta dpyad|{rta'i gzugs dbyibs sam mtshan nyid la brtag pa'i thabs/}
 rta lpags pa|{sngo sman gyi rigs shig ste/ ro mngar la kha/ zhu rjes bsil/ nus pas srin gsod/ lha ba'i nang khrag rgyu bar byed/ chu ser skem/}
 rta spyi|{rta khal skul gtong las 'gan gyi spyi 'doms/}
 rta pho|{pho mo'i zlas phye ba'i rta pho/}
-rta pho drug phrom|{rta mog ro drug steng khra thig can te/ de'i rkan gyi khrag gis rma la phan/}
 rta pho chen|1) {rta pho lus rtsal rdzogs pa/} 2) {'bras bu phyung ba'i rta/}
+rta pho drug phrom|{rta mog ro drug steng khra thig can te/ de'i rkan gyi khrag gis rma la phan/}
 rta phying|{bla chen gyi mchor gos shig}
 rta phyugs|{rta dang/ 'bri g.yag ba mdzo sogs/ rta phyugs 'dogs gdang/}
 rta phrug rta gsar|{ming gi rnam grangs la rta phran dang/ rta yi bu/ rten thur/ rte'u/ thu ru bcas so/}
@@ -17859,7 +17859,7 @@ rtags mtshungs 'dren pa|{ming gang rung gi mthar sbyar ba'i rjes 'jug des/ rang 
 rtags 'dzin sems|{rjes dpag gi rgyu/ rtad kyi tshul 'dzin pa'i blo ste/ tshul gsum dus gcig la dran pa'i blo/dper na/ byas rtags kyis sgra mi rtag par rtogs kha ma'i gang zag gi rgyud la de sgrub kyi rjes su dpag par bya ba'i gzhi yod pa dang/ de sgrub kyi mthun phyogs la yod pa dang/ mi mthun phyogs la med par nges pa'i blo skye ba lta bu'o/}
 rtags 'dzin sems gnyis|{phyogs chos 'jal ba'i rtags 'dzin sems dang/ khyab pa 'jal ba'i rtags 'dzin sems te gnyis so/}
 rtags zur|{rtags sam gtan tshigs kyi sbyor ba 'god pa na/ rgyu mtshan du ma bkod pa'i cha shas sam zur/ dper na/ bum pa chos can/ dngos po'i bye brag yin te/ bum pa dngos po yin/ bum pa dngos po dang bdag gcig tu 'brel/ bum pa ma yin zhing dngos po yin pa du ma grub pa'ang yod pa'i gzhi mthun du dmigs pa yin pa'i phyir zhes rtags zur gsum yod pa lta bu'o/}
-rtags yang dag tshul gsum tshang ba ste|{phyogs chos grub cing 'brel ba nges pa/ dper na/ byas rtags kyis sgra mi rtag par sgrub pa la/ rtags byas pa rtsod gzhi chos can gyi steng du grub pa dang/ gang byas na mi rtag pas khyab pa mthun phyogs la yod pa nyid dang/ gang rtag na ma byas pas khyab pa mi mthun phyogs la med pa bcas kyi rjes su 'gro ldog gi 'brel ba nges pa'o/}
+rtags yang dag|{tshul gsum tshang ba ste/ phyogs chos grub cing 'brel ba nges pa/ dper na/ byas rtags kyis sgra mi rtag par sgrub pa la/ rtags byas pa rtsod gzhi chos can gyi steng du grub pa dang/ gang byas na mi rtag pas khyab pa mthun phyogs la yod pa nyid dang/ gang rtag na ma byas pas khyab pa mi mthun phyogs la med pa bcas kyi rjes su 'gro ldog gi 'brel ba nges pa'o/}
 rtags yang dag gnyis|1) {bsgrub bya'i chos kyi sgo nas dbye na/ dgag rtags yang dag dang/ sgrub rtags yang dag gnyis/} 2) {rtad sgrub tshul gyi sgo nas dbye na/ don sgrub kyi rtags dang/ tha snyad sgrub kyi rtags te gnyis/} 3) {phyogs chos gtan tshigs dgu'i gras kyi rtags yang dag gnyis te/ mi mthun phyogs la gtan med mthun phyogs la khyab byed du 'jug pa dang/ mi mthun phyogs la gtan med mthun phyod la rnam gnyis su 'jug pa'o/}
 rtags yang dag gsum|1) {rtags yang dag la sbyor ba'i sgo nas dbye na/ 'bras bu'i rtags dang/ rang bzhin gyi rtags dang/ ma dmigs pa'i rtad bcas gsum mo/} 2) {sgrub byed kyi sgo nas dbye na/ dngos stobs kyi rtags dang/ grags pa'i rtags dang/ yid ches kyi rtags te gsum mo/}
 rtags rig rtags rigs kyi 'bri tshul gzhan zhig rtags rigs|{tshad ma'i rigs lam gyi nang nas rtags sam gtan tshigs yang dag dang ltar snang skor gyi rnam gzhag ston pa'i gzhung zhig}
@@ -17899,8 +17899,7 @@ rting pa tshugs pa|{rting pa sa la brtan por tshugs pa/ rkang pa'i rting pa tshu
 rting pa yangs pa'i mtshan bzang|{sangs rgyas kyi mtshan bzang so gnyis kyi nang tshan zhig ste/ 'tsho ba la phan btags pa'am srog bsrungs pa nyid kyis rting pa yangs pa/}
 rting po|{ma 'ongs pa/ rting po la bdag sleb yong/}
 rting ma|1) {rjes ma'am phyi ma/ zla ba rting ma/ zhag rting ma/} 2) {mtha' ma/ de ni rang cag mjal thengs rting ma yin/}
-rting ma len pa|{dmag 'thab kyi rgyal kha len pa/ de byas kyi}
-rting ma ma blangs na|{nga dpa' bo min pa'i rtags la zhog}
+rting ma len pa|{dmag 'thab kyi rgyal kha len pa/ de byas kyi rting ma ma blangs na/ nga dpa' bo min pa'i rtags la zhog}
 rting las skyes|{(mngon) nu bo/}
 rting shing|{(yul)} 1) {dkrug byed 'khor lo'i rkang shing gi mar sne gnyis rten sa/} 2) {lham gyi rting pa rgyong byed shing/}
 rting so|{rjes dang/ phyi ma/ dka' ba'i las rnams sngon la tshar na rting sor bya rgyu las sla ba yong/}
@@ -18333,7 +18332,7 @@ stag slog stag lpags kyi gos te gna' dus g.yul 'gyed kyi dpa' bo la bya dga' gna
 stang ba|{(tha dad pa) bstangs pa/ bstang ba/ stongs// phan pa byed pa dang/ phan 'dogs pa/ khyed kyis rtag tu bdag bstangs song/}
 stang rtsa|{steng rteg dang 'dra/}
 stang zil|{dngul rdo ste rdo sman gyi rigs shig ro bska/ zhu rjes bsil/ nus pas mgo chag gso/ khrag shor ba dang skyug pa gcod/ rus mdog 'byin/}
-stang ka|{tshul/ lta stangs/ byed stangs/ gom pa 'dor stangs/ 'gying stangs/ sems kyi 'dzin stangs/ mda' 'phen pa'i stangs ka/}
+stangs ka|{tshul/ lta stangs/ byed stangs/ gom pa 'dor stangs/ 'gying stangs/ sems kyi 'dzin stangs/ mda' 'phen pa'i stangs ka/}
 stangs stabs|{rnam 'gyur/ shin tu khros pa'i stangs stabs kyis sdang sems ston/}
 stangs dpyal|{yab yum mam bza' tshang pho mo gnyis 'dzoms kyi zhe sa ste/ steng zhal zhes kyang 'bri rgyun 'dug}
 stangs 'dzin|{dbye mtshams phye ste 'dzin pa/ bzang ngan stangs 'dzin gyi slob ston gnang ba/}
@@ -18614,8 +18613,9 @@ ston mnyam|{hor zla brgyad pa'i sgang tshad la ston nyin mtshan mnyam pa'i dus t
 ston tha ma|{ston zla gsum pa ste/ hor zla dgu pa/}
 ston tha'i sgang tshad|{ston zla gsum pa ste/ hor zla dgu pa'i dkyil tshad/}
 ston tha'i dbugs thob|{ston zla gsum pa ste/ hor zla dgu pa'i 'go tshugs tsam/}
-ston thog lo tog ston thog snga ma|{lo rer ston thog dus gnyis re bsdu ba'i snga ma/}
-ston thog phyi ma|{lo rer ston thog dus gnyis re bsdu ba'i snga ma/}
+ston thog|{lo tog}
+ston thog snga ma|{lo rer ston thog dus gnyis re bsdu ba'i snga ma/}
+ston thog phyi ma|{lo rer ston thog dus gnyis re bsdu ba'i phyi ma/}
 ston dus|{ston zla gsum/}
 ston dod|{ston mo gtong byed dam/ ston mo'i dod du sprad pa'i dngul sogs/}
 ston 'debs|{ston ka zhing la sa bon 'debs pa/}
@@ -18677,7 +18677,7 @@ stobs ldan dgra bo|{(mngon) brgya byin/}
 stobs ldan bsnyems|{(mngon) 'dod lha/}
 stobs ldan gnas|{(mngon) sa 'og}
 stobs ldan bongs chung|{lus chung yang nus shugs chen po yod pa/ mi stobs ldan bongs chung hur brtson can/}
-stobs ldan bu tig gos can|{gangs sbal gyi ming gi rnam grangs shig}
+stobs ldan mu tig gos can|{gangs sbal gyi ming gi rnam grangs shig}
 stobs nus|{nus shugs/ gzugs phung rgas shing 'khogs pas las ka'i stobs nus shor ba/}
 stobs po che|1) {stobs shugs chen po/} 2) {(mngon) 1/ lcags/ 2/ lha khro bo zhig} 3) {mdo zhig gi ming/}
 stobs phun tshogs kyi zol bstod|{zol bstod kyi rgyan gyi nang gses shig ste/ bstod yul stobs phun tshogs can zhig la rnam pa skyon brjod kyi khul byas nas/ don du sgra gcig gis don gnyis sbyar nas stobs phun tshogs kyi yon tan la shugs kyi bstod pa'i rgyan zhig}
@@ -18914,7 +18914,7 @@ tha snyad btags pa|{ming du btags pa/}
 tha snyad ston byed|1) {lus kyi lag pa/} 2) {yi ge /} 3) {ming tshig}
 tha snyad dus|{gzhi gang la ming de chags pa'am 'jug pa'i dus te/ kun gyi mthun snang du grub nas 'bod pa'i dus/}
 tha snyad pa|1) {'jig rten la srid tshad/} 2) {so so'i skye bo/} 3) {ming/}
-tha snyad sbyod yul|{ming dang grags pa'i rjes su mthun pa'i yul/}
+tha snyad spyod yul|{ming dang grags pa'i rjes su mthun pa'i yul/}
 tha snyad byed pa|{ming brda gsar du 'dogs pa/}
 tha snyad tsam|{ming tsam/}
 tha snyad bshad pa|{ming ngam/ brda chad brjod pa/}
@@ -18956,7 +18956,7 @@ tha li mtha' bzhi|{rta drel thal mdog lo bzhi lon pa/}
 tha le zug|{(sog) dbyar kha khal kha zug phyu pa'i stod du gyon rgyu'i stod khebs kyi ming/}
 tha shal ba|{dman pa'am/ zhan pa dang/ ngan pa/ tha shal ba'i tshul du bzhugs pa/ mi tha shal ba ma yin/ spyod pa tha shal ba/}
 tha son|{sa tha ma'i son/}
-thag sa cha gnyis bar gyi ring tshad dam bar khyon|{sa thag le dbar khri phrag gis chod pa/}
+thag|{sa cha gnyis bar gyi ring tshad dam bar khyon/ sa thag le dbar khri phrag gis chod pa/}
 thag skas|{thag pa la dpyang ba'am 'khyud de 'gro sa'i skas ka/}
 thag khra sbrul mthong|{'dra ba tsam rgyu mtshan du byas nas dngos don la lta stangs nor ba'i dpe/}
 thag 'khyud me tog 'khri shing gi gras kyi me tog cig thag gi thug gi|1) {lag pa sogs kyis reg tsam thug tsam byed stangs/ nad pa la thag gi thug gi ma mang/ rgas 'khogs la phru gus thag gi thug gi sun po ma bzo/ gcig gis gcig la thag thug med pa/} 2) {thug thug mang tshul/ kar kor thag thug mang po byung ba/}
@@ -19228,7 +19228,7 @@ thar sa|{yul gcig nas yul gzhan du thar ba'i lam/ zam pa chad nas gtsang po'i ph
 tharka|{(legs) tha skar/}
 thal ka rdo rje|{shing sman gyi rigs shig ste/ ro kha/ zhu rjes snyoms/ nus pas pags nad sel/ chu ser skem/ srin nad gsod/}
 thal kar|1) {sngo dkar/ glang chen thal kar mche ba drug ldan/} 2) {(mngon) glang chen/}
-thal skad|{chos kyi rtsod pa byed pa'i thog mar rje btsun 'jam pa'i dbyangs kyi sa bon dhI: yig skad mthon por sgrog pa'i skad/ dhI:}
+thal skad|{chos kyi rtsod pa byed pa'i thog mar rje btsun 'jam pa'i dbyangs kyi sa bon dhIH yig skad mthon por sgrog pa'i skad/}
 thal skyon|{tshad las brgal ba'i skyon/ phar sprod tshur len gyi byed sgo tshang ma thal skyon med pa/}
 thal 'khums|{tshad las brgal ba dang tshad ma zin pa/ gzhung sger gyi 'gro song gang btang tshang mar thal 'khums kyi hang zom med pa/ rgyu mtshan khungs thub gzhir bzung gis thal 'khums med par rtsod gleng byed pa/}
 thal gong|{phrag tshigs nas mjing tshigs bar gyi cha shas de'i ming/}
@@ -19239,7 +19239,7 @@ thal 'gyur gyi lan|{phyi rgol gyis tshur thal ba 'phangs pa la rgol bas skyon sp
 thal 'gyur ltar snang|{lan gyis bzlog par nus pa'i ngag ste rtags ma grub pa'am/ ma khyab pa/ khyab pa 'gal ba/ 'dod bcas kyi lan 'debs nus pa'o/}
 thal 'gyur ltar snang bzhi|{rtags ma grub pa dang/ khyab pa 'gal ba dang/ khyab pa ma nges pa dang/ 'dod lan thebs pa ste bzhi'o/}
 thal 'gyur ba|1) {thal ba'i skyon du 'gyur ba/} 2) {thal 'gyur tsam gyis phyir rgol gyi rgyud la bsgrub bya rtogs pa'i rjes dpag skye bar 'dod pas na thal 'gyur ba zhes brjod pa ste/ slob dpon sangs rgyas bskyang dang zla ba grags pa'i rjes su 'brangs nas chos thams cad don dam par rang bzhin gyis ma grub par gtan la phab cing tha snyad 'jig rten grags pa dang mthun par stong dang rten 'byung 'gal med zung 'jug gi grub mtha' smra ba'i dbu ma pa zhig}
-thal 'gyur yang dag lan gyis bzlog mi nus pa'i thal ba 'phen pa'i ngag ste|{thal 'gyur 'god yul gyi blo ngor rtags dang khyab pa grub cing/ dam bca' la tshad mas bsal ba 'bab pa'i rtad ston pa'i thal ngag rnam dag go/}
+thal 'gyur yang dag|{lan gyis bzlog mi nus pa'i thal ba 'phen pa'i ngag ste/ thal 'gyur 'god yul gyi blo ngor rtags dang khyab pa grub cing/ dam bca' la tshad mas bsal ba 'bab pa'i rtad ston pa'i thal ngag rnam dag go/}
 thal 'gyur yang dag gnyis|{sgrub byed 'phen pa'i thal 'gyur dang/ sgrub byed mi 'phen pa'i thal 'gyur te gnyis so/}
 thal rgyugs|1) {thogs med du 'gro ba/ nya mo chu'i nang du thod thug med par thal rgyugs su 'gro ba/} 2) {ma brtags pa'i 'gro stangs/ 'gro lam bde min la ma bltas par rang gar thal rgyugs su 'gro ba/}
 thal ngag 'dod pa rtags su bkod de mi 'dod pa'i thal ba 'phen pa'i ngag ste|{dper na/ sgra rtag par 'dod pa'i ngor/ sgra chos can/ ma byas par thal/ rtag pa'i phyir/ zhes pa lta bu'o/}
@@ -19292,7 +19292,7 @@ thi ba|1) {phug ron/} 2) {'dag byi'u/}
 #thi ba'i mdog mdog sngo skya|
 thi ra|{khrom mam mi mang 'du sa/}
 thi sho legs|{de sho legs dang klu sman mer mo gnyis kyi sras/ sngar bod rgyal bcu gnyis pa ste sa'i legs drug gi ya gyal zhig}
-thig tshad 'dzin sa skud pa lta bur bris pa'i ri mo|{tshangs thig zur thig rtsa thig zlum thig kyog thig nag thig mtshal thig}
+thig|{tshad 'dzin sa skud pa lta bur bris pa'i ri mo/ tshangs thig _zur thig _rtsa thig _zlum thig _kyog thig _nag thig _mtshal thig}
 thig kor|{sgor mo'i dbyibs can gyi ri mo/}
 thig rkyal|{thig rgyag byed kyi thig sa blug snod/}
 thig skud|{thig rgyag byed kyi skud pa/}
@@ -19530,7 +19530,7 @@ thun mong dngos grub|{rdzas sngags kyi sbyor ba la brten nas phyi pa dang nang p
 thun mong dngos grub brgyad|{ril bu dang/ mig sman dang/ sa 'og dang/ ral gri dang/ nam mkhar 'phur ba dang/ mi snang dang/ 'chi ba med pa dang/ nad 'joms te brgyad/}
 thun mong chos|{(mngon) 'khor ba/}
 thun mong mnyam sgrub|{las don rang gzhan mnyam por sgrub pa/ las don 'gangs che'i rigs thun mong mnyam sgrub byed dgos/}
-thun mong sbrul sku'i mandal|{zhing khams grangs med bsam gyis mi khyab pa'i lha mi'i yo byad dam pa mtha' dag blos blangs pa dang/ rang gi kha rje dbang thang dge rtsa dang bcas pa gces dgu'i dngos po thams cad bla ma sprul sku'i lha tshogs la 'bul ba'i mandal/}
+thun mong sprul sku'i maN+Dala|{zhing khams grangs med bsam gyis mi khyab pa'i lha mi'i yo byad dam pa mtha' dag blos blangs pa dang/ rang gi kha rje dbang thang dge rtsa dang bcas pa gces dgu'i dngos po thams cad bla ma sprul sku'i lha tshogs la 'bul ba'i mandal/}
 thun mong ba'i ma nges pa|{ma nges pa'i gtan tshigs gnyis kyi ya gyal/ mthun phyogs dang mi mthun phyogs gnyis kar 'jug pa/ dper na/ sgra mi rtag pa la gzhal bya bkod pa lta bu/ mthun dpe bum pa sogs la 'jug cing/ mi mthun dpe nam mkha' sogs la'ang 'jug pas thun mong ba yin zhing khyab pa la the tshom bskyed pas ma nges pa'o/}
 thun mong ba'i ma nges pa'i rtags drug dngos kyi ma nges pa'i rtags bzhi dang|{lhag ldan gyi ma nges pa'i rtags gnyis te drug go/}
 thun mong ba'i srung 'khor|{gsang sngags rgyud sde bzhi thun mong du bsgom rgyu'i srung 'khor/}
@@ -19892,7 +19892,7 @@ thogs pa med pa|{bar chad ma mchis pa dang/ rgyun mi 'chad pa/ lam bar thogs pa 
 thogs pa gsum|{mig sogs khams bco brgyad la brten nas phye ba'i sgrib pa'i thogs pa dang/ yul la thogs pa/ dmigs pa la thogs ste gsum/}
 thogs pa'i reg pa|{reg pa'i tshogs drug po las mig gi 'dus te reg pa la sogs pa thogs bcas kyi dbang po lnga la brten pa'o/ dper na mig gi 'dus te reg pa ni/ mig gi dbang po dang gzugs dang mig gi rnam shes gsum 'dus te yul yongs su gcod pa 'byung ba ltar ro/}
 thogs med|{'dzam gling mdzes pa'i rgyan drug gi ya gyal/ rgya chen spyod pa'i srol 'byed kyi shing rta slob dpon 'phags pa thogs med ni/ ston pa mya ngan las 'das nas lo dgu brgya lhag lon cing/ dus rabs bzhi pa tsam na/ bram ze mo su pra kA sha shI la zhes pa'i sras su 'khrungs/ ri bo bya rkang du byon nas rje btsun byams pa bsgrub pas zhal dngos su mjal/ theg pa chen po'i mdo'i sbas don mngon rtogs kyi rim pa ston pa'i byams chos sde lnga mi yul du drangs/ de'i dgongs pa 'grel ba'i bstan bcos sa sde lnga dang/ sdom rnam gnyis sogs mang du brtsams/ dbyig gnyen sogs rjes su bzung nas chos mngon pa dar bar mdzad do/}
-thong|1. {gtong ba'i skul tshig }2. {(rnying) rmon lcad/}
+thong|1. {gtong ba'i skul tshig }2. {(rnying) rmon lcags/}
 thong ka|{thong ga dang 'dra/}
 thong skal|{(yul) sa zhing gi bogs ma/}
 thong khor|{(rnying) gong bu'am/ gar bu/}
@@ -20141,7 +20141,7 @@ mthar gyur pa|{mthar phyin pa/ rgyal kha mthar gyur pa/}
 mthar chags|{go rim bzhin nam/ rim pa bzhin/ skad cha mthar chags kyis bshad dgos pa dang/ las don mthar chags kyis byed dgos pa/ gcig rjes gnyis mthud kyis mthar chags su rgyu ba/}
 mthar gtugs|{pha rol tshu rol gyi bar mtshams dang zad mtshams la gtugs pa/ mthar gtugs nas bshad na/}
 mthar lta|{mthar 'dzin pa'i lta ba ste/ 'jig lta'i yul gyi bdag la dmigs nas rtag pa ther zug pa'am phyi mar nying mtshams sbyor ba med pa'i chad par lta ba'i rnam pa can/ byed las dbu ma'i lam gyi nges par 'byung ba la bar du gcod pa'i shes rab nyon mongs can/}
-mthar thug phugs dang|{zad mtshams la slebs pa'am son pa/ legs grub mthar thug bar/ ma rabs kyi mthar thug pa/ mthar thug rgyal kha/ mthar thug dmigs yul/}
+mthar thug|{phugs dang/ zad mtshams la slebs pa'am son pa/ legs grub mthar thug bar/ ma rabs kyi mthar thug pa/ mthar thug rgyal kha/ mthar thug dmigs yul/}
 mthar thug gi sgyu lus|{'od gsal lhan cig skyes pa'i ye shes kyis las nyon rtsa ba nas sbyangs te mthar thug rnam dag sgyu ma'i lha sku longs spyod rdzogs pa'i rnam pa can mi slob pa'i zung 'jug 'bras bu'i tshul du 'grub par 'gyur ba'o/}
 mthar thug bsdoms don|{phugs kyi gnad 'gag gcig tu bsdoms pa'i don/}
 mthar thug pa'i mngon rtogs|{mthar thug pa'i lam ste thams cad mkhyen pa'i ye shes/}
@@ -20177,8 +20177,7 @@ mthing ril|{thing ril dang 'dra/}
 mthing ril gyo mo|{(yul) thing ril/}
 mthing ril mchu|{rma gting shin tu ring por lus pa'i zug rngu 'don byed kyi skam pa chu bya mthing ril gyi mchu 'dra ba zhig}
 mthing shing|{sngo mdog tu 'gyur ba'i tshos shing shig}
-#mthing shog shog bu sngon po|
-mthil|{shog shog bu sngon po/}
+mthing shog|{shog bu sngon po/}
 mthil|1) {dbus sam/ gtso bo/ grong khyer gyi mthil/ las don gyi mthil/ nang don gyi mthil shes pa/} 2) {'og zhabs sam gting/ rkang mthil/ lag mthil/ lham mthil/ rgya mtsho'i mthil/ gtsang po'i mthil/ dkar yol gyi mthil/}
 mthil ko|{lham mthil gyi ko ba/}
 mthil ston pa|{phugs don dang/ snying po mig la ston pa'am bshad pa/ las don gang 'dra byas na phan thogs che ba'i zhal ta bslab bya'i mthil ston rogs gnang/}
@@ -20598,11 +20597,12 @@ da lis|{me tog ser skya dri zhim pa'i shing rigs shig}
 da lo|{lo 'di/ da lo rtswa chu 'dzoms po 'dug}
 dA khu ral|{mong gol hal ha ste khal kha'i yul/ deng mong gol mi dmangs spyi mthun rgyal khab kyi rgyal sa wu'u lan pa thu'o yi gna' ming/}
 dA na shI la|{dus rabs brgyad par kasmir 'khrungs shing/ khri srong lde'u btsan skabs bod la gdan drangs pa'i drin can lo pan gsum gyi ya gyal/}
-da ma ru|{(legs) gsang sngags pa'i rol cha zhig ste g.yas g.yon gnyis phyogs bskrogs nas brdungs chog pa'i lag rnga chung ngu zhig}
-da ru|{da ma ru'i bsdus tshig}
-da ru skrog pa|1) {da ma ru rdung ba'am/ 'khrol ba/} 2) {phra ma byed pa'am/ dbyen sbyor byed pa'i dpe/}
-da ru mgo|{mi ngan mgo gnyis ma/}
-dA ki|{(legs) mkha' 'gro/ dombhi pa/(legs) sngar rgya gar gyi grub chen zhig}
+Da ma ru|{(legs) gsang sngags pa'i rol cha zhig ste g.yas g.yon gnyis phyogs bskrogs nas brdungs chog pa'i lag rnga chung ngu zhig}
+Da ru|{Da ma ru'i bsdus tshig}
+Da ru skrog pa|1) {Da ma ru rdung ba'am/ 'khrol ba/} 2) {phra ma byed pa'am/ dbyen sbyor byed pa'i dpe/}
+Da ru mgo|{mi ngan mgo gnyis ma/}
+DA ki|{(legs) mkha' 'gro/}
+Dom+b+hi pa|{(legs) sngar rgya gar gyi grub chen zhig}
 dag|1) {gnyis tshig la 'gro ba'i rnam dbye dang po'i ming mtha' zhig mi 'di dag las ka de dag} 2) {mang tshig la 'gro ba'i rnam dbye dang po'i ming mtha' zhig mi 'di dag las ka de dag dag sgrog bklag bya mdo sngags dpe cha po ti che chung dang mang nyung gang zhig yin rung de 'go nas 'jug bar ma chad pa dang ma nor bar klog pa/}
 dag ci|{lo ma dri zhim can gyi sngo sman zhig ste/ rtswa ldum rnams sman du bkol rung ba'o/}
 dag bcos|{bzo bcos gtsang ma/ 'char gzhir dag bcos byed/ nor 'khrul la dag bcos byed/}
@@ -20632,7 +20632,7 @@ dag ma|1. {rdza las bzos pa'i ko ba snyol snod/ }2. {lhad ma zhugs pa'i gtsang m
 dag rdzogs smin gsum|{sngags nang rgyud kyi bskyed rim spyi'i ngo bor dag rdzogs smin gsum tshang dgos pa ste/ 'khor ba'i skye 'chi bar do gsum dang skye gnas bzhi la sogs pa'i rnam pa dang mthun par bsgoms pas srid pa gsum po'i zhen snang thams cad sbyang zhing dag par gyur pa dang/ myang 'das dang mthun par ting 'dzin gsum dang/ zhing dang/ lha sogs kyi rnam pa bsgoms pas 'bras bu sku gsum gyi yon tan rnams gzhi la rdzogs pa ste mngon du sad rung gi nus pa khyad par can 'byung ba dang/ de ltar dag rdzogs gnyis ka'ang rdo rje'i lus kyi rtsa thig rlung gsum gnad du bsnun nas rdzogs rim gyi dpe'i ye shes dang don gyi 'od gsal skye ba'i smin byed du 'gro ba/}
 dag zhing|{sangs rgyas kyi zhing khams/}
 dag zhu|1) {'gro song khungs skyel zhu ba/} 2) {bden rdzun khungs skyel zhu ba/}
-dag yig yi ge dag byed kyi dpe cha'i ming|{yi ge'i dag cha mi shes pas dag yig sngog pa/}
+dag yig|{yi ge dag byed kyi dpe cha'i ming/ yi ge'i dag cha mi shes pas dag yig sngog pa/}
 dag yig mkhas pa'i 'byung gnas|{sgra/ tshad/ bzo/ gso/ dbu ma/ phar phyin/ 'dul ba/ mngon pa/ gsang sngags sogs kyi chos skad rnams sde tshan so sor phyes te bsgrigs pa'i ming gi rnam grangs/ dus rabs bco brgyad par lcang skya rol pa'i rdo rjes mdzad pa/}
 dag yig ngag sgron|{ngag gi sgron ma'i ming gzhan zhig}
 dag yig za ma tog dag yig rin chen za ma tog ces bya ba|{bod kyi ming brda'i gnas la rmongs 'khrul sel bar byed pa'i gzhung/ dus rabs bcu drug par zha lu lo tsA ba chos skyong bzang pos mdzad pa'i dag yig gi gzhung tshigs su bcad pa zhig}
@@ -20640,7 +20640,7 @@ dag bsher|{zhu dag dang zhib 'jug yig rigs rtsom sgyur gang byas tshang mar dag 
 dag sa|{shes sgrib phra ba rnams spong bar byed pa'i byang sems kyi sa/}
 dag sel|{nyes skyon med par bzo ba/ skyon med skyon 'dzugs byas par dag sel byed pa/}
 dang|1. {sum cu par/ gsum pa la ni gnyis pa sbyar/ de ni sdud dang 'byed pa dang/ rgyu mtshan tshe skabs gdams ngag lnga'o/ zhes pa ltar dang sgra 'di ni don lnga la 'jug pa'i phrad cig dang} 1) {sdud pa la 'jug pa/ skra dang kha spu/ gcig dang gnyis/} 2) {'byed pa la 'jug pa/ }1. {gzhi gcig nas du ma 'byed pa/ dbang po lnga ni mig dang rna ba dang sna dang lce dang lus so/ }2. {'byed sdud rgyu mtshan tshe skabs gdams ngag gang yang ma yin par bya tshig sogs dang sbyar ba/ khong dang lhan cig tu sleb pa/ khyod dang mnyam du 'gro/ khrims dang 'gal ba/ khrims tshul bzhin khur na dang/ gal srid ma khur na nyes pa yong/ gong dang mtshungs pa/ mi dang 'dra ba/ grogs po dang 'grogs pa/ dgra dang 'thab pa/ chu dang gcig me dang gnyis/ rlung dang gsum/ lugs dang mthun pa/ chu dang thag nye ba/ nyen kha dang 'phrad pa/ gnyen dang bral ba/ pha ma dang 'grogs pa/ yi ge dang sbrags nas btang ba/} 3) {rgyu mtshan la 'jug pa/ sman zos pa dang nad drag pa/ 'grel bshad zhib gsal byas pa dang don gnad rtogs pa/} 4) {tshe skabs la 'jug pa/ nyi ma shar ba dang phyin pa/ kho slebs pa dang 'go btsugs pa/ }2. {gdams ngag la 'jug pa/ ltos dang/ legs par slobs dang/}
-dang kyog dbu khyud de rje btsun sa pan gyis|{dang khyog ni glang po che'i sna lta bu'i a yin la/ de yang yi ge'i dang por 'jug pas de ltar btad par gsungs/ la las sngags kyi dbur om yig 'god srol yod pa bzhin bod yig gi dbur yang om yig bkod pa rim gyis yi ge'i tshul zhig pa dang kyog yin par bshad do/ a om om}
+dang kyog|{dbu khyud de rje btsun sa paN gyis/ dang khyog ni glang po che'i sna lta bu'i a yin la/ de yang yi ge'i dang por 'jug pas de ltar btags par gsungs/ la las sngags kyi dbur oM yig 'god srol yod pa bzhin bod yig gi dbur yang oM yig bkod pa rim gyis yi ge'i tshul zhig pa dang kyog yin par bshad do/}
 dang kha|{dang ga dang 'dra/}
 dang ga|1) {zas za 'dod kyi 'dod pa/ dang ga 'gag song/ yun ring du na bas dang ga log pa/ lto'i dang ga phye song/} 2) {pho ba'am lus khog gi pho ba yod sa/ lto ma 'phrod pas dang ga na ba/}
 dang ga bde ba|{zas za 'dod che ba'am zas la rngams pa/ ming gi rnam grangs la grod che dang/ chog med pa/ lto che/ tshim med bcas so/}
@@ -20686,7 +20686,7 @@ dad pa bzhi|{dang ba'i dad pa dang/ 'dod pa'i dad pa/ yid ches pa'i dad pa/ phyi
 dad pa gsum|{sku la dang ba'i dad pa/ gsung la yid ches kyi dad pa/ thugs la mngon 'dod kyi dad pa bcas gsum/}
 dad pa'i rjes 'brang|{dge 'dun nyi shu'i nang gses/ rgyun du zhugs pa'i 'bras bu la zhugs pa gang zhig dbang po rtul po pha rol gyis bstan pa kho na'i rjes su 'brangs nas bden pa mngon par rtogs par byed pa/}
 dad pa'i stobs|{byang phyogs so bdun gyi stobs lnga'i nang gses shig ste mchog gsum la ma dad pa la sogs pa mi mthun phyogs kyis rdzi ba med pa'i dad pa/}
-dad pa'i stobs bskyed pa la 'jug pa'i phyag rgya'i mdo|{'phags pa dad pa'i stobs bskyed pa la 'jug pa'i phyag rgya zhes bya ba'i mdo bam po lnga dang shloo ka bdun cu pa/ rgya gar gyi mkhan po su rendra bo dhi dang/ lo tsA ba ban de ye shes sdes bsgyur pa/}
+dad pa'i stobs bskyed pa la 'jug pa'i phyag rgya'i mdo|{'phags pa dad pa'i stobs bskyed pa la 'jug pa'i phyag rgya zhes bya ba'i mdo bam po lnga dang shloo ka bdun cu pa/ rgya gar gyi mkhan po su ren+d+ra bo dhi dang/ lo tsA ba ban de ye shes sdes bsgyur pa/}
 dad pa'i nor|{'phags nor bdun gyi nang gses/ las 'bras la yid ches pa'i dad pa ste/ nyin mtshan dge ba'i lam la 'dren par byed pas 'khor lo rin po che dang chos mtshungs pa'o/}
 dad pa'i dbang po|{byang phyogs so bdun gyi dbang po lnga'i nang gses shig ste bden bzhi la mngon par yid ches pa/}
 dad pa'i sa|{dad pa dang/ brtson 'grus/ dran pa/ ting 'dzin/ shes rab bcas yul la gtso bor mkhas pa'i gnas skabs kyi lam ste tshogs lam dang don gcig}
@@ -20744,7 +20744,7 @@ dam pa drug ldan|{phyin drug sgrub pa'i tshul dam pa drug dang ldan par nyams su
 dam pa rigs brgya|{rgyal ba'i phung po lnga bde gshegs dang/ khams bzhi yum/ skye mched drug sems dpa'/ yul lnga rdo rje ma ste nyi shu po rigs lnga lngar phye ba'i gsang 'dus kyi lha brgya/}
 dam pa'i chos|{gang la dmigs na lus can rnams kyi sgrib pa zad pa'i thabs su gyur pa ste/ lung dang rtogs pa'i bdag nyid can gyi chos so/}
 dam pa'i chos dran pa nye bar gzhag pa|{mdo sde dran pa nye bar bzhag pa shloo ka stong phrag sum cu rtsa drug bam po bzhi bcu rtsa dgu'i bdag nyid can ba tshab lo tsA bas bsgyur pa'o/}
-dam pa'i chos pad ma dkar po'i mdo|{bam po bcu gsum dang le'u nyer bdun pa/ pandita su rendra bo dhi dang lo tsA ba bande sna nam ye shes sdes bsgyur cing zhus pa/}
+dam pa'i chos pad ma dkar po'i mdo|{bam po bcu gsum dang le'u nyer bdun pa/ pandita su ren+d+ra bo dhi dang lo tsA ba bande sna nam ye shes sdes bsgyur cing zhus pa/}
 dam pa'i gzugs brnyan|1) {rgyal ba'i sku brnyan/} 2) {bzang po yin pa'i bzo tsam/ dam pa'i gzugs brnyan ston pa tsam las don du mi tha shal ba zhig red/}
 dam pa'i rigs can dra ma lnga|{ston pa mya ngan las 'das nas lo nyi shu rtsa brgyad 'das pa na ri ma la ya gnam lcags yod pa'i rtser gsang bdag phyag na rdo rjes gsang ba'i rgyud mtha' dag gsungs pa'i gdul bya dam pa'i rigs can dra ma lnga ste/ lha grags pa mchog skyong dang/ klu rgyal 'jog po/ gnod sbyin skar mda' gdong/ srin po blo gros thabs ldan/ mi li tstsha bI dri ma med par grags pa bcas so/}
 dam po|{lhod yangs min pa/ sgrigs lam dam po/ lag pa dam po/ gral star tshags dam por sgrigs shig rked rags dam por bcings/ lag tu mtshon cha dam por 'dzin pa/ 'gro chas dam du bsdams nas thon chog chog gyis/}
@@ -20901,7 +20901,7 @@ dal shig shig dal po'i rnam pa|{las brel med par dal shig shig gi ngang du bsdad
 das 'phul|{da'i sngon 'jug da da}
 di di gu gu|{(yul) bya thi ba'i rigs shig}
 di ri ri|{sgra skad mang po rgyun mi 'chad par grag stangs/ khyim mtshes kyi nang nas phru gu'i ngu sgra di ri ri thos pa/ grang ngar che ba'i lhags pa di ri ri brgyab yong/ sa thag ring po nas me sgyogs kyi sgra di ri ri go byung/ 'brug skad di ri ri grag pa/ mi mang po'i 'ur sgra di ri ri 'khor ba/}
-dI pam ka ra shrI dznyA na|{(legs) dpal ldan mar me mdzad ye shes te a ti sha'i rab byung gi mtshan dngos/}
+dI paM ka ra shrI dz+nyA na|{(legs) dpal ldan mar me mdzad ye shes te a ti sha'i rab byung gi mtshan dngos/}
 dig skad|{dig pa'am tshig gsal po med pa'i skad cha/}
 dig snyan|{(mngon) phug ron/}
 dig gtam|{kha dig pa'i skad cha/}
@@ -20947,7 +20947,7 @@ du zhig ga tshod yod|{mi du zhig yod/}
 du yod|1) {ci yod/} 2) {grangs ji tsam yod kyi dri tshig}
 du ru ka|<{durushka}:> 1) {spos kyi bye brag cig} 2) {shug pa tsan dan zer ba'i shug sdong chen po de yin par bshad srol yod/}
 du re ba|{rgyun chags pa/}
-du kham|{(legs) sdug bsngal/ yab rje 'bangs bcas mya ngan du: khams gzir/ 'khor ba'i du:khams yong su skyo ba/}
+duHkhaM|{(legs) sdug bsngal/ yab rje 'bangs bcas mya ngan duHkhaMs gzir/ 'khor ba'i duHkhaMs yong su skyo ba/}
 dug|1) {sman gyi ldog zla/ rang bzhin gyi dug 'gyur ba'i dug sbyar ba'i dug mthong dug reg dug chang dug sha dug zas dug dug 'gog pa/ dug ngan/ dug phog pa/ dug btab pa/ rang skyon btang snyoms bzhag pa dug dug kha la bzas na rang nyid pham/ ming gi rnam grangs la ka ko la dang/ 'joms byed ster/ nag po brtsegs/ be'u'i lte ba/ tshangs pa'i bu/ rab tu gsal bcas so/} 2) {dug gi gzugs su bkod pa'i nyon mongs/ dug bcom pa/}
 dug gi me tog ga dur ri dug gi me tog dug gi mtshon cha|{(mngon) dug sbrul/}
 dug lnga|{nyon mongs dug lnga/ 'dod chags/ zhe sdang/ gti mug nga rgyal/ phrag dog ste lnga ni thar ba'i srog 'phrog par byed cing rang rgyud sdug bsngal bar byed pa/}
@@ -20964,7 +20964,7 @@ dug mda'|{dug byugs pa'i mda'i mdel lcags/}
 dug pa|1. {gos hrul/ }2. {(rnying) ngan pa/}
 dug po|{gos hrul rnying pa/}
 dug 'phrog sbrul dug sel thub pa'i sngo sman zhig dug dbal|{dug gi nus pa/}
-dug wa|{bcos dka' ba'i ske sogs kyi wa ba/}
+dug lba|{bcos dka' ba'i ske sogs kyi lba ba/}
 dug sbyor ba|1) {kha zas sogs la dug 'debs pa/} 2) {dug bzo ba/}
 dug sbrang|{mchu dug can gyi sbrang bu/}
 dug sbrul|{dug yod pa'i sbrul/ dug sbrul pang du blangs pa/}
@@ -21009,7 +21009,7 @@ dung skyong|{klu rgyal gyi bye brag cig}
 dung khang|{mgo bo'i ka li/}
 dung khrag|1) {klad khrag} 2) {thod pa'am/dung snod khrag gis gang ba/}
 dung mkhan|1) {dung dkar las rgyan cha bzo mkhan/} 2) {rol cha dung sogs bzo mkhan/} 3) {dung gtong mkhan/}
-dung 'khor|1) {bod rigs bud med kyi lag par gyon pa'i dung gi lag 'khor/} 2) {ma ni dung phyur yod pa'i 'khor chen/}
+dung 'khor|1) {bod rigs bud med kyi lag par gyon pa'i dung gi lag 'khor/} 2) {ma Ni dung phyur yod pa'i 'khor chen/}
 dung 'khyil ri mo|{g.yas g.yon du 'khyil ba'i ri mo dung ris lta bu/}
 dung gi thor cog 'phags yul gyi sman pa bi byi dga' byed dang|{lha tho ri snyan btsan gyi sras mo lha lcam yid kyi rol cha gnyis kyi sras su spyi lo'i dus rabs gsum par sku 'khrungs/ chung ngu'i dus nas rang gi yab las reg pa rtsa'i mdo/ 'tsho ba zas kyi mdo/ sbyor ba sman gyi mdo/ gtar bsreg dpyad kyi mdo/ rma chas bzo yi mdo bcas dang/ de dag gi 'grel bshad khog 'bubs/ sa bcad/ lag len sogs gsan te mkhas par gyur/ rgyal po lha tho ri snyan btsan dang/ de'i sras khri snyan gzungs btsan gnyis kyi bla sman pa mdzad/ 'di nyid ni bod yul gyi sman pa kun gyi phyi mo yin pa dang/ g.yu thog yon tan mgon po yang gdung rus 'di las 'phros par grags/dung gi thor cog gi sras blo gros chen po/ de'i sras blo gros mtshungs med/ de'i sras blo gros rab gsal/ de'i sras blo gros rgyal mdzod/ de'i sras blo gros bshes gnyen bcas byung bas de rnams kyis rim bzhin bod kyi rgyal po 'brong gnyan lde ru dang/ stag ri gnyan gzigs/ gnam ri srong btsan/ srong btsan sgam po rnams kyi bla sman pa mdzad/ 'on kyang skabs de dag la bod la yi ge med stabs dar rgyas cher ma phyin par grags/}
 dung gi ldem shing dkar po|{mkhregs shing dkar po'i rigs shig}
@@ -21089,8 +21089,7 @@ dur khrod|<{shamshAn}>{ mi'i ro skyel sa/ ming gi rnam grangs la 'jig gnas dang/
 dur khrod kyi chas brgyad|{mi mgo'i dbu rgyan dang/ mi mgo'i do shal/ glang chen gyi pags pa'i stod g.yogs/ zhing lpags kyi g.yang gzhi/ stag lpags kyi sham thabs/ zhag gi zo ris/ khrag gi thig le/ thal chen gyi tshom bu bcas brgyad do/}
 dur khrod kyi ras|{ro khebs/}
 dur khrod brgyad|{dur khrod chen po brgyad dang don gcig}
-dur khrod chen po brgyad|{shar du gtum drag}
-dang|{byang du tshang tshing 'khrigs pa/ nub tu rdo rje 'bar ba/ lhor keng rus can/ dbang ldan du drag tu rgod pa/ mer bkra shis tshal/ bden bral du mun pa drag po/ rlung du ki li ki li'i sgra sgrog pa bcas brgyad/}
+dur khrod chen po brgyad|{shar du gtum drag dang/ byang du tshang tshing 'khrigs pa/ nub tu rdo rje 'bar ba/ lhor keng rus can/ dbang ldan du drag tu rgod pa/ mer bkra shis tshal/ bden bral du mun pa drag po/ rlung du ki li ki li'i sgra sgrog pa bcas brgyad/}
 dur khrod bdag po|{keng rus gzugs can mi min zhig}
 dur khrod pa|{dur khrod kyi gnas su phyin te nyams len byed mkhan/}
 dur khrod ma|{(mngon) dpal ldan lha mo/}
@@ -21369,7 +21368,7 @@ de byung 'brel|{'brel ba'i nang gses/ de las de byung gi 'brel ba ste/ rgyu dang
 de 'brel|{de dang mtshungs pa/ de dang dus mnyam/ 'tsho ba je legs su song bar ma zad/ de 'brel rig gnas kyi chu tshad kyang mtho ru phyin yod/}
 de ma khad|{de ma thag}
 de ma gtogs|{de las gzhan/}
-de ma thag lam sang|{'bod mi 'byor ba'i dus de ma thag tu phyin pa yin/ skabs dang po'i las grwa grub pa'i de ma thag tu skabs gnyis pa'i las 'go btsugs pa yin/}
+de ma thag|{lam sang/ 'bod mi 'byor ba'i dus de ma thag tu phyin pa yin/ skabs dang po'i las grwa grub pa'i de ma thag tu skabs gnyis pa'i las 'go btsugs pa yin/}
 de ma thag pa|{de ma thag dang don gcig}
 de ma thag pa'i rkyen|{rkyen bzhi'i nang gses/ sems sems byung mtshungs pa rnams kyis snga ma gang zhig 'gag pa'i de ma thag tu rang gi phyi lod kyi sems sems byung skyed pa'o/}
 de ma thag pa'i lam|{myur lam/}
@@ -21399,7 +21398,7 @@ de bzhin nyid dmigs bsam gtan|{sa dang po yan chod sa bcu pa man chad kyi byang 
 de bzhin nyid gsum|{mngon pa kun btus lugs su de bzhin nyid ni chos nyid la khyad med kyang/ chos can rten tha dad pa'i sgo nas dge ba dang/ mi dge ba dang/ lung ma bstan gyi de bzhin nyid gsum mo/}
 de bzhin 'ongs pa|{de bzhin gshegs pa dang don gcig}
 de bzhin gshegs pa|<{tathAgta}:>{ srid zhi gnyis kyi mtha' la mi gnas pa'i de bzhin nyid kyi lam la brten nas byang chub chen por mngon par gshegs pa/}
-de bzhin gshegs pa rjes su dran pa|{sangs rgyas rjes su dran pa dang don gcig de bzhin gshegs pa thams cad kyi byin gyi rlabs sems can la gzigs shing sangs rgyas kyi zhing gi bkod pa kun tu ston pa/rgya gar gyi mkhan po dzi na mi tra dang/ su rendra bo dhi dang/ lo tsA ba bande ye shes sde dang cog ro klu'i rgyal mtshan gyis bsgyur pa'i mdo sde zhig}
+de bzhin gshegs pa rjes su dran pa|{sangs rgyas rjes su dran pa dang don gcig de bzhin gshegs pa thams cad kyi byin gyi rlabs sems can la gzigs shing sangs rgyas kyi zhing gi bkod pa kun tu ston pa/rgya gar gyi mkhan po dzi na mi tra dang/ su ren+d+ra bo dhi dang/ lo tsA ba bande ye shes sde dang cog ro klu'i rgyal mtshan gyis bsgyur pa'i mdo sde zhig}
 de bzhin gshegs pa dri med zla 'od|{sangs rgyas shig gi mtshan/}
 de bzhin gshegs pa bdun gyi sngon gyi smon lam gyi khyad par rgyas pa|{theg pa chen po'i mdo shloo ka brgyad brgya pa/ rgya gar gyi mkhan po dzi na mi tra dang/ lo tsA ba bande ye shes sdes bsgyur pa'o/}
 de bzhin gshegs pa rnams kyi sangs rgyas kyi zhing gi yon tan brjod pa'i chos kyi rnam grangs|{rgya gar gyi mkhan po dzi na mi tra dang/ dA na shI la dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus pa'i mdo sde glegs bam nga par bzhugs pa/}
@@ -21410,7 +21409,7 @@ de bzhin gshegs pa la ngan sems kyis khrag phyung ba|{mtshams med lnga'i nang ts
 de bzhin gshegs pa'i 'khor bzhi|{dge tshul pha ma dang/ dge slong pha ma bcas bzhi'o/}
 de bzhin gshegs pa'i dge ba bsam gtan|{shes bya thams cad ma lus par thugs su chud cing nyon mongs pa dang shes bya'i sgrib pa ma lus par spangs pas ci la yang rnam par mi rtog par lhun gyis grub nas bdag dang gzhan gyi don ma lus par 'dzin pa/}
 de bzhin gshegs pa'i chos sku|{sku gsum gyi nang gses sangs rgyas kyi chos sku ste spang rtod mthar phyin pa'i ye shes kyi sku/}
-de bzhin gshegs pa'i snying rje chen po nges par bstan pa|{'phags pa de bzhin gshed pa'i snying rje chen po nges par bstan pa zhes bya ba gzungs kyi dbang phyug rgyal pos zhus pa'i mdo bam po bdun pa/ rgya gar gyi mkhan po shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa/}
+de bzhin gshegs pa'i snying rje chen po nges par bstan pa|{'phags pa de bzhin gshed pa'i snying rje chen po nges par bstan pa zhes bya ba gzungs kyi dbang phyug rgyal pos zhus pa'i mdo bam po bdun pa/ rgya gar gyi mkhan po shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa/}
 de bzhin gshegs pa'i snying po|1) {'phags pa de bzhin gshegs pa'i snying po zhes bya ba'i mdo bam po gcig pa/ rgya gar gyi mkhan po shAkya pra bha dang/ lo tsA ba bande ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa'o/} 2) {bde gshed snying po ste rang bzhin gnas rigs/}
 de bzhin gshegs pa'i stobs bcu|{stobs bcu dang don gcig}
 de bzhin gshegs pa'i bstan pa|{lung dang rtogs pa'i chos/}
@@ -21433,8 +21432,8 @@ de yo|{de kun nam thams cad/}
 de rag|{(yul) nye char ram kha sang/ de rag ngos mjal zhu skabs/}
 de rang|{rang nyid du ngos gzung ba'i tshig cig kha sang yong mkhan mi de rang red/}
 de ring|{da lta'i nyin mo/ de ring gi las ka de ring 'grub pa bya dgos/ de ring nas bzung dus mtshams gsar pa zhig shar byung/}
-de ring kha sang|{de ring yan chad kyi nyin shas ring/ de ring kha sang gnam gshis tsha grang snyom po 'dug}
 de ring kha rtsang|{de ring kha sang dang don gcig}
+de ring kha sang|{de ring yan chad kyi nyin shas ring/ de ring kha sang gnam gshis tsha grang snyom po 'dug}
 de ring phan chad|{da lta'i sngon chad dang phyin chad/}
 de ring sang nyin|1) {de ring dang phyi nyin gnyis/} 2) {de ring man chad kyi nyin shas ring/}
 de la brten nas|{de 'dra yin stabs/ rgyu mtshan de la brten nas phan tshun 'brel lam dam zab byung ba/}
@@ -21515,7 +21514,7 @@ do dam|1) {bdag sprod/ gal che'i dngos po rnams do dam yag po byed dgos/} 2) {bt
 do dam pa|1) {bdag sprod byed mkhan/} 2) {gu dog po yin pa dang lhod yangs med pa/}
 do dam gzhan bcol|{gzhan la mngags nas do dam byed du bcug pa/}
 do do tan tan|{gzab gzab nan nan/}
-do bdag don gyi bdag po'am ngo ma|{do bdag rnams la 'dri rtsad zhib gsal byas pa/}
+do bdag|{don gyi bdag po'am ngo ma/ do bdag rnams la 'dri rtsad zhib gsal byas pa/}
 do bdag dngos|{do bdag ngo ma/ lam zur nas bsgrugs pa'i dngos po rnams brlag mkhan do bdag ngo ma'i lag tu bskyal ba/}
 do bdag le 'khri|{do bdag dang le thogs pa'i mi ngo ma/}
 do mdo|{(rnying) mtshan mo/}
@@ -21654,7 +21653,6 @@ don dam bden pa|{bden pa gnyis kyi ya gyal zhig ste/ bye brag smra bas gang zhig
 don dam rnam par nges pa'i chos 'khor|{sangs rgyas kyis gsungs pa'i chos 'khor rim pa gsum pa/}
 don dam pa|1) {gnas lugs dngos/} 2) {de kho na nyid/}
 don dam pa ngo bo nyid med pa nyid|{ngo bo nyid med pa nyid gsum gyi ya gyal/ yongs su grub pa'i chos rnams te/ skud pa nyag ma re re'i steng du thag khra dang sbrul gnyis ka med pa lta bu don dam par rang gi mtshan nyid kyis ma grub pa'o/}
-don dam pa stong pa nyid|{stong pa nyid bcu drug gi nang gses shig ste/ mya ngan las 'das pa dngos po rang bzhin gyis ma grub pa'o/}
 don dam pa stong pa nyid|{stong pa nyid bcu drug gi nang gses shig ste/ mya ngan las 'das pa dngos po rang bzhin gyis ma grub pa'o/}
 don dam pa'i kun rdzob|{yang dag kun rdzob/}
 don dam pa'i dge ba|{de bzhin nyid dang myang 'das/}
@@ -22151,7 +22149,7 @@ dris lan slog pa|{dri lan 'jal ba'am skad cha dris don la lan btab pa/}
 dru gu|1) {pho long ste/ skud pa'i gong bu/} 2) {gna' rabs mnga' ris kyi byang dang li yul gyi lho bar yod pa'i rgyal phran zhig gi ming/}
 dru bu|{skud pa'i gong bu/ skud pa ring po dru bur gril ba/}
 dru ma|{byu ru/}
-drug grangs ka|{ming gi rnam grangs la 'gro ba dang/ rgyan/ dus/ phyod glang/ bro ba/ mtshams/ bzang po/ ro bcas so/}
+drug|{grangs ka/ ming gi rnam grangs la 'gro ba dang/ rgyan/ dus/ phyod glang/ bro ba/ mtshams/ bzang po/ ro bcas so/}
 drug dkar|{g.yu'i bye brag cig}
 drug skyes|{glu dbyangs nges pa bdun gyi ya gyal zhig}
 drug 'go|{gru mo'i nang zur nas mar sor bzhi gzhal mtshams su gnas pa'i mchin pa dang 'brel ba'i gtar rtsa zhig ste/ de gtar na mchin nad dang/ glo tshad sogs la phan/}
@@ -22307,12 +22305,12 @@ dros pa|{dro ba'i 'das pa/}
 drwa mig|{yi ge po ti 'jug snod shing sgrom gyi drwa mig}
 dha du ra|{(legs) snang ba dgu 'gyur te thang phrom dkar nag khra gsum gyi spyi ming zhig}
 dharma sing ha|{(legs) chos kyi seng ge /}
-dharma|{(legs) chos/}
-dharmap'la|{(legs) chos skyong ste bod du phebs myong ba'i rgya gar gyi slob dpon bod kyi pa'l rnam gsum gyi ya gyal zhig}
+dharmaH|{(legs) chos/}
+dharmapAla|{(legs) chos skyong ste bod du phebs myong ba'i rgya gar gyi slob dpon bod kyi pAl rnam gsum gyi ya gyal zhig}
 dhi dhi ka|{dhI ti ka dang 'dra/}
 dhI ti ka|{(legs) gtad rabs lnga pa ste nyan thos dgra bcom pa zhig}
 dhU ti|{(legs) a wa dhU ti ste rtsa dbu ma/}
-dhU ba|{(legs) brtan pa/}
+dhU baH|{(legs) brtan pa/}
 dhu wa ka|{(legs) rtsa ba'am nges pa/ dper na/ nyi ma'i dhu wa/ gza' dhu/}
 gdags khri btsan po|{mer khri btsan po dang gdags lha dkar mo gnyis kyi sras/ sngar bod rgyal drug pa ste gnam gyi khri bdun gyi ya gyal zhig}
 gdags pa|1. {'dogs pa'i ma 'ongs pa/ }2. {ming gi tha snyad/}
@@ -22357,12 +22355,13 @@ gdab pa|1. {'debs pa'i ma 'ongs pa/ }2. 1) {byed pa bcu gcig nang gi 'pho byed c
 gdab dmigs|{gdab par bya ba'i dmigs yul/}
 gdab yas|{grangs gnas shig}
 gdam ka|{gdam sgrug bzang ngan gnyis kyi nang nas gdam ka ma nor ba zhig rang gis byed dgos/}
-gdam nga|{gang yang rung ba'i don/ la lar gdam nga can nyid de/ 'phreng phreng dang 'phrin phrin lta bu'o/ 'phreng phreng 'phrin phrin gdam nga can/gcig tu ma nges pa zhig ming tshig 'di gnyis gang rung sbyar chog pa'i gdam nga can yin/ dngos po 'di tsho'i nang nas gang 'dod blangs chog pa'i gdam nga can zhig yin/}
-#gdam ngag gdams ngag dang 'dra|
+gdam nga|{gang yang rung ba'i don/ la lar gdam nga can nyid de/ 'phreng phreng dang 'phrin phrin lta bu'o/}
+gdam nga can|{gcig tu ma nges pa zhig _ming tshig 'di gnyis gang rung sbyar chog pa'i gdam nga can yin/ dngos po 'di tsho'i nang nas gang 'dod blangs chog pa'i gdam nga can zhig yin/}
+gdam ngag|{gdams ngag dang 'dra/}
 gdam pa|{'doms pa'i ma 'ongs pa/}
 gdam bya'i dbang cha|{bdam bya'i dbang cha dang 'dra/}
-#gdams ngag man ngag gam phan pa'i ngag bslab bya'i gdams ngag la nyan pa|
-gdangs ngag khyad par can|{theg chen gyi rigs can 'tshang rgya ba'i lam cha tshang ston pa'i mdo dang bstan bcos thams cad do/}
+gdams ngag|{man ngag gam phan pa'i ngag bslab bya'i gdams ngag la nyan pa/}
+gdams ngag khyad par can|{theg chen gyi rigs can 'tshang rgya ba'i lam cha tshang ston pa'i mdo dang bstan bcos thams cad do/}
 gdams ngag gi gzhung|{byang chub lam gyi sgron ma/ blo sbyong gi khrid/ bstan rim gyi khrid/ bden bzhi'i khrid/ rten 'brel gyi khrid/ bden gnyis kyi khrid sogs mang ngo/}
 gdams ngag bcu gcig dge slong gi sdom pa 'bog pa'i mjug tu gdams ngag brjod pa ste|{dge slong gi bslab bya mdor bsdus brjod pa dang/ de la bslab tshul brjod pa yin la/ de'i nang gses su bsten bya 'tsho ba rnam dag dang/ bsrung bya tshul khrims rnam dag dang/ nyams len spyod pa rnam dag la dge sbyong gi chos bzhi dang/ bsnyen rdzogs thob pas mchog tu 'dod pa'i don 'grub pa dang/ gnas brtan rnams dang tshul khrims mnyam pa dang/ mkhan slob la gus par bya ba dang/ grogs la gus par bya ba bcas dul ba'i gnas la bslab pa dang/ rtogs pa lta ba rnam dag la spong klog byed pa dang/ yang dag par blang ba la bslab pa dang/ bslab pa la gus par sbyar ba dang/ bsgrub par bya ba thabs brjod pa bag yod par gdams pa bcas bcu gcig go/}
 gdams ngag ston pa|{nyams len gyi gnad dam snying po shod pa/}
@@ -22524,14 +22523,14 @@ gdong 'dzar|{chos po ti'i mtshan yig 'khod pa'i 'dzar/}
 gdong 'dzin|{sgra gcan gdong dang nyi zla phrad de 'dzin pa'i ming/}
 gdong zhu|{rim brgyud kyis ma zhus par zhu yul gtso bo de rang gi mdun du rang nyid kyis thad kar zhus pa/ snga phyi'i bde sdug yong rkyen tshang ma don gyi bdag po ngo ma rang gi sku mdun du gdong zhu mthar phyin byas pa yin/}
 gdong bzhi pa|{(mngon) tshangs pa/}
-gdong gzhi mig brgyad|{mi mang 'dzoms pa'i don/ don dag de'i skor nga rang tsho gdong bzhi mig brgyad kyis gros thag bcad pa yin no/}
+gdong bzhi mig brgyad|{mi mang 'dzoms pa'i don/ don dag de'i skor nga rang tsho gdong bzhi mig brgyad kyis gros thag bcad pa yin no/}
 #gdong yig glegs bam gyi gdong khebs steng gi yi ge|
 gdong yig gi rgya|{rgya rim pa bdun gyi nang gses/ glegs bam mi 'khrug par byed pa'i rtags te gdong 'dzar/}
 gdong g.yogs bcing ba|{phyi 'jug gi nang gses/ slob ma rnams dkyil 'khor mthong ba re zhig bsgrib pa dang/ ma rig pas ldongs pa mtshon byed du mig dar dmar po dpral bar bcing ba'o/}
 gdong ris|{ngo gdong/ gdong ris ngan pa/}
 gdong len pa|{mdun du 'gro ba/ dmag gi mtshon cha'i gdong len/ gdong len 'thab 'dzing pa/ phar 'gro dmag gi gdong len yin/ tshur yong dpung gi rjes ma yin/ sprang po yin na khyi kha gdong len pa zhig dgos/}
 gdong shing|{(yul) lham gyi gdong rgyong byed kyi shing/}
-dgong shed|{ham spobs/ rang don khog tu bcug nas gzhung gi rgyu nor la 'dod rngam gyi gdong shed chen po byed/}
+gdong shed|{ham spobs/ rang don khog tu bcug nas gzhung gi rgyu nor la 'dod rngam gyi gdong shed chen po byed/}
 gdong gshis|{ngo gdong gi rnam 'gyur/ kho'i rdzun rkub rdol bas kha skyengs nas gdong gshis 'gyur song/}
 gdong gsher|{phan tshun gdong thug gis rtsod pa/ gyod ya gnyis gdong gsher byed du 'jug pa/}
 gdong bsher ra sprod|{dngos su gdong thug nas ra sprod byed pa/ phan tshun gnyis kyi bshad tshul 'gal 'dzol che bas gdong bsher ra sprod mi byed thabs med byung/}
@@ -22633,7 +22632,6 @@ bdag dman pa|{gus phran nam/ gus chung zhes pa lta bu'i khengs skyung ngam/ rang
 bdag 'dzin|{phung po lnga gang rung la brten nas bdag tu 'dzin pa'i blo'am nga'o snyam pa'i ngar 'dzin/}
 bdag 'dzin 'jig lta|{dmigs pa nga la dmigs nas rnam pa rang bzhin gyis grub par 'dzin pa/}
 bdag 'dzin gnyis|{lam gyi dgag bya gnyis te chos dang gang zag gi bdag 'dzin/}
-bdag 'dzin gnyis|{lam dgyi dgag bya gnyis te chos dang gang zag gi bdag 'dzin/}
 bdag gzhan|1) {rtag 'jug skab skyi byed pa po dang bya ba'i yul yin la de yang byed po gtso phal dang bye pa'i las bcas dngos po bdag gi khongs su 'du ba dang/ bya yul bya las dang bcas pa dngos po bzhan gyi khongs su 'du/} 2) {rang gzhan gnyis/ bdag phan gzhan gnod kyi las ka/ bdag gzhan brje ba'i byang chub kyi sems/}
 bdag gzhan brje ba'i byang chub kyi sems|{bdag gi bde ba gzhan la ster/ gzhan gyi sdug bsngal rang gis len par bsgom pa'i byang chub kyi sems bskyed tshul zhig}
 bdag gzhan mnyam brje|{bdag gzhan mnyam pa'i byang chub kyi sems dang bdag gzhan brje ba'i byang chub kyi sems kyi bsdus ming/}
@@ -23028,7 +23026,7 @@ mdel par|{bod mda'i mdel ril lugs rgyag sa'i par/}
 mdel ril|{bod mda'i nang blug rgyu'i zha nyes bzos pa'i mde'u ril/}
 mdel shubs|{mde'u 'jug snod/}
 mdo|1) {nyung ngur bsdus pa'i sdom mam gnad 'gag} 2) {chu dang/ lam sogs kyi 'dzoms 'gag lam bzhi mdo/ chu gsum mdo/ brag gsum mdo/ lam mdor lus pa/} 3) {khang pa sogs kyi phyi'am mda'/ khang pa sbug mdo/ lung pa'i phu mdo/} 4) {sde snod gsum gyi nang las mdo sde/} 5) {mdo sngags kyi zlas dbye ba'i mdo/}
-mdo kun las btus pa|{byang chub sems dpa'i bslab bya'm spyod pa gtso bor ston pa'i gzhung dpal mgon po klu sgrub kyis mdzad pa/ bam po lnga pa/ rgya gar gyi mkhan po dzi na mi tra dang/ shI lendra bo dhi dang/ lo tsA ba bande ye shes sde'i 'gyur/}
+mdo kun las btus pa|{byang chub sems dpa'i bslab bya'm spyod pa gtso bor ston pa'i gzhung dpal mgon po klu sgrub kyis mdzad pa/ bam po lnga pa/ rgya gar gyi mkhan po dzi na mi tra dang/ shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sde'i 'gyur/}
 mdo kha|{skad cha'i snying po/ mi de'i skad cha mdo kha 'gril po 'dug}
 mdo khams|1) {a mdo dang khams gnyis kyi spyi ming/} 2) {ming gzhan smad khams te da lta 'bri chu stod rgyud kyi gyas gyon la zer/}
 mdo khams sgang drug smad mdo khams sgang drug dang don gcig mdo dge 'dun|{sngar lha ldan smon lam skabs gdan sa gsum gyi sgrig khongs la dngos su ma 'dzul ba'i tshogs khang gi mdo na bzhugs pa'i btsun gral/}
@@ -23085,7 +23083,7 @@ mdog mdog bcos pa'i tshul lam khul|{mi shes pa shes mdog mdog byed pa/}
 mdog ldan|1) {sngo zhig} 2) {(mngon) gser spyi/}
 mdog med skyes|{(mngon) so ma rA dzA/}
 mdog dmar|{(mngon)} 1) {khrag} 2) {padma ra ga/}
-mdog mjes|{kha dog lta na sdug pa/ mdog mdzes me tog}
+mdog mdzes|{kha dog lta na sdug pa/ mdog mdzes me tog}
 mdog legs|{kha dog bzang po/ rtags ma mdog legs shig legs skyes su stsal ba/}
 mdog shor|{kha dog shor ba'am nyams pa/ lus stobs nyams na mdog shor yong/}
 mdog gsal mkhris pa|{lus kyi rtsa ba'i mkhris pa lnga'i ya gyal pags la gnas pa zhig ste/ byed las lus kyi pags pa'i mdog gsal zhing dang bar byed pa yin/}
@@ -23409,7 +23407,7 @@ mdos ris|{skud pa tshos tshogs spel ba'i nam mkha' dang khyung tshang sogs mtsho
 'dus pa|1. {'du ba'i 'das pa/ }2. 1) {tshogs pa/} 2) {dge 'dun pa/} 3) {tshigs bcad rtsom tshul zhig ste/ brjod bya'i don gcig la rjod byed sho lo ka du ma yod pa la bya tshig kyang du ma yod pa/} 4) {(mngon) lus/} 5) {gsang ba 'dus pa'i bsdus tshig}
 'dus pa rgya mtsho|{dge 'dun mang po tshogs sde/}
 'dus pa chen po theg pa chen po'i mdo sde las de bzhin gshegs pa'i dpal gyi dam tshig ces bya ba theg pa chen po'i mdo|{bam po gsum dang le'u bzhi pa/ rgya gar gyi mkhan po sarba dznyA de wa dang/ lo tsA ba bande dpal brtsegs kyis bsgyur pa/}
-'dus pa chen po rin po che tog gi gzungs|{bam po brgyad dang le'u bcu gsum pa/ pandi ta shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes zhus te skad gsar bcad kyis bcos pa/}
+'dus pa chen po rin po che tog gi gzungs|{bam po brgyad dang le'u bcu gsum pa/ pandi ta shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes zhus te skad gsar bcad kyis bcos pa/}
 'dus pa chen po las sa'i snying po'i 'khor lo bcu pa|{mdo sde zhig bam po bcu dang le'u brgyad pa/ rgya'i mkhan po hwa shang zab mo la sogs pa dang/ lo tsA ba bande rnam par mi rtog pa'i 'gyur/}
 'dus pa lugs gnyis|{'phags pa klu sgrub dang/ sangs rgyas ye shes zhabs so so nas brgyud pa'i gsang ba 'dus pa lugs gnyis/}
 'dus pa'i nad|{rlung dang/ mkhris pa/ bad kan bcas mnyam du 'dus pa'i nad de/ mtshon byed bad kan smug po lta bu'o/}
@@ -23682,7 +23680,7 @@ mdos ris|{skud pa tshos tshogs spel ba'i nam mkha' dang khyung tshang sogs mtsho
 'dra bshus|1) {ma dpe dang 'dra bar bris pa/} 2) {'dra bar bris pa'i dpe ris/}
 'dra se 'dres se|{'dra min sna tshogs mnyam du 'dres pa/}
 'dra gsob|{srog ldan 'dra ba'i stong gsob/ 'dra gsob bzos nas glud du brdzangs pa/}
-'dra mthil|{(rnying) lag mthil/}
+'drag mthil|{(rnying) lag mthil/}
 'drad pa|{(tha dad pa) 'drad pa/ 'drad pa/ 'drod// 'thog pa/ rus par 'byar ba'i sha rnams sos 'drad pa/}
 'dral ba|{(tha dad pa) dral ba/ dral ba/ drol// 'joms pa/ dam tshig 'dral ba/ mtshams bcad dral ba/ ngo tsha dral ba/ sgrig khrims 'dral bar mi byed pa/}
 'dral byed|{(mngon) thong gshol/}
@@ -23881,7 +23879,8 @@ rdo ko bye|{rdo phag mgo dang don gcig}
 rdo klad|{rdo sman gyi rigs/ dbyibs klad pa dang 'dra ba zhig ste/ ro bska/ zhu rjes snyoms/ nus pas klad pa 'dzag pa sdom zhing/ rma'i shu' skyed/}
 rdo dkar gong|{rdo dkar po zhig}
 rdo dkar po|{(mngon) shel/}
-rdo bkyag rdo las bzos pa'i skas 'dzeg rdo rko ba|{rdo la ma ni sogs gzungs sngags dang/ chos dpe sna tshogs rko mkhan/}
+rdo bkyag|{rdo las bzos pa'i skas 'dzeg}
+rdo rko ba|{rdo la ma Ni sogs gzungs sngags dang/ chos dpe sna tshogs rko mkhan/}
 rdo skas|{rdo las bzos pa'i skas 'dzeg rdo skas thog 'dzegs nas 'gro ba/}
 rdo skyur|{rdo sman gyi rigs mtshur ltar ro skyur ba zhig ste/ nus pas pho ba'i bad kan 'joms pa dang/ pho nad ma zhu ba sel/ me drod skyed/}
 rdo skyes|{(mngon) brag zhun/}
@@ -23922,7 +23921,7 @@ rdo rje gri gu|{(mngon) kye rdo rje/}
 rdo rje gro lod|{gu ru mtshan brgyad kyi ya gyal zhig}
 rdo rje rgya gram|{las bzhi sogs mtshon byed sna tshogs rdo rje'am/ lha'i phyag mtshan gyi bye brag cig}
 rdo rje can|{(mngon)} 1) {rdo rje 'chang/} 2) {phyag na rdo rje/}
-rdo rje gcod pa|{shes rab kyi pha rol tu phyin pa rdo rje gcod pa/ rgya gar gyi slob dpon shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur/}
+rdo rje gcod pa|{shes rab kyi pha rol tu phyin pa rdo rje gcod pa/ rgya gar gyi slob dpon shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes bsgyur/}
 rdo rje lcags kyu ma|{sgo ma bzhi'i nang tshan zhig}
 rdo rje 'chang|<{badzradhAra}>{ rigs kun gyi khyab bdag rgyud kyi ston pa/ mdo las shAkya thub pas gsang sngags chos gsung skabs kyi sku'i rnam par zer/ ming gi rnam grangs la kha sbyor bdun ldan dang/ nges pa lnga ldan/ rdo rje can/ rdo rje 'chang chen/ rid kun khyab bdag rigs brgya'i bdag gsang sngags rgyal bcas so/}
 rdo rje 'chang chen|{(mngon) rdo rje 'chang/}
@@ -23930,7 +23929,7 @@ rdo rje 'jigs byed|{grub chen la li tas o rgyan yul nas spyan drangs pa'i yi dam
 rdo rje nyi ma|1) {mdo zhig gi ming/} 2) {byang chub sems dpa' rdo rje 'od/} 3) {sangs rgyas shig gi mtshan/}
 rdo rje snying 'grel|{sems 'grel skor gsum gyi nang tshan/ dgyes pa rdo rje'i rgyud brtag pa gnyis pa dus 'khor ltar du 'grel ba/ phyag na rdo rjes brtsams/}
 rdo rje snying po|{gsang sngags kyi snying bcud/}
-rdo rje snying po'i gzungs|{'phags pa rdo rje'i snying po'i mdo'i gzungs bam po gcig pa/ rgya gar gyi slob dpon shI lendra bo dhi dang/ lo tsA ba bande ye shes sdes zhus te skad gsar bcad kyis bcos pa'o/}
+rdo rje snying po'i gzungs|{'phags pa rdo rje'i snying po'i mdo'i gzungs bam po gcig pa/ rgya gar gyi slob dpon shI len+d+ra bo dhi dang/ lo tsA ba bande ye shes sdes zhus te skad gsar bcad kyis bcos pa'o/}
 rdo rje lta bu'i ting nge 'dzin|{theg pa che chung so so'i sgom lam gyi 'bras bu mthar thug thob pa'i gegs su gyur pa'i spang bya phra ba'i mthar thug pa de nyid 'dzoms pa la thogs pa med pa'i mthu dang ldan pa gnyen po bar chad med lam mo/}
 rdo rje lta bu'i sems bskyed|{sems bskyed nyer gnyis kyi nang gses/ sa bzhi pa ba'i rgyud kyi brtson 'grus kyi phar phyin dang ldan pa'i sems bskyed ni bla na med pa'i byang chub la yid ches pa brtan pas bdud kyis mi phyed pas na rdo rje lta bu'o/}
 rdo rje theg pa|{(mngon) gsang sngags kyi theg pa/}
@@ -23963,7 +23962,7 @@ rdo rje gzhon nu|{bla med rgyud kyi yi dam phur pa'i ming gi rnam grangs shig}
 rdo rje bzhi bskyed|{lha bskyed tshul zhig ste/ stong nyid bsgoms nas pad nyi la sogs pa'i gdan gyi steng du zla nyi sa bon las 'od zer 'phros slar 'dus pa las lha'i sku rdzogs par bskyed de gnas gsum du yi ge gsum dgod pa/}
 rdo rje zam pa|{gsang sngags rnying ma'i rgyud sde zhig}
 rdo rje gzegs ma'i gtan tshigs|{gtan tshigs chen po lnga'i nang gses/ rgyu la dpyod pa dngos smra'i log rtog gi brag ri 'jig pa rdo rje gzegs ma lta bu rnam par thar ba'i sgo mtshan ma med pa ston pa'i gtan tshigs te/ myu gu lta bu'i dngos po rnams chos can/ bden par skye ba med de/ bdag dang gzhan dang gnyis ka dang gnyis min te rgyu med las mi skye ba'i phyir/ zhes pa mi snang ba'i 'brel zla rgyu ma dmigs pa'i rtags so/}
-rdo rje ri rab chen po'i rtse mo'i khang pa brtsegs pa'i gzungs|{rgya gar gyi mkhan po shI lendra bo dhi dang/ pradznyA siddhi dang/ lo tsA ba bnde ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa'o/}
+rdo rje ri rab chen po'i rtse mo'i khang pa brtsegs pa'i gzungs|{rgya gar gyi mkhan po shI len+d+ra bo dhi dang/ pradznyA siddhi dang/ lo tsA ba bnde ye shes sdes bsgyur cing skad gsar bcad kyis bcos pa'o/}
 rdo rje rin po che|{rdo rje pha lam/}
 rdo rje ro langs ma|{lha mo dbyangs can ma drag tu khros pa'o/}
 rdo rje sems dpa'|<{badzrasatwa}>{ phyag g.yas rdo rje snying khar gsor zhing/ g.yon pas dril bu dku la brten pa/ zhabs gnyis skyil mo krung gis bzhugs pa/ sku mdog dkar gsal zla ba'i mdog can gyi yi dam rigs brgya'i khyab bdag}
@@ -24019,7 +24018,7 @@ rdo ba'i nad|{(mngon) brag zhun/}
 rdo ba'i bu|{(mngon) ri las 'ong ba'i tshin rtsi/}
 rdo bye'u mgo|{rdo sman gyi rigs dbyibs bye'u'i mgo dang 'dra ba zhig ste/ ro bska/ zhu rjes drod/ nus pas rma gso/ rus chag sbyor/ rma'i chu ser phyir 'dren/}
 #rdo brag rdo chen po'am brag gong|
-rdo 'bum|{ma ni sogs brkos pa'i rdo'i phung po/}
+rdo 'bum|{ma Ni sogs brkos pa'i rdo'i phung po/}
 rdo sbal|{sbal pa rdo zan/ pho bar rdel chags yod pas de'i zas su rdo za bar grags/}
 rdo sbom|{rdo che ba/}
 rdo mal|{rdo tshur blangs pa'i rjes shul/}
@@ -24099,8 +24098,7 @@ rdol|{rdal ba'i skul tshig}
 rdol chos|{gang byung bab col du spyod pa'i rtsing spyod/ lugs dang mi mthun pa'i rdol chos rang snang gang dran byed pa/}
 rdol gtam|{ma brtags gang byung shod pa'i 'chal gtam/}
 rdol thabs smra ba|1) {skad cha byung rgyal rings stabs su smra ba/} 2) {(rnying) tshig nyog ldab ldib smra ba/}
-rdol ba|{(tha mi dad pa) grums pa'am zhig pa/ khog ltir zhabs rdol ba/ chu mig cig rdol ba/ rma brtol nas rnag rdol ba/ sgo nga}
-rdol nas byi'u thon pa|{byas nyes kyi skyon mtshang rdol ba/ rdol ba'i khyim/ rdol ba'i bu ga /}
+rdol ba|{(tha mi dad pa) grums pa'am zhig pa/ khog ltir zhabs rdol ba/ chu mig cig rdol ba/ rma brtol nas rnag rdol ba/ sgo nga rdol nas byi'u thon pa/ byas nyes kyi skyon mtshang rdol ba/ rdol ba'i khyim/ rdol ba'i bu ga /}
 #rdol bug rdol ba'i bu ga|
 rdol bon|{brdol bon dang 'dra/}
 rdos|{bongs tshad/ rdos che ba/ lus rdos chung chung zhig las med kyang snying stobs chen po 'dug}
@@ -24593,7 +24591,7 @@ sdom pa'i tshul khrims|{nyes spyod mtha' dag las ldog par byed pa ste/ mi dge ba
 sdom bu|{khang chung/ skyed tshal gyi mtha' sdom bus bskor ba/}
 sdom byang|1) {dpe cha'i kha yig} 2) {khag mang phyogs bsdus kyi tho yig}
 sdom byed phyag rgya|{gdon bgegs 'ching byed kyi phyag rgya/}
-sngom min|{gzhan gnod gzhi dang bcas pa la rgyun du zhugs nas lus ngag mi sdom pa ste shan pa dang 'jud mthun ma sogs kyi bya ngan dang 'brel ba'i rnam par rig byed kyi gzugs/}
+sdom min|{gzhan gnod gzhi dang bcas pa la rgyun du zhugs nas lus ngag mi sdom pa ste shan pa dang 'jud mthun ma sogs kyi bya ngan dang 'brel ba'i rnam par rig byed kyi gzugs/}
 sdom gtsang|{bslab khrims gtsang ba/}
 sdom brtson|{rab byung/ sdom brtson ldan pa'i bshes gnyen/}
 sdom brtson dam pa|{rigs gsum mgon po dang/ mkhan slob chos gsum/ lo tsA ba sogs mtshon pa'i dpe ris shig ste/ ral gri de 'jam pa'i dbyangs dang khri srong lde'u btsan mtshon byed dang/ po ti de phyag na rdo rje mtshon byed/ ri mo'i dkyil du yod pa'i pad ma de spyan ras gzigs dang slob dpon pad ma 'byung gnas mtshon byed/ ngang pa mgo gnyis can de zhi ba 'tsho mtshon byed/ ne tso mgo gnyis can de lo tsA ba mtshon byed bcas red/}
@@ -24821,13 +24819,13 @@ na yam|{tshod tshod dam spam spam/ ma brtags ma dpyad par na yam ma shod/}
 na yol|{lang tsho rgas pa'm na tshod song ba/}
 na ra g.yu mtsho|{bod rang skyong ljongs kyi mtsho sna rdzong gi byang rgyud du yod/}
 na ra ra|1) {sne mo 'dzar ba'am 'phyang ba/} 2) {rgyun mi 'chad pa/}
-na ra|{(legs) mi/}
+na raH|{(legs) mi/}
 na rak|{(legs) dmyal ba ste na rag kyang zer/}
 na ram|1) {rim pa bstar chags/} 2) {sngo sman gyi rigs shig ste/ ro kha la mngar/zhu rjes bsil/ nus pas 'khru ba gcod/ rgyu gzer la phan/}
 na rI ki la|{(legs) shing be ta'i 'bras bu/}
 na rim|1) {na tshod kyi rim pa/ rgan gzhon na rim bzhin du gral bsgrigs pa/} 2) {rabs sam rim pa/ mi rabs na rim/ 'dzin grwa na rim bzhin du slob sbyong byed pa/}
 na re|{zer ba/ khong na re/ khyod rnams nyon dang/ gtam snyan po zhig yod zer/ mi gzhan dag na re/ 'di 'dra byas na yag po 'dug zer/}
-na re|{no re/ nor 'khrul/ tshig na re no res don mi go/ na re ba/ rgyun chags pa'm nar ma/ las grwa btsugs pa nas bzung ste las rgyun na re bar 'dzin mus red/}
+na re no re|{nor 'khrul/ tshig na re no res don mi go/ na re ba/ rgyun chags pa'm nar ma/ las grwa btsugs pa nas bzung ste las rgyun na re bar 'dzin mus red/}
 na ro|{bod yig gi dbyangs bzhi'i tha ma mtshon byed kyi brda zhig}
 na rogs|{don med ston pa'i tshig cig don med 'khyams pa rkang pa na rogs red/}
 na le sham|{pho ba ris kyi ming gzhan zhig}
@@ -24844,7 +24842,7 @@ nA ma|{(legs) zhes bya ba'i skad dod/}
 nA ro mkha' spyod ma|{pan chen nA ro pa nas brgyud pa'i mkha' spyod ma ste sngags bla med kyi yi dam zhig}
 nA ro chos drug rgya gar gyi pan chen na ro ta pa nas brgyud pa'i gdams pa ste|{'di la chos drug 'dren lugs gnyis las gcig ni/ gtum mo'i rnal 'byor dang/ 'od gsal/ sgyu lus/ bar do/ 'pho ba/ grong 'jug bcas drug yang gcig ni/ gtum mo dang/ 'od gsal/ sgyu lus/ zung 'jug 'pho ba/ grong 'jug ste drug}
 nA ro pa|{dus rabs bcu gcig pa'i skabs su byung ba'i rgya gar gyi grub chen tee lo pa'i dngos slob/ bod kyi mar pa lo tsA'i bla ma yin zhing/ mar pa lo tsA la bde mchog dang nA ro chos drug sogs kyi gdams pa spel gnang mdzad/}
-nA lendra|{sngar rgya gar ma ga dha rgyal khab kyi rgyal bu rgyal byed kyi tshal na yod pa'i dgon pa grags can zhig dus rabs lnga pa nas drug pa'i dus 'go'i bar du btab/ der dgon chen brgyad yod pa dang dge 'dun gzhis byes mi grangs chig khri tsam zhig rgyun du bzhugs/ der theg chen theg chung dang/ rig byed/ tshad ma/ sgra rig pa/ gso ba rig pa sogs bslab pa'i gnas yin pas rgya gar du sangs rgyas chos lugs kyi slob grwa mtho shos shig tu gyur/ rang rgyal thang rgyal rbas kyi shyan tsang (htang zan bla ma) dang dbyi cing sogs der slob gnyer lo mang mdzad/ dus rbas bcu gnyis pa'i dus mjug tu bsnubs shing/ nye rabs gzhi nas de'i rjes shul khag gcig la 'og nas bton/}
+nA len+d+ra|{sngar rgya gar ma ga dha rgyal khab kyi rgyal bu rgyal byed kyi tshal na yod pa'i dgon pa grags can zhig dus rabs lnga pa nas drug pa'i dus 'go'i bar du btab/ der dgon chen brgyad yod pa dang dge 'dun gzhis byes mi grangs chig khri tsam zhig rgyun du bzhugs/ der theg chen theg chung dang/ rig byed/ tshad ma/ sgra rig pa/ gso ba rig pa sogs bslab pa'i gnas yin pas rgya gar du sangs rgyas chos lugs kyi slob grwa mtho shos shig tu gyur/ rang rgyal thang rgyal rbas kyi shyan tsang (htang zan bla ma) dang dbyi cing sogs der slob gnyer lo mang mdzad/ dus rbas bcu gnyis pa'i dus mjug tu bsnubs shing/ nye rabs gzhi nas de'i rjes shul khag gcig la 'og nas bton/}
 nag khung|{mun nag}
 nag khra|{nag shas che ba'i khra khra/ nag ge nog ge/ ri mo tshon sogs zub pa'i rnam pa/ mdog ris nag ge nog ge med par gsal po 'dug tshon ris rnams nag ge nog ger gyur 'dug}
 nag ge ba|{skyon dang/ dri nog chags tshul/ gos rnying nag ge ba/ bya spyod nag ge ba/}
@@ -25033,7 +25031,7 @@ nang pa'i ston pa|{sangs rgyas pa'i chos lugs srol gtod mkhan shAkya thub pa/}
 nang pa'i bstan pa|{sangs rgyas kyi bstan pa/}
 nang phug sbug gi cha|{khang pa'i nang phug lung pa'i nang phug las don gyi nag phug}
 nang phyogs|1) {khang pa dang/ ra ba sogs kyi nang khongs/} 2) {nang khul/} 3) {grub mtha' phyi nang gi zlas phye ba'i nang sde/}
-nag phrad|{nang lugs su phan tshun thug phrad/ grogs po phan tshun nang phrad byung ba/}
+nang phrad|{nang lugs su phan tshun thug phrad/ grogs po phan tshun nang phrad byung ba/}
 nang bon|{sangs rgyas dang cha 'dra ba'i bon po/}
 nang byan|1) {bran g.yog} 2) {khong du chud pa'am nges par shes pa/}
 nang byan chud pa|{khong du chud pa'am rtogs pa/ shes bya mtha' dag nang byan chud pa/}
@@ -25240,7 +25238,7 @@ nam mkha'i dbyings|{bar snang gi dgung/}
 nam mkha'i mig|{(mngon) nyi ma/}
 nam mkha'i mu khyud|{(mngon) srin bu me khyer/}
 nam mkha'i me tog|1) {med pa'am mi srid pa'i dpe/} 2) {(mngon) rgyu skar/}
-nam mkha'i mdzod|1) {byang sems shig gi mtshan/} 2) {nor ci 'dod 'byung ba'i bang mjod/} 3) {'phags pa nam mkha'i mdzod kyis zhus pa zhes bya ba theg pa chen po'i mdo/ bam po brgyad pa/ rgya gar gyi mkhan po bi dza ya shI la dang/ shI lendra bo dhi dang/ lo tsA ba bnde ye shes sdes bsgyur te skad gsar bcad kyis bcos pa'o/}
+nam mkha'i mdzod|1) {byang sems shig gi mtshan/} 2) {nor ci 'dod 'byung ba'i bang mjod/} 3) {'phags pa nam mkha'i mdzod kyis zhus pa zhes bya ba theg pa chen po'i mdo/ bam po brgyad pa/ rgya gar gyi mkhan po bi dza ya shI la dang/ shI len+d+ra bo dhi dang/ lo tsA ba bnde ye shes sdes bsgyur te skad gsar bcad kyis bcos pa'o/}
 nam mkha'i zil pa|{gnam g.yer ba'i skabs ba mo 'byung ba'i chu rdul/}
 nam mkha'i 'od|{(mngon) srin bu me khyer/}
 nam mkha'i rlangs pa|{(mngon) ba mo/}
@@ -25294,7 +25292,7 @@ nam seng tsam|{nam langs ma langs tsam/}
 nam srod|{mtshan mo'i cha stod/}
 nam sros pa|{sa rub pa/}
 nam gsal ba|{skya rengs tha ma shar ba/ bya skad gsum pa brgyab nas nam gsal yong/}
-nam|{(legs) 'dud do'am phyag 'tshal ba/}
+namaH|{(legs) 'dud do'am phyag 'tshal ba/}
 na'u ga|{spang ljang gu/}
 nar 'gyangs|{dus tshod phyir bshol/ las ka nar 'gyangs su gtong ba/ las don 'di nar 'gyangs phyi bshol du ma song bar dus thog so sor byed dgos/}
 nar nar|{dbyibs nar mo'am 'dzar 'dzar/ thag pa nar nar du drud/ chu nar nar du rgyug pa/ gos nar nar du 'dzar/ gtan 'khel gyi dus tshod nar nar du byas mi chog}
@@ -25341,10 +25339,10 @@ ni gu|1) {bu mo chung ngu/} 2) {mkha' 'gro ma ni gu/}
 ni gu'i chos drug sngags lugs ni gu mkha' 'gro nas brgyud pa'i chos drug ste|{gtum mo bde drod rang 'bar/ sgyu lus chags sdang rang grol/ rmi lam nying 'khrul rang dag 'od gsal gti mug rang sangs/ 'pho ba ma bsgoms sangs rgyas/ bar do rgyal ba longs sku rnams so/}
 ni sgra|{gzhi las logs su dgar ba'am/ dmigs kyis 'byed pa dang/ nges gzung ngam/ nan gyis brnan pa dang/ tshig gi kha skong bcas la 'jug pa'i phrad rang dbang can zhig mthing ga ni sngo sangs las gzhan no/ khyod ni dpa' zhing khyod ni mdzangs/ las don myur du tshar bar ni/ brtson 'grus chen po skyed dgos so/}
 ni ru ha|{rtug skam dang/ gzhang srin lta bu lte 'og man gyi nad la sman bskol nas khu ba grod pa'i nang blug ste gshang lam nas mas btang dgos pa zhig ste/ nang gses su dbye na sbyor ba rnon po dang 'jam po/ bar ma bcas gsum mchis/}
-ni la|{(legs) nIl dang 'dra/}
-nI la tho tha|{lan tshwa'i rigs kyi nang tshan mtshur sngon te/ ro lan tsha/ nus pa drod/ 'bras kyi nad dang/ skran la phan/ mig gi ling thog len/}
+ni la|{(legs) nIla dang 'dra/}
+nI la tho Tha|{lan tshwa'i rigs kyi nang tshan mtshur sngon te/ ro lan tsha/ nus pa drod/ 'bras kyi nad dang/ skran la phan/ mig gi ling thog len/}
 nim pa|{shing sman gyi rigs shig ste/ ro kha/ zhu rjes snyoms/ nus pas tshad pa dang/ skom dad/ yi ga 'chus pa sogs sel/ pags nad dang/ me dbal 'joms/}
-nIl|{(legs) nor bu'i rigs rdo sngon po zhig}
+nIla|{(legs) nor bu'i rigs rdo sngon po zhig}
 nu skyes|{(mngon) 'o ma/}
 nu mgo|{nu ma'i rtse mo/}
 #nu tog nu ma'i rtse mo|
@@ -25372,8 +25370,8 @@ nub rgyud|{nub ngos sam nub phyogs/}
 nub sgo|{nub phyogs su yod pa'i sgo/}
 nub ngos|{nyi ma nub sar kha lta ba'i phyogs/}
 nub gcig lhag por nyal ba'i ltung byed|{ltung byed 'ba' zhig pa dgu bcu'i nang gses/ bsnyen par ma rdzogs pa dang lhan cig tu mtshams nang gcig tu nub gnyis las lhag par nyal ba'o/}
-nub blta|{nub tu kha gtad pa/ khang pa sgo nub blta/}
 nub stod|{nub phyogs stod smad gnyis su phye ba'i stod cha/}
+nub blta|{nub tu kha gtad pa/ khang pa sgo nub blta/}
 nub pa|{(tha mi dad pa)} 1) {nyi zla sogs bzhud nas mi mngon par 'gyur ba/ nyi ma nub song/} 2) {chu'i nang du 'bying ba/ gru gzings rgya mtsho'i gting du nub/} 3) {srol rgyun sogs nyams par 'gyur ba/ byas rjes kyi snyan grags ji srid du mi nub pa/ lag rtsal gyi rgyun bzang nub tu mi 'jug}
 nub phyogs|{nyi ma nub pa'i phyogs/}
 nub phyogs bdag po|{(mngon) nub kyi phyogs skyong chu lha/}
@@ -25405,7 +25403,7 @@ nus rtsal|{yon tan nam lag rtsal/}
 nus zla|{(mngon) rgyal zla ba ste hor zla bcu gnyis pa/}
 nus shugs|{stobs dang shed shugs/ nus shugs gcig sgril/ nus shugs gang yod 'don pa/ nus shugs yod dgu rtsal sprugs/}
 ne gu|{(rnying) nag po/}
-ne gro ta|{nya gro rda dang 'dra/}
+ne gro ta|{n+ya gro rda dang 'dra/}
 ne thang|{na thang chung chung/}
 ne ne|{a ne ste pha'i sring mo che chung/}
 ne ne mo|{ne ne dang don gcig}
@@ -25439,7 +25437,7 @@ no no|{jo lags sam a jo/}
 no mon han|{(sog) sngar sog skad kyi go ming zhig}
 no yon|{(sog) dpon po/}
 no yon hu thug thu|{(sog) sog skad kyi go ming zhig}
-nog ba lang dang rnga mong gi mjing steng gi sha 'bur|{nog dang lkog shal med na yang/ ya so can gyi ba lang yin/}
+nog|{ba lang dang rnga mong gi mjing steng gi sha 'bur/ nog dang lkog shal med na yang/ ya so can gyi ba lang yin/}
 nog kha|{ja mdog lta bu'i kha dog}
 nog can|{(mngon)} 1) {ba lang/} 2) {sa glang lo/}
 nog 'bur|{phyugs kyi mjing steng gi sha 'bur/}
@@ -25553,7 +25551,7 @@ nor bsris pa|{rgyu dngos zad kyis dogs te spyod mkhas byed pa/}
 nor lha|1) {nor gyi lha'i rigs/} 2) {(mngon) nor lha la chu lha dang/ brtan pa/ zla ba/ 'dzin byed/ rlung/ me/ nam langs/ 'od byed bcas brgyad yod pas grangs brgyad mtshon/}
 nol thabs bgyi|{(rnying) phan tshun dmag 'thab rgyag pa/}
 nos|{nod pa'i skul tshig}
-nya gro ta|{(legs) bod skad du rkang mang zhes bya zhing/ de'i sa bon ni yungs dkar gyi bzhi cha tsam yod pa la lo re la yal ga rgyang grags tsam du khyab par skye bar bshad pas shin tu 'phel stobs che ba'i shing zhig gi ming/ sa bon chung smin nya gro ta'i/ yal 'dab rgyas pas rgyang grags khebs/ ming gi rnam grangs la nya gro dha dang/ pa da/ bhu bad bcas so/}
+n+ya gro ta|{(legs) bod skad du rkang mang zhes bya zhing/ de'i sa bon ni yungs dkar gyi bzhi cha tsam yod pa la lo re la yal ga rgyang grags tsam du khyab par skye bar bshad pas shin tu 'phel stobs che ba'i shing zhig gi ming/ sa bon chung smin n+ya gro ta'i/ yal 'dab rgyas pas rgyang grags khebs/ ming gi rnam grangs la n+ya gro dha dang/ pa Da/ bhu bad bcas so/}
 #gnag 'bri g.yag dang mdzo mo bcas pa'i phyud rigs|
 gnag khyu|{dud 'gro 'bri g.yag dang/ mdzo'i khyu/}
 gnag rjes|{phyugs rigs kyi rkang lag gi rjes/}
@@ -25621,7 +25619,7 @@ gnam rgya sa rnyi|{phyogs tshang mar rgya rnyi btsugs pa lta bu dgra bo'am nyes 
 gnam rgyan|1) {bla re/} 2) {thog yol/}
 gnam sgo|1) {thog kha nas yar mar 'dzul sa'i sgo/} 2) {thog gi skar khung/} 3) {'byung rtsis las byung ba ltar na skar ma ngan pa shar ba'i phyogs/}
 gnam sngon po|1) {nam mkha' sngo sangs/} 2) {(yul) gnam dpang du 'dzugs pa'i mna' tshig cig}
-gnam lcags|1) {lce 'bab bam thog mda' 'phangs pa gnam lcags thog las tsha/} 2) {sa 'og nas gter bton pa'i rdo rje dang phur pa lta bu brdungs na skad snyan zhing/ kha dog gsal min snum mdangs can lcad phal pas mi bdzi ba zhig ste/ nus pas bgegs 'joms shing smyo byed la phan/}
+gnam lcags|1) {lce 'bab bam thog mda' 'phangs pa gnam lcags thog las tsha/} 2) {sa 'og nas gter bton pa'i rdo rje dang phur pa lta bu brdungs na skad snyan zhing/ kha dog gsal min snum mdangs can lcags phal pas mi bdzi ba zhig ste/ nus pas bgegs 'joms shing smyo byed la phan/}
 gnam lcags sgra|{(mngon) 'brug sgra/}
 gnam lcags thog bab|{mgo steng du thog brgyab pa lta bur glo bur gyi god chags byung ba'i dpe/ mi 'dod pa gnam lcags thog bab ltar byung ba/}
 gnam lcags 'bar ba|{ri bo zhig bod rang skyong ljongs kyi sman gling rdzong khongs yar klungs gtsang po'i khug pa chen po'i nang du yod cing/ de'i mtho tshad rgya mtsho'i ngos nas smi 7756 yod/ 7756}
@@ -25993,7 +25991,7 @@ rna shal|{rna ba'i 'og gi pags 'dzar/}
 rna shes|{rna ba'i rnam par shes pa ste/ rkyen rang gi thun mong ma yin pa'i bdag rkyen rna dbang la brten nas byung ba'i rang yul du gyur pa'i sgra'i skye mched kyi ngo bo rang stobs kyis mthong ba'i rig pa/ dper na/ gtam skad cha nyon byed kyi shes pa lta bu/}
 #rna gshog rna ba'i 'dab phrum krong nge ba|
 rna lhong sgrog sbyangs|{yig cha sogs rna bar go nges kyi sgrog sbyangs byed pa/}
-rnag sha khrag rul nas chags pa'i khu ba|{rnag dri/ rnag 'brum/ rnag btsir ba/}
+rnag|{sha khrag rul nas chags pa'i khu ba/ rnag dri/ rnag 'brum/ rnag btsir ba/}
 rnag khug pa|{rnag chags pa/ rma la rnag khug pa/}
 rnag khrag sha khrag rul nas dkar por gyur pa'i rnag dang lus kyi khrag dmar po gnyis kyi bsdus tshig rnag brtol ba|{rnag bton pa/}
 rnag thog gtsag 'khel|{gnad la 'khel ba'i dpe/}
@@ -26066,7 +26064,7 @@ rnam thar dad pa'i 'jug ngogs|{rje btsun tsong kha pa chen po'i rnam thar/ dus r
 rnam thos|{mang po thos pa'am rgya cher thos pa/}
 rnam thos kyi bu|{rnam thos sras dang don gcig}
 rnam thos sras|<{beeshrabana}:>{ rgyal chen rigs bzhi'i nang gses ri rab kyi byang ngos kyi rgyal chen nam byang gi phyogs skyong/ ming gi rnam grangs la rkang pa gsum ldan dang/ rgyal po'i rgyal/ ngal bsos po/ gter gyi bdag rtag bde byed/ nor gyi bdag nor sbyin rgyal/ nor sbyin 'dren pa/ nor rtsen/ gnas srung po/ gnod sbyin rgyal/ rna rgyan gcig pa/ rnam sras/ dpal gter/ byang gi phyogs skyong/ byang phyogs bdag po/ dbyig gi char 'bebs/ mi la zhon/ mig skya/ mig ya/ mig gsum grogs po/ mi'i chos ldan/ rtsa gsum pa/ 'od yangs tsha bo/ rin chen snying po/ lus ngan/gsang bdag bcas so/}
-rnam dag rnam par dag pa ste nyes skyon dang bral ba'am yang dag pa|{gtsang ma/}
+rnam dag|{rnam par dag pa ste nyes skyon dang bral ba'am yang dag pa/ gtsang ma/}
 rnam dag sgom lam|{theg chen zag med sgom lam gang zhig spangs pa mthar thug gi rgyur gyur pa'o/}
 rnam dag tshul khrims 'dul ba'i 'bum|{bon gyi spyod pa'i skor gyi gzhung lugs shig}
 rnam bdun gyi rigs pa|{bdag dang shing rta dpe don sbyar ba'i sgo nas bshad de/ shing rta de shing rta'i yan lag rnams dang don gcig dang tha dad rten dang brten pa bcas bzhi dang/ ldan pa dang lnga/ tshogs pa dang dbyibs gnyis te bdun gyis gang zag gi bdag med gtan la phab pa'o/}
@@ -26103,8 +26101,7 @@ rnam par thar pa'i sgo gsum|{rnam par thar pa thob par byed pa'i ting nge 'dzin 
 rnam par 'thor ba'i 'du shes|{mi sdug pa sgom pa'i rnal 'byor zhig}
 rnam par dag pa|{rnam dag dang don gcig}
 rnam par dag pa sa gzhan na gnas pa|{spyod pa sa gzhan na gnas pa'i nang gses shig ste/ spo ba gsum dang/ mgu ba gsum dang/ spo ldan/ mgu ldan/ spo mgu dbyung ba bcas so/}
-rnam par dag pa'i rgyu lnga|{lam dngos yongs su dag pa dang/ nyer bsdogs yongs su dag pa/}
-rnam par rtog pas ma smas pa|{dran pas yongs su zin pa/ mya ngan las 'das par bsngos pa bcas lnga'o/}
+rnam par dag pa'i rgyu lnga|{lam dngos yongs su dag pa dang/ nyer bsdogs yongs su dag pa/ rnam par rtog pas ma smas pa/ dran pas yongs su zin pa/ mya ngan las 'das par bsngos pa bcas lnga'o/}
 rnam par dag pa'i sa|{byang chub kyi sa/}
 rnam par dag pa'i lha|{rgyun du zhugs pa nas sangs rgyas kyi bar/}
 rnam par dul|{(mngon) rta mchog}
@@ -26428,11 +26425,10 @@ snang ngor mdzes pa|{mthong snang du 'dra chags}
 snang ngos|1) {mdun phyogs sam mthong phyogs/} 2) {mthong sang gi phyogs/}
 snang chung|{mthong chung ngam gtsigs chen po ma yin pa/ gcig gis gcig la snang chung rtsis med ma byed/ dgra bor snang chung byed mi nyan/}
 snang chung khur med|{mthong chung lhod yangs/ spyi don tshang mar snang chung khur med ma byed/}
-sang chung lhod yangs|{bya ba la blo sgrim po med pa/ las don sgrub skabs snang chung lhod yangs byas na nor 'khrul yong/}
+snang chung lhod yangs|{bya ba la blo sgrim po med pa/ las don sgrub skabs snang chung lhod yangs byas na nor 'khrul yong/}
 snang chen|{gtsigs chen po/}
 snang mched thob gsum|{snang ba/ mched pa/ nyer thob gsum gyi bsdus ming/}
 snang brnyan|{gzugs brnyan/}
-snang stong|{gzugs brnyan/}
 snang stong|{snang ba thabs dang stong pa shes rab/}
 snang stong dbyer med|{snang ba thabs dang stong pa shes rab dbyer med pa ste/ yul gyi cha nas snang stong zung 'jug}
 snang dag|1) {do snang dang/gnad 'gag snang dag med/ brtson 'grus yod na mkhas par 'gyur ba snang dag med/ bka' slob de'i nang du dgongs don gal che ba zhig 'dug pa la khyod rang snang dag byung ngam ma byung/ sger gyi khe phan la snang dag ma btang ba/} 2) {dogs pa/ khyed rang thugs lhod lhod gnang nas phebs dang/ 'di phyogs ngos kyi las don la snang dag gtong mi dgos/}
@@ -26460,7 +26456,7 @@ snang ba ma byung|{do snang ma byung ba/ mi ngan gyis gnod skyon byed par snang 
 snang ba med pa|1) {sems khur med pa'am do snang med pa/ las don la snang ba med par yang yeng byas nas nor 'khrul chen po byung ba/} 2) {'od med pa/ mar snum gyi bzhu mar la dkar gsal gyi snang ba med pa/}
 snang ba bzhi|{gsang sngags rdzogs pa chen po'i lam nyams su blangs pa las thob pa'i slob lam nas mi slob lam bar gyi lam gyi snang ba ste/ chos nyid mngon sum gyi snang ba/ nyams snang gong 'phel gyi snang ba/ rig pa tshad phebs kyi snang ba/ chos zad blo 'das kyi snang ba rnams so/}
 snang ba za zi|1) {mthong snang nges pa med pa/ rmi lam gyi snang ba za zi 'char ba/} 2) {'od snang mi gsal ba/ sprin gseb nas zla 'od kyi snang ba za zi zhig 'phro ba/}
-snang ba gyeng ba|{sems gyeng ba/ gzhan la snang ba gyeng bzhin du las ka byas na don thog 'khel mi yong/}
+snang ba g.yeng ba|{sems g.yeng ba/ gzhan la snang ba g.yeng bzhin du las ka byas na don thog 'khel mi yong/}
 snang ba gsum|{snang gsum dang don gcig}
 snang ba'i bdag po|{(mngon) nyi ma/}
 snang ba'i dbang po|{(mngon) mig}
@@ -26469,10 +26465,10 @@ snang bar gang shar|{sems la gang dran te 'os dang mi 'os kyi bsam gzhigs med pa
 snang byed|{(mngon)} 1) {nyi ma/} 2) {mig} 3) {'od zer spyi/} 4) {me/}
 snang med|1) {mthong med/} 2) {ji mi snyam pa'i tshul lam do gal mi byed pa/ mang tshogs kyi bsam 'char snang med du skyur mi nyan/ gzhan skyon mi rjod pa mi 'grig la/ rang skyon snang med du bzhag nas mi sel ba de bas kyang mi 'grig} 3) {(mngon) }1. {mtshan mo/ }2. {mun pa/}
 snang med bag yangs|{khur med lhod yangs/}
-snang med chor med|{do snang med cing khe nyen mi tshor ba/}
-snang med gyang gyeng|{rang mthong rang 'gying gi snang med rtog bzo/ snang med gyang gyeng gis rang che rang bstod byed pa/}
+snang med tshor med|{do snang med cing khe nyen mi tshor ba/}
+snang med g.yang g.yeng|{rang mthong rang 'gying gi snang med rtog bzo/ snang med g.yang g.yeng gis rang che rang bstod byed pa/}
 snang med ling skyur|{khur med rgyang skyur/}
-snang med lhod gyeng|{khur med sems gyeng ngam rang dgar 'jog pa/}
+snang med lhod g.yeng|{khur med sems g.yeng ngam rang dgar 'jog pa/}
 snang rtse shag las khungs|{sngar bod sa gnas srid gzhung skabs/ lha sa'i gling skor nang khongs sgrigs khrims gnon gcod byed mkhan gyi las khungs yin zhing/ las khungs tshugs yul khrom stod sa khul sngags pa snang rtse ba zer ba zhig gi sdod shag tu byas pas ming snang rtse shag ces thogs so/}
 snang tshad|1) {'od che chung gi tshad/} 2) {mthong tshad dam rig tshad/ spyi pa'i las don mig la snang tshad tshang mar bdag sprod byed dgos/}
 snang tshul|1) {yid la shar tshul/} 2) {mig la mngon pa'i tshul/}
@@ -26480,7 +26476,7 @@ snang zhig dgon|{si khron zhing chen khongs rnga ba rdzong gi bon dgon che gras 
 snang zhen|{mthong ba'i yul la chags pa/}
 snang bzhi|{snang ba bzhi dang don gcig snang 'do/ 'od kyi snang ba/}
 snang yul|{blo ngor snang ba'i sgo nas rig par bya ba/ dper na/ bum pa dang/ bum pa'i don spyi lta bu/}
-snang gyel|{(rnying)} 1) {sge'u khung dang rab gsal/} 2) {gnas dben pa/}
+snang g.yel|{(rnying)} 1) {sge'u khung dang rab gsal/} 2) {gnas dben pa/}
 snang rung ma dmigs pa'i rtags|{ma dmigs pa'i rtags yang dag gi nang gses/ rtsod gzhi'i steng du dgag chos med nges su sgrub nus pa'i rtags te/ dper na/ mtshan dus kyi rgya mtsho chos can/ du ba med de/ me med pa'i phyir/ zhes pa lta bu 'gog byed rgyu ma dmigs pa'i rtags kyis dgag chos 'bras bu yod pa bkag pa'o/}
 snang rung ma dmigs pa'i rtags gnyis|{'brel zla ma dmigs pa'i rtags yang dag dang/ 'gal zla dmigs pa'i rtags yang dag go /}
 snang la ma nges pa|{blo rig bdun gyi nang gses/ rang gi 'jug yul du gyur pa'i rang mtshan gsal bar snang yang de la nges pa 'dren mi nus pa'i shes pa/ dper na mig shes kyis gzugs la lhag par chags bzhin pa'i gnas skabs kyi sgra 'dzin shes pa lta bu snang yang ma nges pa'o/}
@@ -26500,9 +26496,8 @@ snang gsum|{sa skya'i lam 'bras kyi nyams len gyi gzhi ma'am sngon 'gro/ thog ma
 snangs chen|{(rnying) rtsis che ba'am gtsigs can/}
 snad pa|{(tha mi dad pa) bsnad pa/ bsnad pa// rmas pa'am nyams pa/ lag pa rdo dbar du tshud nas mdzub mo chung zad bsnad pa/ dgra dang 'thab 'dzing byas kyang rang dmag ma bsnad ma rmas pa/ rta thog nas lhungs kyang mgo lus la snad skyon ma byung/}
 snad yar|{rmas pa'am skyon zhugs pa/}
-snabs|{sna'i zag chu'am sna lud/}
-snabs lug pa|{ming gi rnam grangs la ngar snabs dang/ sna rtug sna yi dri/ sna lud bcas so/}
-snabs rtug sna lud|{snabs rtug ltar ring du dor ba/}
+snabs|{sna'i zag chu'am sna lud/ snabs lug pa/ ming gi rnam grangs la ngar snabs dang/ sna rtug sna yi dri/ sna lud bcas so/}
+snabs rtug|{sna lud/ snabs rtug ltar ring du dor ba/}
 snabs ldug pa|{snabs lug pa'am/ snabs rtug don pa/}
 snabs phyi ba|1) {ras kyis snabs rtug 'byid pa/} 2) {snabs 'bud pa'am 'don pa/}
 snabs phyis|{snabs rtug 'byid byed kyi snam ras/}
@@ -26576,7 +26571,7 @@ snum byug zhun mar sogs mthil bzhi dang rlung gsang rnams su byugs te rlung nad 
 snum rtsi|{zhag tshi'am snum bag}
 snum tshil|{snum dang tshil bu/}
 snum tshil li ba|{snum mdangs thon stangs shig}
-snum chos ma|{snum gyis btsos pa'i kha zas/}
+snum tshos ma|{snum gyis btsos pa'i kha zas/}
 snum zhag|1) {snum dang zhag tshil/} 2) {snum bkrag gam snum mdangs/ gyon pa snum zhag can/}
 snum zhag dod po|{snum gyi mdog bkrag mngon gsal che ba/ khang pa snum zhag dod po/ yul lung snum zhag dod po/ sa zhing snum zhag dod po/ zhal ras snum zhag dod po/}
 snum za|{(mngon) sgron me/}
@@ -26620,7 +26615,7 @@ sne'u rgod|{sngo zhig}
 sne'u sngon|{sngo'am rtswa sngon po zhig}
 sne'u gdong|{sne gdong gi 'bri tshul gzhan zhig}
 sne'u tshod|{sngo tshod/}
-sne'u gyung|{sngo zhig}
+sne'u g.yung|{sngo zhig}
 sno ba|{(tha dad pa) bsnos pa/ bsno ba/ snos// sbru ba dang/ rdzi ba/ g.yo ba/ snur ba/ thud sno ba/ gro zhib legs par bsnos nas bag leb bzo/}
 snog pa|{(tha dad pa) bsnogs pa/ bsnog pa/ snogs// gong 'og dkrug pa dang bsre ba/ dpe cha tshang ma bsnogs song/}
 snog po|{(rnying)} 1) {phon che ba'am shong che ba/} 2) {bcud che ba/}
@@ -26665,8 +26660,8 @@ snos|{sno ba'i skul tshig}
 snrubs|{rgyu skar nyi shu rtsa brgyad kyi nang gses shig ming gi rnam grangs la gru sog ma dang/ mA la/ rtsa ba yang bcas so/}
 snrel zhi|{(rnying)} 1) {go rim 'chol ba/} 2) {'phred dam logs/}
 snron|{rgyu skar nyi shu rtsa brgyad kyi nang gses shig ming gi rnam grangs la gang bu dang/ lde'u/ lha ldan ma/ lha dbang ldan bcas so/}
-snron zla ba|{hor zla bzhi pa'i bcu drug nas lnga pa'i tshes bco lnga'i bar du snron zla ba zer/}
 snron gyis nya ba|{hor zla lnga pa'i tshes bco lnga/}
+snron zla ba|{hor zla bzhi pa'i bcu drug nas lnga pa'i tshes bco lnga'i bar du snron zla ba zer/}
 brnag pa|{dran pa'i don du go ba'i rnog pa'i ma 'ongs pa/}
 brnag min gyi gtam|{mi bzod pa'i gtam/}
 brnags pa|{dran pa'i don du go ba'i rnog pa'i 'das pa/}
@@ -26845,7 +26840,7 @@ pan zha|{(rgya) sngo zhig}
 pan grub|{pandi ta dang grub thob/}
 pan chen|{(legs) pandi ta chen po ste mkhas pa chen po/}
 pan chen sdom rgyun|{kha che'i pan chen shAkya shri nas brgyud pa'i sdom rgyun/}
-pan chen shAkya shrI|{kha che pan chen yang zer ba de ni rab byung gnyis pa'i me lug lor kasmir 'khrungs pa dang rang lo nyer gsum la rab tu byung nas rgya gar dkyil khul gyi na lendra'i mkhan thog mjug ma byed ring la kha che'i dmag gis dgon sde gtor bas slob ma gtso bo dang lhan du bod la phebs/ mtshur phur byams pa'i sku brnyan chen po bzhengs shing/ sa pan la bsnyen rdzogs gnang/ chos grags kyi tshad ma rnam 'grel sogs kyang spel/ rab byung bzhi pa'i shing khyi lor rang yul kasmir log nas rab byung bzhi pa'i shing bya lor 'das/}
+pan chen shAkya shrI|{kha che pan chen yang zer ba de ni rab byung gnyis pa'i me lug lor kasmir 'khrungs pa dang rang lo nyer gsum la rab tu byung nas rgya gar dkyil khul gyi na len+d+ra'i mkhan thog mjug ma byed ring la kha che'i dmag gis dgon sde gtor bas slob ma gtso bo dang lhan du bod la phebs/ mtshur phur byams pa'i sku brnyan chen po bzhengs shing/ sa pan la bsnyen rdzogs gnang/ chos grags kyi tshad ma rnam 'grel sogs kyang spel/ rab byung bzhi pa'i shing khyi lor rang yul kasmir log nas rab byung bzhi pa'i shing bya lor 'das/}
 pan chen er te ni|{(sog) bod kyi dge lugs sprul sku zhig gi mtshan te/ pan zhes pa ni legs sbyar gyi skad yin zhing/ pandi ta'i bsdus ming yin/ bod skad du mkhas pa'i don du 'jug er te ni zhes pa ni sog skad yin zhing/ bod skad du rin po che'i don du 'jug de ni rab byung bcu gnyis pa'i chu sbrul lor pan chen sku phreng lnga pa blo bzang ye shes la manydzu gong mas che bstod kyi mtshan gsol ba zhig yin pas/ de nas bzung sku phreng rim byon la pan chen er te ni zhes 'bod/ pan chen sku phreng dang po mkhas grub dge legs dpal bzang nas da bar sku phreng bcu byon/ de dag gi gdan sa ni gtsang bkra shis lhun po yin/}
 pan zhwa|{pandi ta'i zhwa mo sne ring zhig}
 pandi ta|{(legs) lnga rig pa ste rig pa'i gnas lnga shes pa'i mkhas pa/}
@@ -28762,7 +28757,7 @@ pho ba 'tshing ba|{zas ma zos kyang pho ba gang ba ltar gyur pa'i bad kan gyi na
 pho ba bzang po|{lto ba stobs ldan nam/ nad med/}
 pho ba ri lu|{pho ba ris dang 'dra/}
 pho ba ril bu|{pho ba ris dang 'dra/}
-pho ba ris|{shing sman gyi rigs 'bras bu la nor lug gi pho kha'i ri mo ltar dod pa zhig ste/ ro tsha/ nus pas drod skyed/ zas 'ju/ bad kan dang grang nad gzhil/ ming gi rnam grangs la drod sman hril mo dang/ na le sham/ pho tshe/ ma rI tse soo panydza na/ shi ku ma ni/ ha re nu ga/ a ba ku tsa/ a blku dza rnams so/}
+pho ba ris|{shing sman gyi rigs 'bras bu la nor lug gi pho kha'i ri mo ltar dod pa zhig ste/ ro tsha/ nus pas drod skyed/ zas 'ju/ bad kan dang grang nad gzhil/ ming gi rnam grangs la drod sman hril mo dang/ na le sham/ pho tshe/ ma rI tse soo pany+dza na/ shi ku ma ni/ ha re Nu ga/ a ba ku tsa/ a balku dza rnams so/}
 pho ba'i bad kan|{pho ba'i be snabs kyi ming gi rnam grangs shig}
 pho ba'i me drod|{pho ba'i nang du zas skom myag bzhu sbyong ba sogs me dang mthun pa'i drod kyi las byed pa de la me drod ces zer/ ngo bo ni lus kyi rtsa ba'i mkhris pa lnga'i ya gyal 'ju byed mkhris pa yin no/}
 pho ba'i rlung tshabs|{tshabs rigs drug gi tshabs nad pho bar byer ba'i nad cig ste/ nad rtags su pho ba sbo zhing ldang dub byed pa dang/ kha zas 'ju dka' ba sogs 'byung ba zhig}
@@ -28797,7 +28792,7 @@ pho zom|{bod kyi khyo ga'i lham zon pa/}
 pho gzer|{pho nad bye brag}
 pho bzo|1) {ma yin yin mdog gi rnam 'gyur/ pho bzo 'don pa'i dus ma yin/ snying rus 'don pa'i dus yin/} 2) {rang bzo dang 'ol tshod/}
 pho yan|{bza' zla med pa'i skyes pa/}
-pho yig ngag thog nas yi ge rjod skabs so so'i skye gnas kyi rtsol shugs che shos sam|{grims shos yin pa'i yi ge rnams/} 1) {gsal byed sum cu tham pa/ ka ao ?} 2) {ming gzhi'i pho yig ka ca ta pa tsa} 3) {sngon 'jug gi pho yig ba} 4) {rjes 'jug gi pho yig ga da ba sa}
+pho yig|{ngag thog nas yi ge rjod skabs so so'i skye gnas kyi rtsol shugs che shos sam/ grims shos yin pa'i yi ge rnams/} 1) {gsal byed sum cu tham pa/ ka -- a } 2) {ming gzhi'i pho yig ka ca ta pa tsa} 3) {sngon 'jug gi pho yig ba} 4) {rjes 'jug gi pho yig ga da ba sa}
 pho rab|{skyes pa pho blo rgya chen po yod pa/ pho rab cig gi khog la rta brgya rgyug sa'i thang yod/}
 pho rabs chad pa|{rigs rgyud chad pa'am bu rgyud yong rgyu med pa'i skyes pa/}
 pho ril|{spod rdzas dang pho ba drod skyed byed kyi sman zhig pho ril dkar po/ pho ril nag po/}
@@ -29887,7 +29882,7 @@ phur lding|{ling ling du 'phur stangs/ nam mkha'i dbyings su 'phur lding mngon p
 'phyo dgu|{'dab chags dang ri dwags spyi'i ming/}
 'phyo lding|{'phur zhing lding ba/}
 'phyo ba|{(tha mi dad pa)} 1) {lding zhing 'phur ba/ bya rnams mkha' la 'phyo ste thang du 'bab/ nya rnams chu'i nang du 'phyo ba/} 2) {'phag mchong rgyag pa/ seng ge gangs dkar ltongs su 'phyo ba/} 3) {sems mi bde ba/ mdza' grod yun ring ma thug pas blo sems ha cang 'phyo ba zhig byung/}
-'phyo zam|{chu steng gi bar snang/ chu steng la lcad thag sogs btang nas btsugs pa'i zam pa/}
+'phyo zam|{chu steng gi bar snang/ chu steng la lcags thag sogs btang nas btsugs pa'i zam pa/}
 'phyogs|{'phyag pa'i skul tshig}
 'phyong|1) {khang pa'i zur/} 2) {(rnying) skyong ba/}
 'phyongs|{'phyong dang 'dra/}
@@ -30526,7 +30521,7 @@ bu chen|{slob ma gtso bo/ thugs sras bu chen/}
 bu chos|{jo 'brom gnyis ka'i slob mar gyur pa bu rngog legs pa'i shes rab kyis zhus te jo bo rje a ti shas gsungs pa 'brom ston rgyal ba'i 'byung gnas kyi skyes rabs rnam thar mang po dang/ mjug tu jo bo sku gshegs nas 'brom la bka' gdams bstan pa gtad tshul ston pa'i chos po ti zhig sprul pa'i glegs bam yang zer/}
 bu rta|{mi dang rta'i bsdus ming/ bu rta bzang gras bsdus pa/ bu rta gang hrag}
 bu ston chos 'byung|{bde bar gshegs pa'i bstan pa'i gsal byed chos kyi 'byung gnas gsung rab rin po che'i mdzod ces bya ba/ khro phu pa bu ston rin chen grub kyis rab byung lnga pa'i chu khyi lor bsgrigs/ gsung 'bum lha sa'i par ma shog lhe khyon 212 nang brgya dang nyer gnyis yan chad rgya gar dang bal yul du dam pa'i chos byung tshul dang/ de man chad bsil ljongs su bstan pa byung tshul/ mjug tu bka' bstan bod du bsgyur to cog gi dkar chag kyang bkod yod pa'i lo rgyus khungs ma zhig (1290-}1364) {212 ya 122 122 1322}
-bu ston rin chen grub|{rab byung lnga pa'i lcad stag lo la gtsang shab smad du 'khrungs/ bka' brgyud pa khro lo'i yang slob/ zhwa lu chos sder 'chad nyan yun ring mdzad/ rgya gar nas bod du 'gyur ba'i glegs bam mtha' dag zhib mor dpyad de bsgrigs rim snga phyi gtan 'bebs mdzad de bstan 'gyur de rnams gcig tu bstan pa'i rtsa lag tu gyur/ mdo sngags gnyis dang rig gnas che chung gi gzhung dang 'grel bshad brgya phrag du ma brtsams te gsung 'bum po ti nyi shu rtsa drug yod/ de'i brgyud 'dzin rim byon rnams la zhwa lu ba'i grub mtha'am bu lugs zhes grags/ rje tsong kha pas de'i slob ma las rgyud kyi skor gsan/ rab byung drug pa'i shing 'brug la 'das/ (1290-}1364)
+bu ston rin chen grub|{rab byung lnga pa'i lcags stag lo la gtsang shab smad du 'khrungs/ bka' brgyud pa khro lo'i yang slob/ zhwa lu chos sder 'chad nyan yun ring mdzad/ rgya gar nas bod du 'gyur ba'i glegs bam mtha' dag zhib mor dpyad de bsgrigs rim snga phyi gtan 'bebs mdzad de bstan 'gyur de rnams gcig tu bstan pa'i rtsa lag tu gyur/ mdo sngags gnyis dang rig gnas che chung gi gzhung dang 'grel bshad brgya phrag du ma brtsams te gsung 'bum po ti nyi shu rtsa drug yod/ de'i brgyud 'dzin rim byon rnams la zhwa lu ba'i grub mtha'am bu lugs zhes grags/ rje tsong kha pas de'i slob ma las rgyud kyi skor gsan/ rab byung drug pa'i shing 'brug la 'das/ (1290-}1364)
 bu thang|{(yul) mag pa/}
 bu deb|1) {ma deb la brten nas bshus pa'i bu deb/} 2) {sngar bod kyi sa gnas srid gzhung skabs mnga' bdag gi zhing khral bsdu byed deb/}
 bu dod|{bu tshab/ bu dod cig blangs pa rig pa rno/}
@@ -31866,7 +31861,7 @@ bla 'khyar ba|{bla tshe gzhan du 'thor ba'am gyar ba/}
 bla gab|{steng g.yogs sam/ thog g.yogs/ 'grul pa ri zhol bla gab med pa'i gnas su sdod pa/}
 bla gab can|{(mngon) khang pa/}
 bla gor zho sha|{sman gyi bye brag cig}
-bla gos|<{auttarAesamga}>{ 'tsho ba'i yo byad bcu gsum gyi nang gses/ chos gos rnam gsum gyi ya gyal dge tshul slong gnyis kas nyin mor bgo ba'i stod gos ser po zhig ste/ snam phran bdun dang/ glegs bu phyed dang gsum pa/ tshad snam sbyar dang 'dra la/ deng sang yongs grags su chos gos zhes brjod/}
+bla gos|<{ut+tarA+esaMga}>{ 'tsho ba'i yo byad bcu gsum gyi nang gses/ chos gos rnam gsum gyi ya gyal dge tshul slong gnyis kas nyin mor bgo ba'i stod gos ser po zhig ste/ snam phran bdun dang/ glegs bu phyed dang gsum pa/ tshad snam sbyar dang 'dra la/ deng sang yongs grags su chos gos zhes brjod/}
 bla gyar ba|{bla srog gzhan du 'thor ba/}
 bla grwa|{bla ma dang grwa pa'i bsdus ming/}
 bla 'gugs|{bla 'khyams pa tshur 'gugs pa/}
@@ -31914,8 +31909,8 @@ bla ma mchod pa|{tshogs zhing bla ma la dngos 'byor yid sprul gyi mchod pa 'bul 
 bla ma gnyis|{rtsa ba'i bla ma dang brgyud pa'i bla ma/}
 bla ma dam pa|1) {bla ma yang dag pa'am mchog tu gyur pa/} 2) {bla ma 'das po/}
 bla ma pa|{rgya gar gyi nang pa'i grub mtha' smra ba zhig gi ming/}
-bla ma ma ni|{(yul) phan pa'i 'bu zhig lus phra zhing ring ba/ gshog pa cha gnyis yod pa/ mthon por 'phur thub pa/ chu khar 'tsho zhing lto rten 'bu srin yin/}
-bla ma ma ni ba|{(yul) sngar bod du ma ni skul ba dang sbrags las dkar nag gi thang bshad rgyag pa'i rnal 'byor pho mo/}
+bla ma ma Ni|{(yul) phan pa'i 'bu zhig lus phra zhing ring ba/ gshog pa cha gnyis yod pa/ mthon por 'phur thub pa/ chu khar 'tsho zhing lto rten 'bu srin yin/}
+bla ma ma Ni ba|{(yul) sngar bod du ma Ni skul ba dang sbrags las dkar nag gi thang bshad rgyag pa'i rnal 'byor pho mo/}
 bla ma rin po che|{bla mar 'bod pa'i gus ming/}
 bla ma'i brgyud pa|{bla rabs rim brgyud/}
 bla ma'i rnal 'byor|{rang gi rtsa ba'i bla ma sangs rgyas kun 'dus kyi ngo bor sgom pa'i cho ga zhig}
@@ -34083,19 +34078,19 @@ ma nu bse shing|{shing sman bse shing dkar po/}
 ma nu'i bu|{(mngon) mi/}
 ma ne|{ol sko ste ma le/}
 ma no ha|{(legs) tshon ldong ros/}
-ma ni|{(legs)} 1) {nor bu/} 2) {om ma ni pad me hUm ? zhes pa' yi ge drug}
-ma ni ka|{(legs) nor bu'i rgyan cha/}
-ma ni bka' 'bum|{chos rgyal srong btsan sgam pos brtsams pa'i thugs rje chen po'i sgrub skor dang/ bod kyi lo rgyus dang bka' chems sogs pod gnyis yod do/}
-ma ni 'khor lo|{ma ni yig drug mang po dril ba'i 'khor lo/}
-ma ni chu 'khor|{chus skor ba'i ma ni 'khor lo/}
-ma ni thang rdog|{(yul) kha gdan gyi ri mo zhig gi ming/}
-ma ni dung|{ma ni 'don thengs dung phyur gcig dpang por btsugs pa ste bod kyi yul srol nang gi mna' tshig cig}
-ma ni dung 'khor|{ma ni grangs dung phyur gcig yod pa'i 'khor chen/}
-ma ni 'dren 'dren|1) {thags thogs med pa/ kha bde po'i mi des skad cha bshad na chu rgyug rgyug ma ni 'dren 'dren red/} 2) {skad cha bskyar skor yang skor kho na shod pa/ mi de sger don kho na ma ni 'dren 'dren byed mkhan zhig red/}
-ma ni ma|1) {sil snyan gyi bye brag cig} 2) {ma ni'i ri mo yod pa'i gos chen zhig} 3) {ma ni dbyangs su 'then mkhan gyi bud med/}
-ma ni rlung 'khor|{rlung gis skor ba'i ma ni 'khor lo/}
-ma ni lag skor|{ma ni sogs kyi yig dril bcug ste lag tu bskor rgyu zhig}
-ma ni rdo phung|{yig drug rdo la brkos te spungs pa'i phung po/}
+ma Ni|{(legs)} 1) {nor bu/} 2) {oM ma Ni pad me hUM zhes pa' yi ge drug}
+ma Ni ka|{(legs) nor bu'i rgyan cha/}
+ma Ni bka' 'bum|{chos rgyal srong btsan sgam pos brtsams pa'i thugs rje chen po'i sgrub skor dang/ bod kyi lo rgyus dang bka' chems sogs pod gnyis yod do/}
+ma Ni 'khor lo|{ma Ni yig drug mang po dril ba'i 'khor lo/}
+ma Ni chu 'khor|{chus skor ba'i ma Ni 'khor lo/}
+ma Ni thang rdog|{(yul) kha gdan gyi ri mo zhig gi ming/}
+ma Ni dung|{ma Ni 'don thengs dung phyur gcig dpang por btsugs pa ste bod kyi yul srol nang gi mna' tshig cig}
+ma Ni dung 'khor|{ma Ni grangs dung phyur gcig yod pa'i 'khor chen/}
+ma Ni 'dren 'dren|1) {thags thogs med pa/ kha bde po'i mi des skad cha bshad na chu rgyug rgyug ma Ni 'dren 'dren red/} 2) {skad cha bskyar skor yang skor kho na shod pa/ mi de sger don kho na ma Ni 'dren 'dren byed mkhan zhig red/}
+ma Ni ma|1) {sil snyan gyi bye brag cig} 2) {ma Ni'i ri mo yod pa'i gos chen zhig} 3) {ma Ni dbyangs su 'then mkhan gyi bud med/}
+ma Ni rlung 'khor|{rlung gis skor ba'i ma Ni 'khor lo/}
+ma Ni lag skor|{ma Ni sogs kyi yig dril bcug ste lag tu bskor rgyu zhig}
+ma Ni rdo phung|{yig drug rdo la brkos te spungs pa'i phung po/}
 ma gnas|{dngos po'i ma rtsa'i rin gong/ bzo skrun ma gnas/}
 ma pad|{lha'i bzhugs khri'i pad gdan/}
 ma dpe|{dpe bya sa'i ma phye/ ma dpe ltar 'bri ba/}
@@ -35017,7 +35012,7 @@ mu thug pa|{(rnying) bgo bsha' bya ba/}
 mu mtha'|{mtha'/ nam mkha'i mu mtha'/ zhing ga'i mu mtha'/ grong gi mu mtha'/}
 mu mthud|{rgyun mthud dam 'phro mthud/ rgyal kha'i ngang mu mthud de mdun du skyod pa/}
 mu dang kha da chad|{(rnying) mtha' dang kha mtho dman mnyam par gang ba/}
-mu dra'i phyag rgya|{rin po che'i rdo khru gang par ma ni yig drug rang byon yod pa bod rgyal lha tho tho ri'i skabs rgya gar nas bod du drangs pa nang pa'i rten rnying gi gras shig}
+mu dra'i phyag rgya|{rin po che'i rdo khru gang par ma Ni yig drug rang byon yod pa bod rgyal lha tho tho ri'i skabs rgya gar nas bod du drangs pa nang pa'i rten rnying gi gras shig}
 mu rdo|{zhing kha'i bar 'gram gyi rdo tsog gam rdo phung/}
 mu ni|{(legs) thub pa/}
 mu ne btsan po|{khri srong lde btsan dang tshe sbong bza' gnyis kyi sras/ bod rgyal gdung rabs so dgu pa yin la/ 'dis kyang rgyal po snga ma bzhin dam pa'i chos la brtsi bkur ches cher byas/ bsam yas dang lha sa dang khra 'brug tu sde snod gsum gyi mchod pa chen po bzhi btsugs/ deb ther du des 'bangs kyi ltogs phyug lan gsum snyoms par mdzad ces dang/ chab srid mdzad nas lo gcig dang zla ba bdun la yum gyis dug btang nas grongs zhes bshad pa 'di gnyis phan tshun 'gal mi 'gal la lo rgyus smra ba dag gi 'dod tshul tha dad pa yod do/}
@@ -35100,7 +35095,7 @@ me khebs|{thab dang me phor khog ltir sogs kyi steng du g.yog byed cig}
 me khyem|{me thal 'don spyad/}
 me khyer|{'bu'i bye brag cig ming gi rnam grangs la skar skyod dang/ mkha' snang ngo/}
 me mkha' rgya mtsho|{shing sprel lo ste/ spyi lo 624 lor rigs ldan rgya mtsho rnam rgyal khrir 'khod pa dang/ kla klo zhugs pa dus mnyam/ de nas brtsams te rigs ldan rgyal dka'i lo mtha' spyi lo 1026 ste me stag lo'i bar du lo ngo bzhi brgya dang gsum song ba de la rgyud las me mkha' rgya mtshor grags/de'i phyi lor rab byung dang po'i 'go bzung bas/ de dang rab byung lo grangs bsres pa ni kla klo'i gnas tshad kyi lo grangs brtag ched yin/}
-me 'khor|1) {lcags lam thog gtong ba'i 'khor lo/} 2) {mchod me'i steng du btsugs pi' ma ni'i 'khor lo rang 'gul can/}
+me 'khor|1) {lcags lam thog gtong ba'i 'khor lo/} 2) {mchod me'i steng du btsugs pa'i ma Ni'i 'khor lo rang 'gul can/}
 me grung po|{dud pa dang thal ba nyung ba'i me/}
 me grogs lcags|{nag rtsis lugs lcags kyis me gso bas me'i grogs lcags kyis yin pa'i bshad tshul/}
 me dgra chu|{nag rtsis ltar chus me gsod pas me'i dgra chu'o/}
@@ -35766,7 +35761,7 @@ dmigs pa gnad kyi dar ya kan|{sngo zhig}
 dmigs pa bzhi|{zhi gnas kyi dmigs yul du gyur pa'i chos bzhi ste/ khyab pa'i dmigs pa dang/ spyad pa rnam sbyong gi dmigs pa/ mkhas pa'i dmigs pa/ nyon mongs rnam sbyong gi dmigs pa bcas bzhi/}
 dmigs pa yul gyi khams drug khams bco brgyad kyi nang tshan zhig ste|{gzugs/ sgra/ dri/ ro/ reg bya/ chos te drug dmigs pa la thogs pa/ sems sems byung gis chos gcig la dmigs pa na de la thogs nas chos gzhan dmigs pa la gegs byed pa lta bu'o/}
 dmigs pa'i khams|{phyi'i khams so/}
-dmigs pa'i 'bras bu skye ba'i sa|{sngags rnying ma'i gzhung du/ rnal 'byor bzhi ba'i skabs su thob pa'i sa bdun pa ste/ sgom lam du slob pa'i zung 'jug gi don de la dmigs shing goms pas 'bras bu mi slob pa'i zung 'jug gi sku 'grub pas/ sa bdun a dmigs pa'i 'bras bu skye ba'i sa zhes bya'o/}
+dmigs pa'i 'bras bu skye ba'i sa|{sngags rnying ma'i gzhung du/ rnal 'byor bzhi ba'i skabs su thob pa'i sa bdun pa ste/ sgom lam du slob pa'i zung 'jug gi don de la dmigs shing goms pas 'bras bu mi slob pa'i zung 'jug gi sku 'grub pas/ sa bdun pa dmigs pa'i 'bras bu skye ba'i sa zhes bya'o/}
 dmigs bu|{long 'khrid pa/ dmigs bu med pa'i dmus long thag ring 'gro mi thub/}
 dmigs med|{stong nyid/}
 dmigs 'dzugs|1) {dmigs bkar gyis mdzub mo 'dzugs pa/ mi nges can zhig la las don nges can zhig byed par dmigs 'dzugs byas pa/} 2) {bu lon len dus bzhag pa'i gta' ma/}
@@ -36527,10 +36522,10 @@ tsi tsi|1) {'bru'i rigs khre rgod/} 2) {byi ba/ tsi tsi ram pa za bar za lugs da
 tsi tsi sgam po|{byi ba'i rigs shig ste/ 'phur shes la so yang yod pa'i bya min byi min zhig}
 tsi tsi sa 'dzin|{sngo zhig}
 tsig ge ba|{(rnying) cung zad tsam/}
-tsitta|{(legs) sems sam snying/}
-tsittamani|{tsin ta ma ni'i 'bri srol gzhan zhig}
+tsit+ta|{(legs) sems sam snying/}
+tsit+tamaNi|{tsin ta ma Ni'i 'bri srol gzhan zhig}
 tsid bu|{(rnying) lo gnyis par slebs pa'i ra phrug}
-tsin ta ma ni|{(legs) yid bzhin nor bu ste 'jig rten du shin tu 'byung ba dkon pa'i rin po che zhig nus pas lus la 'chang ba tsam gyis nad gdon 'joms shing/ bsam don 'grub par grags/}
+tsin ta ma Ni|{(legs) yid bzhin nor bu ste 'jig rten du shin tu 'byung ba dkon pa'i rin po che zhig nus pas lus la 'chang ba tsam gyis nad gdon 'joms shing/ bsam don 'grub par grags/}
 tsi'u|{tsi gu dang don gcig}
 tsu ta|1) {mi rkang pa gcig pa'i yul/ tsu ta'i yul du slebs pa na/ rkang gnyis pa la mir mi rtsi/} 2) {rin po che'i bye brag cig}
 tsu ma ti|{sha ro dang/ rgyus pa/ rus 'dzer sogs 'don byed kyi skam pa 'jab rtse'i dbyibs can zhig}
@@ -37563,7 +37558,7 @@ tsha la rgyag pa|{gser dngul zangs lcags sogs la tsha las sbyor mthud byed pa/ z
 tsha lag cha dang mi nor ba'i rtags kyi tsha 'phru|{tsha  {~}  ? cha}
 tsha lam|{'grul pas tsha phog rgyag sa'i bar gyi lam tshad/ lha sa nas snye thang bar tsha lam gcig gi sa yod/}
 tsha lu ma|{shing thog gi bye brag mtho zhing grang ba'i sa khul du tsha lu ma mi skye/}
-tsha lum lum|{tsha po long long du 'khol tshul/ me steng du bzhag apa'i bza' btung tshang ma tsha lum lum du 'khol/}
+tsha lum lum|{tsha po long long du 'khol tshul/ me steng du bzhag pa'i bza' btung tshang ma tsha lum lum du 'khol/}
 tsha lums|{sman rigs blug pa'i chu tsha po'i lums/}
 #tsha log ja bsrubs ma grang mo yang bskyar bsros pa'i tsha po|
 tsha long long|1) {tsha ba che tsam zhig chu tsha long long zhig gis 'khrud pa/} 2) {dngangs skrag che tsam byung tshul/ sems tsha long long byed pa/}
@@ -38574,7 +38569,7 @@ mtshan rdzogs pa'i dpe byad|{sangs rgyas kyi dpe byad bzang po brgyad cu'i nang 
 mtshan zhabs|1) {snga dus bod kyi bla sprul che khag gi mtshan nyid zhabs phyi/} 2) {snga dus bod kyi bla chen khag gi ming gsham 'jug tshig cig ste/ dper na dpal bzang po zhes pa lta bu/ dpal bzang po dpal bzang po}
 mtshan gzhi|1) {mtshan nyid kyis mtshon bya mtshon pa'i gzhir gyur pa/ dper na/ gser bum de bum pa'i mtshan gzhi yin pa lta bu'o/} 2) {mtshon bya'i khyad par ram dpe/}
 mtshan bzang po|1) {rtags mtshan bzang po/} 2) {skyes bu chen po'i bsod nams kyi mthu las grub cing bsod nams de mtshon par byed pa'i phyag zhabs 'khor lo'i mtshan sogs sum cu rtsa gnyis po rnams so/}
-mtshan bzang po sum cu rtsa gnyis|{phyag zhabs 'khor los mtshan pa dang/ rus sbal zhabs/ phyag zhabs sor mo dra bas 'brel ba/ phyag zhabs 'jam zhing gzhon sha chags pa/ sku'i gnas bdun mtho ba/ sor mo ring ba/ rting pa yangs pa/ sku che zhing drang ba/ zhabs long bu mi mngon pa/ ba spu gyen du phyogs pa/ byin pa ae na ya'i 'dra ba/ phyag ring zhing mdzes pa/ 'doms kyi sba ba sbubs su nub pa/ pags pa gser mdog 'dra ba/ pags pa srab cing 'jam pa/ ba spu re re nas g.yas su 'khyil ba/ zhal mdzos spus brgyan pa/ ro stod seng ge 'dra ba/ dpung pa'i mgo zlum pa/ thal gong rgyas pa/ ro mi zhim pa ro mchog snang ba/ sku n.ya gro dha ltar chu zheng gab pa/ gtsug tor bltar mi mngon pa/ ljags ring zhing srab pa/ gsung tshangs dbyangs lta bu/ 'gram pa seng ge'i 'dra ba/ tshems shin tu kar ba/ tshems mnyam pa/ tshems thags bzang ba/ tshems grangs bzhi bcu tshang ba/spyan mthon mthing 'dra ba/ spyan gyi rdzi ma ba mchog gi rdzi ma 'dra ba ste sum cu rtsa gnyis/}
+mtshan bzang po sum cu rtsa gnyis|{phyag zhabs 'khor los mtshan pa dang/ rus sbal zhabs/ phyag zhabs sor mo dra bas 'brel ba/ phyag zhabs 'jam zhing gzhon sha chags pa/ sku'i gnas bdun mtho ba/ sor mo ring ba/ rting pa yangs pa/ sku che zhing drang ba/ zhabs long bu mi mngon pa/ ba spu gyen du phyogs pa/ byin pa ae na ya'i 'dra ba/ phyag ring zhing mdzes pa/ 'doms kyi sba ba sbubs su nub pa/ pags pa gser mdog 'dra ba/ pags pa srab cing 'jam pa/ ba spu re re nas g.yas su 'khyil ba/ zhal mdzos spus brgyan pa/ ro stod seng ge 'dra ba/ dpung pa'i mgo zlum pa/ thal gong rgyas pa/ ro mi zhim pa ro mchog snang ba/ sku n+ya gro dha ltar chu zheng gab pa/ gtsug tor bltar mi mngon pa/ ljags ring zhing srab pa/ gsung tshangs dbyangs lta bu/ 'gram pa seng ge'i 'dra ba/ tshems shin tu kar ba/ tshems mnyam pa/ tshems thags bzang ba/ tshems grangs bzhi bcu tshang ba/spyan mthon mthing 'dra ba/ spyan gyi rdzi ma ba mchog gi rdzi ma 'dra ba ste sum cu rtsa gnyis/}
 mtshan rangs po|{mtshan mo sgang tshang/ mdang mtshan rangs po gnyid khug ma song/}
 mtshan la dgung 'degs|{ming dang la rgya mthon por bkyag pa/ dpa' bo byas rjes can gyi mtshan la dgung 'degs zhu ba/}
 mtshan lam|{rmi lam gyi zhe sa/}
@@ -39873,8 +39868,8 @@ zhi ba|1.{(tha mi dad pa) yal ba/ rlung 'tshub zhi ba/ tsha ba zhi ba/ grang ba 
 zhi ba skyes pa|{(mngon) tshang bdag}
 zhi ba snying po|<{shintamgarbha}>{ chos rgyal khri srong lde btsan dus su bod du gdan drangs pa'i rgya gar gyi pandi ta zhig 'dis bsam yas kyi rab gnas mkhan byas par bu ston bzhed/}
 zhi ba myang 'das|{nyon mongs spangs pa'i 'gog bden/}
-zhi ba 'tsho|<{shantarkshita}>{ sngar bhangga la'i yul du za hor rgyal po'i sras su 'khrungs/ dpal na lendrara slob dpon ye shes snying po las rab tu byung zhing bsnyen par rdzogs/ rgya gar gyi dbu ma rang rgyud pa'i slob dpon zhig dang/ dbu ma shar pa gsum gyi ya gyal zhig yin/ dbu ma rgyan la sod pa'i bstan bcos brtsams/ chos rgyal khri srong lde btsan gyi dus su bod du phebs/ bsam yas gtsug lag khang bzhengs pa'i bkod pa mdzad/ sad mi mi bdun rab tu byung nas dge 'dun gyi sde bod du thog mar btsugs/ 'dul ba dang dbu ma spel/ mtshan mkhan bo dhi satwa zhes grags/ mkhan chen 'di dang/ slob dpon pad ma 'byung gnas/ chos rgyal khri srong lde btsan gsum la mkhan slob chos gsum du grags/ snga phyir bod du lo bcu lhag tsam bzhugs te gshegs/}
-zhi ba lha|{spyi lo'i dus rabs bdun pa'am brgyad pa tsam la rgya gar gyi rgyal po dge ba'i go cha'i sras su 'khrungs shing/ chung ming zhi ba'i go cha zer/ na lendrar rab tu byung nas spyod 'jug dang byang chub sems dpa'i bslab btus sogs brtsams/}
+zhi ba 'tsho|<{shantarkshita}>{ sngar bhangga la'i yul du za hor rgyal po'i sras su 'khrungs/ dpal na len+d+rar slob dpon ye shes snying po las rab tu byung zhing bsnyen par rdzogs/ rgya gar gyi dbu ma rang rgyud pa'i slob dpon zhig dang/ dbu ma shar pa gsum gyi ya gyal zhig yin/ dbu ma rgyan la sod pa'i bstan bcos brtsams/ chos rgyal khri srong lde btsan gyi dus su bod du phebs/ bsam yas gtsug lag khang bzhengs pa'i bkod pa mdzad/ sad mi mi bdun rab tu byung nas dge 'dun gyi sde bod du thog mar btsugs/ 'dul ba dang dbu ma spel/ mtshan mkhan bo dhi satwa zhes grags/ mkhan chen 'di dang/ slob dpon pad ma 'byung gnas/ chos rgyal khri srong lde btsan gsum la mkhan slob chos gsum du grags/ snga phyir bod du lo bcu lhag tsam bzhugs te gshegs/}
+zhi ba lha|{spyi lo'i dus rabs bdun pa'am brgyad pa tsam la rgya gar gyi rgyal po dge ba'i go cha'i sras su 'khrungs shing/ chung ming zhi ba'i go cha zer/ na len+d+rar rab tu byung nas spyod 'jug dang byang chub sems dpa'i bslab btus sogs brtsams/}
 zhi ba'i grong|1) {(mngon) ri khrod dgon gnas dben sa/} 2) {thar pa'i go 'phang/}
 zhi ba'i 'gros|1) {dal ba'i 'gro stangs/} 2) {(mngon) chu bya ngang pa/}
 zhi ba'i rdo rje|{lha'i phyag mtshan gyi bye brag cig}
@@ -41460,7 +41455,7 @@ zla 'phro|{tshes zla gcig gis khyim zla'i dod mi thub pas mda' ro'i cha gnyis lh
 zla ba|1) {skar khyim du rgyu ba'i gza' zla ba'i go la ste nam mkha'i ri bong can/ ming gi rnam grangs la ku mud gnyen dang/ ga bur dbang/ rgya mtsho skyes/ rgya mtsho dga'/ rgya mtsho'i mar gsar/ rgyu skar bdag po/ rgyu skar gtso/ bcu drug cha/ cha gter/ chags skyed/ chu las skyes/ gnyis skyes rgyal po/ steng 'phur/ thos ldan dbang/ bdud rtsi spro/bdud rtsi'i 'byung gnas/ bdud rtsi'i 'od can/ bdud rtsi'i 'od/ bdud rtsis mtshan/ bde 'byung gtsug rgyan/ nam mkha'i rna ba/ pad ma'i dgra/ mun 'joms/ dbang phyug gtsug rgyan/ tshes bdag mtshan mo'i bdag po/ mtshan mo'i nor bu/ mtshan mor byed/ 'od dkar can/ ri dwags mtshan ma/ ri bong can/ ri bong 'dzin/ shar gyi thig le/ bsil byed/ bsil sbyin mkhan/ bsil zer can bcas so/} 2) {dus kyi zla ba/ spyir zla ba'i dkar cha dang dmar cha 'phel 'grib bco lnga re ste zhag sum cur longs tshe zla ba'i tha snyad btags pa de tshes zla yin la/ gzhan yang nyin zla dang khyim zla zhes pa'ang yod/ zla ba ngo re bzhin/ zla thog lo bzhag lo khar zla mthud/} 3) {res gza' bdun gyi gnyis pa/} 4) {(mngon) 1/zla ba gcig las med pas grangs gcig mtshon/ khu ba/}
 zla ba skyes|{(mngon) chu bo sindhu/}
 zla ba gong ma|{zla ba sngon ma/}
-zla ba grags pa|{rgya gar gyi dbu ma thal 'gyur ba'i slob dpon zhig ste/ spyi lo'i dus rabs bdun pa tsam la rgya gar lho rgyud kyi bram ze'i khyim zhig tu sku 'khrungs shing rab tu byung nas klu sgrub kyi dbu ma'i bstan bcos sogs bslabs te na lendra'i mkhan po mdzad cing/ dbu ma'i gzhung tshig gsal dang/ dbu ma 'jug pa sogs mdzad de sangs rgyas bskyangs kyi brgyud pa bzung nas dbu ma thal 'gyur ba'i srol btod/}
+zla ba grags pa|{rgya gar gyi dbu ma thal 'gyur ba'i slob dpon zhig ste/ spyi lo'i dus rabs bdun pa tsam la rgya gar lho rgyud kyi bram ze'i khyim zhig tu sku 'khrungs shing rab tu byung nas klu sgrub kyi dbu ma'i bstan bcos sogs bslabs te na len+d+ra'i mkhan po mdzad cing/ dbu ma'i gzhung tshig gsal dang/ dbu ma 'jug pa sogs mdzad de sangs rgyas bskyangs kyi brgyud pa bzung nas dbu ma thal 'gyur ba'i srol btod/}
 zla ba rgyas pa|1) {zla ba nya gang ba/} 2) {sangs rgyas shig gi mtshan/}
 zla ba snga ma|{zla ba 'di'i sngon ma/}
 zla ba cha|{zla ba ya ma yin pa ste zla ba gnyis pa/ bzhi pa/ drug pa lta bu/}
@@ -42748,7 +42743,7 @@ yab yab po|{sems rang sar gnas mi thub pa/}
 yab yum|1) {pha ma gnyis/} 2) {khyo shug gnyis/}
 yab yob|{ya be yo be'i bsdus tshig}
 yab sras|1) {pha dang bu/} 2) {slob dpon dang slob ma/}
-yab sras mjal ba'i mdo|{yab sras mjal ba de kho na nges par bstan pa'i bam po bco lnga pa le'u nyer drug dang/ sho lo ka bzhi stong lnga brgya yod pa/ rgya gar gyi mkhan po shI lendra bo dhi dang/ dzi na mi tra dang/ dA na shI la dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus te skad gsar bcad kyis bcos pa'o/}
+yab sras mjal ba'i mdo|{yab sras mjal ba de kho na nges par bstan pa'i bam po bco lnga pa le'u nyer drug dang/ sho lo ka bzhi stong lnga brgya yod pa/ rgya gar gyi mkhan po shI len+d+ra bo dhi dang/ dzi na mi tra dang/ dA na shI la dang/ lo tsA ba bande ye shes sdes bsgyur cing zhus te skad gsar bcad kyis bcos pa'o/}
 yam|{yams dang 'dra/}
 yam bu|{nee pA la'i rgyal sa ka te ma gru/}
 yam me ba|{ha lam mam rags tsam/ slob sbyong yam me ba zhig las byed rgyu ma byung/}
@@ -42867,7 +42862,7 @@ yi ge mchan bkod|{go dka' ba bkral ba'i yig chung bkod pa/}
 yi ge 'jug pa'i gnas brgyad|{sgra/ skad/ ming/ mtshan ma/ brda/ tha snyad/ tshig don bcas brgyad/}
 yi ge gnyis|{dbyangs dang/ gsal byed gnyis/}
 yi ge rtags 'byar ma|{the'u brgyab pa'am phab yod pa'i yi ge/}
-yi ge drug ma|1) {ommanipadmehUm/ zhes pa'i gzungs/} 2) {spyan ras gzigs kyi mtshan gyi bye brag cig}
+yi ge drug ma|1) {oMmaNipad+mehUM/ zhes pa'i gzungs/} 2) {spyan ras gzigs kyi mtshan gyi bye brag cig}
 yi ge drug ma'i rig sngags|{spyan ras gzigs kyi gzungs kyi snying po/}
 yi ge bsnol ba|{snga ma'i gsal byed phyi mar spos la phyi ma'i gsal byed snga mar spos pa/ hidra + ? sa/ hraidra + ? sra/ sraidra + ? hra/ sidha/ sidhe/ sengge}
 yi ge pa|1) {yig mkhan/} 2) {(mngon) shing gi srin bu zhig}
@@ -43702,7 +43697,7 @@ g.yab g.yob|{g.yab mo g.yob tshul/}
 g.yabs|{skyibs kyi don du go ba'i g.yab kyi 'bri srol gzhan zhig}
 g.yabs pa|{g.yob pa'i 'das pa/}
 g.yam|{zhar ram zhor ram rjes/ gzhan gyi g.yam la rgyug pa/ tshig gi g.yam la mi rgyug par dpyad par bya/}
-g.yam pa|{rang bzhin gyis chags pa'i rdo leb/ g.yam sgrom/ rdo g.yam pa'i steng la ma ni brkos pa/ mgo thog g.yam sel/}
+g.yam pa|{rang bzhin gyis chags pa'i rdo leb/ g.yam sgrom/ rdo g.yam pa'i steng la ma Ni brkos pa/ mgo thog g.yam sel/}
 g.yam bzang bka' brgyud|{g.ya' bzang bka' brgyud kyi 'bri srol gzhan zhig}
 g.ya'|1) {dri ma ste/ lcags zangs sogs kyi ngos la chags pa'i nag nog/ dkar g.ya'/ g.ya' brgyab pa/ g.ya' chag pa/ g.ya' lang ba/ ha yang gi g.ya' bsangs pa/ lcags g.ya' sman/ zangs g.ya' dug nam mkha' g.ya' dag} 2) {bag gam zhad/ 'khor g.yog gi g.ya' dri bro ba/ mi ngan rgyal por bskos na spre'u'i g.ya'/ cham pa phog pa'i g.ya' byung ba/ gnam dwangs po yong g.ya' 'dug than pa gtang g.ya' gsal po shar ba/ 'chi 'gro ba'i g.ya'/} 3) {rdza ri/}
 g.ya' kyi|{sngo sman gyi rigs shig ste/ ro kha/ zhu rjes bsil/ nus pas snod mkhris rgyas pa zhi/ mkhris nad gyen du skyug pa dang/ thur du bshal ba sogs byed/ ming gi rnam grangs la khrag dar ya kan dang/ gangs kyi lha mo/ rgyal po zla bsil/ dar ya kan/ bdud rtsi rab bsil/ g.ya'i bcud bcas so/}
@@ -44241,7 +44236,7 @@ rang byung zangs|{sa 'og tu rang bzhin gyis chad pa'i zangs/}
 rang byung ye shes|{sems can gyi rgyud la ye nas gnas pa'i dbyings dang ye shes gnyis su med pa'i rig pa'o/}
 rang byung rags|{chu 'gog byed rang grub kyi rags/}
 rang byung sol rlangs|{sa snum dang/ rdo sol sogs kyi gter kha nas thon pa'i 'bar rdzas kyi rlangs pa zhig}
-rang byon|{rtsol ba la ma brten par byung ba/ lha sku rang byon/ ma ni rang byon/}
+rang byon|{rtsol ba la ma brten par byung ba/ lha sku rang byon/ ma Ni rang byon/}
 rang byon lnga ldan|{rang byung lnga ldan dang don gcig}
 rang dbang|{bya spyod thams cad gzhan la bstun mi dgos pa/ mi lus kyi rang dbang/ 'gro spyod kyi rang dbang/ rang dbang rang bdag rang dbang rang btsan/ rang dbang rang 'dzin/ rang dbang rang la med pa/ ming gi rnam grangs la 'gog pa med pa dang/ nga yir ba/ ltos pa med pa/ bdag gir ba/ bdag dbang ba/ gzhan gyis ma bzung ba/ gzhan la ma rag pa/ rang gar spyod/ rang gir byed/ rang dga' bcas so/}
 rang dbang med pa|1) {gzhan la ltos dgos pa dang brten dgos pa/ khyim tshang gar skyes 'dam ka'i rang dbang med/} 2) {rang gis bdag sprod mi thub pa'am tshod 'dzin mi thub pa/ gad mo rang dbang med par shor ba/ thal mo rang dbang med par rdeb pa/}
@@ -44773,7 +44768,7 @@ ri gseb|{ri'i khrod dam nang/}
 ri bsang|{ri rtse la btang ba'i bsang/}
 ri bsang klung skyed|{dbang thang klung rta yar ldan du gso phyi gnas ri sogs grags ldan gyi ri mgo btho sar bsangs gsur gser skyems sogs gtong ba dang klun gskyed cod pan dar cog 'dzugs pa'i yul srol zhig}
 rig rgyud|1) {sems kyi rgyun/} 2) {sems kyi gshil ka'am rang bzhin/}
-rig sngags|{lha'i 'phrin las dang thugs rdo rje shes rab kyi cha gtso bor sgrub pa'i sngags te bud med kyi gzugs dbyibs kyi lha edang/ de stong pa'i sgra dang phyag rgyal sogs pa'o/}
+rig sngags|{lha'i 'phrin las dang thugs rdo rje shes rab kyi cha gtso bor sgrub pa'i sngags te bud med kyi gzugs dbyibs kyi lha dang/ de stong pa'i sgra dang phyag rgyal sogs pa'o/}
 rig sngags 'dzin pa|1) {sngags kyi lam bdag tu 'chang ba/} 2) {sngags kya yi ge blor 'dzin pa/}
 rig bcos|{rang bzo/ khungs med tu bcos/}
 rig stong dbyer med|{sems dang stong pa nyid gcig tu 'dres pa/}
@@ -45021,7 +45016,7 @@ rin chen me|{de bzhin gshegs pa zhig}
 rin chen dmar po|{(mngon) padma rAga}
 rin chen brtsegs pa|{(mngon) ri rab/}
 rin chen zla bas zhus pa|{'phags pa rin chen zla bas zhus pa zhes bya ba theg pa chen po'i mdo/ sho lo ka nyis brgya nyer bdun pa/ rgya gar gyi mkhan po bishuddha singha' dang lo tsA ba dge slong dpal gyis bsgyur te/ slad kyi pandi ta bityA ka ra singha dang lo tsA ba bande de ba tsantrasa zhus pa'o/}
-rin chen bzang po|1) {lo chen rig chen bzang po ste/ rab byung dang po ma shar sngon gyi lo drug cu re dgu sa rta lor lha ye shes 'od kyi sras su mnga' ris gu ge'i cha wo ratna ru sku 'khrungs/ dgung lo gsum par rab tu byung/ bcu bdun thog 'phags yul du byon nas lo bcu bzhugs/ jo bo na ro ta pa sogs pandi ta bdun cu rtsa lnga bsten nas mdo rgyud sogs rig gnas gang la 'chad rtsod rtsom bsgyur thogs pa med par gyur te bstan pa phyi dar gyi skabs su gsar ma'i lo tsa' ba thams cad kyi thog mar gyur/ sangs rgyas skar rgyal btul/ mdo sde'i skor gzhung grans bcu bdun dang mngon pa'i gzhung so gsum/ rgyud kyi le tshan brgya rtsa brgyad sogs rgya gzhung bod du bsgyur ba dang 'gyur bcos mdzad pa shin tu mang zhing/ khyad par du gso ba rig pa'i skor la slob dpon dpa' bos mdzad pa'i yan lag brgyad pa'i snying po bsdus pa dang/ de'i 'grel pa kha che pan chen zla ba mngon dgas mdzad pa'i zla zer sogs legs par bsgyur cing gtan la phab pas bod yul du dar rgyas gyur pas ma tshad/ dpal phag mo gru pa'i dus rgya nag tu'ang dar bas rgyal po hwang the'i hu'i i ci'i dus yar klungs mchig sman gyis bskul nas pho brang ta'i tung du ye shes dpal gyis zhus dag mdzad de brkos pa'i rgya par yang yod/ lo chen 'di nyid la gso rig gi brgyud pa 'dzin pa'i slob ma'i thu bo ru gyur pa spu rengs kyi sman pa mi bzhi'i gtsos bod yul kun tu khyab par gyur te mdzad rjes shin tu che/ (958-}1055) 2) {(mngon) gser/}
+rin chen bzang po|1) {lo chen rig chen bzang po ste/ rab byung dang po ma shar sngon gyi lo drug cu re dgu sa rta lor lha ye shes 'od kyi sras su mnga' ris gu ge'i cha waM rat+na ru sku 'khrungs/ dgung lo gsum par rab tu byung/ bcu bdun thog 'phags yul du byon nas lo bcu bzhugs/ jo bo na ro ta pa sogs pandi ta bdun cu rtsa lnga bsten nas mdo rgyud sogs rig gnas gang la 'chad rtsod rtsom bsgyur thogs pa med par gyur te bstan pa phyi dar gyi skabs su gsar ma'i lo tsa' ba thams cad kyi thog mar gyur/ sangs rgyas skar rgyal btul/ mdo sde'i skor gzhung grans bcu bdun dang mngon pa'i gzhung so gsum/ rgyud kyi le tshan brgya rtsa brgyad sogs rgya gzhung bod du bsgyur ba dang 'gyur bcos mdzad pa shin tu mang zhing/ khyad par du gso ba rig pa'i skor la slob dpon dpa' bos mdzad pa'i yan lag brgyad pa'i snying po bsdus pa dang/ de'i 'grel pa kha che pan chen zla ba mngon dgas mdzad pa'i zla zer sogs legs par bsgyur cing gtan la phab pas bod yul du dar rgyas gyur pas ma tshad/ dpal phag mo gru pa'i dus rgya nag tu'ang dar bas rgyal po hwang the'i hu'i i ci'i dus yar klungs mchig sman gyis bskul nas pho brang ta'i tung du ye shes dpal gyis zhus dag mdzad de brkos pa'i rgya par yang yod/ lo chen 'di nyid la gso rig gi brgyud pa 'dzin pa'i slob ma'i thu bo ru gyur pa spu rengs kyi sman pa mi bzhi'i gtsos bod yul kun tu khyab par gyur te mdzad rjes shin tu che/ (958-}1055) 2) {(mngon) gser/}
 rin chen ri gsum|{ri bo gangs can dang/ ri bo 'bigs byed/ ri bo man dha ra bcas gsum/}
 rin gnyis 'khor lo|{(mngon) dngul sgor mo/}
 rin mnyam brje 'tshong|{phan tshun drang bzhag gis tshong rgyag pa/}
@@ -45617,7 +45612,7 @@ frlung skar bdun|{mgo dang/ me bzhi/ nag pa/ nabs so/ dbo/ sa ri/ tha skar rnams
 rlung skran|{ngo bo mi brtan pa 'phyo lding 'phel 'bri sogs byed pa'i rlung las gyur pa'i skran nad cig}
 rlung bskams|{lhags pas skam pa/}
 rlung khyab byed|{lus yongs su khyab pa'i rlung ste/ rtsa ba'i rlung lnga'i nang gses shig}
-rlung 'khor|1) {rlung 'tshub sgor mo/} 2) {rlung gis skor ba'i ma ni 'khor lo sogs/} 3) {rlung g.yob byed kyi 'khor lo/}
+rlung 'khor|1) {rlung 'tshub sgor mo/} 2) {rlung gis skor ba'i ma Ni 'khor lo sogs/} 3) {rlung g.yob byed kyi 'khor lo/}
 rlung 'khor ba|1) {rlung 'khyir mor 'khor ba/} 2) {'tshig pa za ba/}
 rlung 'khyil|{rlung skor 'khyil/}
 rlung 'khrugs pa|1) {rlung drag po langs pa/} 2) {lus kyi rlung khams 'khrugs pa/}
@@ -45845,7 +45840,7 @@ la yogs|{(yul) gzhan la tshul min gyi bya ba byas pa'i ngan 'bras rang thog smin
 la la|{'ga' re 'am kha shas/ skad cha la la bden zhing skad cha la la mi bden/}
 la la nA|{(legs) zla ba'i khams rgyu bar byed pa'i rtsa rkyang ma'i ming gzhan zhig}
 la la phud|{sngo sman gyi rigs shig ste/ ro tsha/ zhu rjes drod/ nus pas pho nad grang ba dang/ ma zhu ba sel/}
-la li ta|{sngar rgya gar ma ghadhar gsang sngags nyams su len pa'i chos pa de na lendrar slob gnyer mdzad de grub pa thob pa'i pandi tar gyur pa zhig}
+la li ta|{sngar rgya gar ma ghadhar gsang sngags nyams su len pa'i chos pa de na len+d+rar slob gnyer mdzad de grub pa thob pa'i pandi tar gyur pa zhig}
 la lung|1) {la dang lung pa/} 2) {gang sa gang la/ la brgyab lung brgyab/ la gtam lung gtam/ la dgu lung dgu/}
 la lo|{grangs gnas shig}
 la shags|{nang gos srab mo zhig}
@@ -45859,7 +45854,7 @@ lag kor|{lag pa'i rgyan gyi bye brag cig}
 lag dkris|{lag gdub/}
 lag rkyong|{(mngon) sprang po/}
 lag skam|{(yul)} 1) {lcags sogs 'dzin byed chung gras/} 2) {zas nor bcud chung god che'i gnyer pa lta bu'i ming ngan/} 3) {lag pa dam po'am ser sna che ba/}
-lag skor|1) {lag pas skor ba'i mchig} 2) {ma ni lag skor/}
+lag skor|1) {lag pas skor ba'i mchig} 2) {ma Ni lag skor/}
 lag skyes|1) {rang gi sgo rtsar skyes pa'i rta phyugs sogs/} 2) {rgyal rigs/} 3) {(mngon) sen mo/}
 lag skyogs|{lag pa ya gcig gis bed spyod byed pa'i stabs bde'i skyogs/}
 lag khug|{(yul) ja sogs blug snod khug ma chung ngu'i ming/}
@@ -45867,7 +45862,7 @@ lag khog|{(yul) lag pa gnyis ka 'byar ba'i phyugs sha stod khog lag khyer/ngo sp
 lag khyor|{lag pa ya gcig gi khyor ba/}
 lag khrid|{dngos khrid dam dmar khrid/ zhal lung lag khrid/}
 lag 'khar|{'khar rgyug gam ber ka/ lag 'khar btsugs nas khyar khyor du 'gro ba/}
-lag 'khor|1) {lag pas bskor bya'i mchig} 2) {lag pas skor rgyu'i ma ni'i 'khor lo/}
+lag 'khor|1) {lag pas bskor bya'i mchig} 2) {lag pas skor rgyu'i ma Ni'i 'khor lo/}
 lag 'khru|{(mngon) sen mo/}
 lag gi bla|1) {las dpon/} 2) {dgon sde'i las ka byed mi/}
 lag mgo|{lag pa'i mkhrig ma man chad/}
@@ -47268,7 +47263,7 @@ shAkya thub pa|{(legs) shAkya mu ne/ shAkya thub pas bkag kyang mi khogs pa dang
 shAkya mu ne|{(legs) sangs rgyas shAkya thub pa ste/ chung dus mtshan don kun grub pa zhes grags/ khong ni dri med shAkya'i rgyal rgyud las yab zas gtsang ma'i rigs su sku 'khrungs pa yin la/ sa mo lug gi lo'i chu stod zla ba'i nya la yum sgyu 'phrul ma'i lhums su zhugs/ lcags pho sprel lo'i sa ga zla ba'i tshes bdun la lumbi na'i tshal du sku bltams/ gzhon nu'i dus nas sgyu rtsal drug cu rtsa bzhi rang dbang du byas/ bu mo sa 'tsho ma sogs khab tu bzhes te btsun mo'i tshogs kyis bskor te rgyal srid bskyangs/ dgung lo nyer dgu'i thog khyim nas khyim med par rab tu byung ste mchod rten rnam dag gi drung du dpal rang byung gis bsnyen par rdzogs/ chu bo nee ranydza na'i 'gram du lo drug tu dka' ba spyad/ dgung lo so lnga pa shing pho rta'i lo'i sa ga zla ba'i tshes bco lnga'i srod la bdud btul/ gung la mnyam par bzhag tho rangs la mngon par rdzogs par sangs rgyas/ de nas zhag bdun phrag bdun gyi mthar chu stod zla ba'i tshes bzhir yul wa rA na sir bka' dang po bden bzhi'i chos 'khor bskor/ rim bzhin rgyal po'i khab dang/ bya rgod phung po la sogs par bka' bar pa mtshan nyid med pa dang/ bka' tha ma legs pa rnam par phye ba'i chos kyi 'khor lo bskor/ mthar dgung lo gya gcig pa lcags 'brug sa ga zla ba'i tshes bco lnga la gnas rtswa mchog drung du sku mya ngan las 'da' ba'i tshul bstan pa sogs mdzad pa chen po bcu gnyis yod do/ mtshan gyi rnam grangs la go'u ta ma dang/ goo ta ma/ dge sbyong chen po/ nyi ma'i rgyud/ nyi ma'i gnyen gyur/ nyi ma'i rigs 'khrungs/ nyi ma'i rus/ rdo rje gdan pa/ bu ram shing pa/ mi mjed bdag po/ mi mjed snying po/ tshul khrims gter/ zas gtsang sras/ shAkya'i tog shAkya seng ge/ lha yi yang lha/ lha yi lha bcas so/}
 shAkya 'od|{rgya gar gyi slob dpon rgyan drug gi ya gyal 'dul ba bdud rtsi'i rgyan gyi slob dpon zhig ste/ khong gis dge tshul gyi ka ri ka sum brgya ba sogs mdzad/}
 shAkya ye shes|{byams chen chos rje'i ming/ byams [chen chos rje shAkya ye shes zer ba der ltos]}
-shAkya shri bha dra|{kha che pan chen rgya gar shri nA lendra'i khri rabs tha ma 'di rab byung gnyis pa'i me lug lor 'khrungs/ rab byung gsum pa'i shing byi lor khro phu lo tsA ba byams pa dpal gyis gdan drangs te bod du byon/ sa pan gyi mkhan po mdzad/ lo bcu'i ring la rwa sgreng dang/ lho brag gnyal smad sogs yul khams mang du bshad sgrub kyi bstan pa spel/ rab byung bzhi pa'i shing bya lo la 'das/}
+shAkya shri bha dra|{kha che pan chen rgya gar shri nA len+d+ra'i khri rabs tha ma 'di rab byung gnyis pa'i me lug lor 'khrungs/ rab byung gsum pa'i shing byi lor khro phu lo tsA ba byams pa dpal gyis gdan drangs te bod du byon/ sa pan gyi mkhan po mdzad/ lo bcu'i ring la rwa sgreng dang/ lho brag gnyal smad sogs yul khams mang du bshad sgrub kyi bstan pa spel/ rab byung bzhi pa'i shing bya lo la 'das/}
 shAkya seng ge|1) {shAkya thub pa'i mtshan gyi rnam grangs shig} 2) {gu ru mtshan brgyad kyi ya gyal zhig}
 shAkya'i rgyal po|{(mngon) shAkya thub pa/}
 shAkya'i tog|{(mngon) shAkya thub pa/}
@@ -47809,7 +47804,7 @@ shes pa bcu|{sangs rgyas kyi sa'i shes pa bcu ste/ chos shes pa dang/ rjes su sh
 shes pa gnyis|1) {dbang shes yid shes/} 2) {sems sems byung/} 3) {rtog pa rtog med kyi shes pa/} 4) {tshad ma tshad min gyi shes pa/} 5) {'khrul ma 'khrul gyi shes pa/} 6) {mngon gyur bag la nyal gyi shes pa/}
 shes pa rtog med|{rtog pa dang bral ba'i shes pa ste brgyal ba'i yid shes dang/ dbang po lnga'i shes pa lta bu/}
 shes pa 'thibs pa|{rig pa mi gsal ba/}
-shes pa spros med|{sems rnam rtog gi gyeng ba med pa/}
+shes pa spros med|{sems rnam rtog gi g.yeng ba med pa/}
 shes pa yer re sing nge|{(rnying) rig pa dwangs shing gsal sing nge/}
 shes pa'i stobs|{sems stobs sam shes rab kyi stobs/}
 shes pas srid la mi gnas pa'i gzhi shes|{sher phyin don bdun cu'i nang gses gzhi don dam la ltos te stong nyid rtogs pa'i shes rab kyis srid mtha' 'gog byed kyi rtogs rigs su gnas pa'i theg chen 'phags pa'i mkhyen pa'o/}
@@ -47981,7 +47976,7 @@ shwa 'od|{chu log gam/ 'od pa/ shwa 'od rgyug pa/ shwa 'od 'brub pa/ char chen b
 shwa la|{la zhig bod rang skyong ljongs kyi 'bri ru rdzong gi shar rgyud du yod/ de'i mtho tshad rgya mtsho'i ngos nas smi 5090 yod/}
 shra ba na|{(legs) hor zla bdun pa/}
 shri khanta|{(legs)} 1) {dpal gyi dum bu/} 2) {tsan dan dkar po/}
-shri nA lendra|{(legs) nA lendra la ltos/}
+shri nA len+d+ra|{(legs) nA len+d+ra la ltos/}
 shrI kA la tskra|{(legs) dus 'khor/}
 shrI sedha|{dpal ldan seng ge ste rgya gar gyi slob dpon zhig yin pa des bod rgyal khri srong lde'u btsan dus bod la rdzogs pa chen po'i snying thig thog mar spel/}
 shloo ka|{sho lo ka'i 'bri srol gzhan zhig}
@@ -48873,7 +48868,7 @@ su zhig su 'dra zhig ste gang zag gi spyi sgra|{mi su zhig gis yid ches byed/ 'd
 su ra|{(rnying) chang/}
 su ru pan tsa|{(yul) si pan te spod ro tsha ba/}
 su rug|1) {lham bzo byed kyi ko ba'i bye brag cig} 2) {(sog) khyu'am phyugs kyi tshogs pa/}
-su rendra bo dhi|{(legs) lha'i dbang po byang chub dus rabs dgu pa tsam la bod rgyal khri gtsug lde'u btsan nam khri ral pa can gyis bod du gdan drangs pa'i rgya gar gyi slob dpon zhig yin pa des bka' dang bstan bcos mang po bsgyur yod/}
+su ren+d+ra bo dhi|{(legs) lha'i dbang po byang chub dus rabs dgu pa tsam la bod rgyal khri gtsug lde'u btsan nam khri ral pa can gyis bod du gdan drangs pa'i rgya gar gyi slob dpon zhig yin pa des bka' dang bstan bcos mang po bsgyur yod/}
 su lu|1) {bod du me kha gso byed kyi shing bongs thung la yal 'dab 'dzings te skye ba zhig} 2) {lug phrug gi spu ltar sgor sgor 'khyil bzhin skye ba'i mi'i skra dbyibs shig su lu mgo /} 3) {ba lu/} 4) {phyugs kyi nang khrol sul mang/ su lu ka/ (rnying) 'bru'i chang/}
 su su|{su dang su zhes pa'i bsdus tshig mi su su slebs 'dug su su slebs mi 'dug 'thus mi su su phebs 'dug}
 #sug kyog rkang pa 'khyog po|
@@ -49246,7 +49241,7 @@ ser po dpa' bo|{ser po btsan dug dang 'dra/}
 ser po tsan dug sngo zhig ser phyur phyur|{mdog ser po'i mdangs can/ shing tog lu ma ser phyur phyur/}
 ser phreng|{ser 'phreng dang 'dra/}
 ser 'phreng|1) {grwa pa rnams mchod rdzas thogs nas phreng bsgrigs pa'i star/} 2) {phreng ba ser po/}
-ser ba|{sprin gyi rdo'am/ skyin thang/ ser ba 'bab pa/ ser ba srung thabs/ da lo ser ba'i gnod pa phra mo tsam yang ma byung/ phyi dgra lcad nag gi ser ba 'dra/ nang dgra khang rgan gyi thigs chu 'dra/ ming gi rnam grangs la chu mkhregs dang/ rdo yi char/ sprin gyi ka ba/ sprin gyi gong bu/ sprin gyi rdo/ sprin gyi rus pa/ lo thog gshed bcas so/}
+ser ba|{sprin gyi rdo'am/ skyin thang/ ser ba 'bab pa/ ser ba srung thabs/ da lo ser ba'i gnod pa phra mo tsam yang ma byung/ phyi dgra lcags nag gi ser ba 'dra/ nang dgra khang rgan gyi thigs chu 'dra/ ming gi rnam grangs la chu mkhregs dang/ rdo yi char/ sprin gyi ka ba/ sprin gyi gong bu/ sprin gyi rdo/ sprin gyi rus pa/ lo thog gshed bcas so/}
 ser sbrengs|{mchod rdzas thogs pa'i grwa pa phreng bsgrigs pa'i star/}
 ser ma|1) {zhing kha bzha' tshan sa bon 'debs ran tsam yod pa'i ming/} 2) {btsun ma/} 3) {lha mo au ma/}
 ser mo|{ser mo ba'i bsdus ming/}
@@ -50062,7 +50057,7 @@ slo dron|{lto ba'i nang gi btso tsha po/}
 slo ma|1) {smyug bshags kyis bslas pa'i lugs snod khebs gcod can/} 2) {(yul) 'bru 'phyar snod/}
 slog gos|{slog pa'i gos sam/ lug chen gyi phags pa'i gos/}
 slog cha|1) {dngos po blangs pa'i skyin tshab phyir sprod bya rgyu'i cha shas/} 2) {'bul mtshon dngos po cha tshang mi len par phyir slog pa'i cha shas/}
-slog pa|1.{(tha dad pa) bslogs pa/ bslog pa/ slogs//} 1) {sa rgod sogs gsar du sbol ba dang/ phyir anng ngam steng 'og sgyur ba/ thang stong bslogs nas sa zhing bzos/ khang rnying bslogs nas gsar du bzo/ phags rtsag phyi nang bslogs te seng ge 'khrab/} 2) {log tu 'jug pa/ bang mi de phyir slogs shig 'khon lan slog pa/ tshong slog tshong gi bzhi zur yin/ bzang po'i bzang lan 'jal bar lo dang zla ba dgos/ ngan pa'i ngan lan slog par zhogs las gcig gis chog }2.{pags rtsag slog pa g.yogs med/ slog hrul/}
+slog pa|1.{(tha dad pa) bslogs pa/ bslog pa/ slogs//} 1) {sa rgod sogs gsar du sbol ba dang/ phyir nang ngam steng 'og sgyur ba/ thang stong bslogs nas sa zhing bzos/ khang rnying bslogs nas gsar du bzo/ phags rtsag phyi nang bslogs te seng ge 'khrab/} 2) {log tu 'jug pa/ bang mi de phyir slogs shig 'khon lan slog pa/ tshong slog tshong gi bzhi zur yin/ bzang po'i bzang lan 'jal bar lo dang zla ba dgos/ ngan pa'i ngan lan slog par zhogs las gcig gis chog }2.{pags rtsag slog pa g.yogs med/ slog hrul/}
 slog rul|{pags pa'i gos rnying ral rul/}
 slogs|{slog pa'i skul tshig}
 slong rkyen|{skul slong yong ba'i shugs rkyen nam rgyu rkyen/}
@@ -50709,7 +50704,7 @@ bsam gyis mi khyab pa las 'das pa|{grangs gnas shig}
 bsam gyis mi khyab pa'i dpal|{byang sems shig}
 bsam grub|{bsam pa bzhin grub pa/}
 bsam gros legs bsdur|{phan tshun bsam blor gang 'char gyi gnad don rnams gros bsdur legs par byed pa/}
-bsam ngan|{gzhan la gnod pa byed 'dod kyi ngan sems/ bsam ngan khog bcug bsam ngan snying bcang/ bsam ngan sbyor rtsub/ bsam ngan g.yo 'phrul/ bsam ngan gyis ma nyes kha g.yogs byas pa/ bsam ngan ma ni 'dren pa las/ sems bzang glu chung gtong ba dga'/}
+bsam ngan|{gzhan la gnod pa byed 'dod kyi ngan sems/ bsam ngan khog bcug bsam ngan snying bcang/ bsam ngan sbyor rtsub/ bsam ngan g.yo 'phrul/ bsam ngan gyis ma nyes kha g.yogs byas pa/ bsam ngan ma Ni 'dren pa las/ sems bzang glu chung gtong ba dga'/}
 bsam ngan phung sbyor|{bsam ngan gyis gzhan dag phung la sbyor rtsis byed pa/}
 bsam 'char|{sems kyi 'char sgo'am dran tshul/ bsam 'char go bsdur/ bsam 'char bton pa/ bsam 'char mi mthun pa/}
 bsam brjod|{sems nang gang dran dang/ kha nas gang bshad/ bsam brjod mi mthun pa/ bsam brjod gcig mthun/ bsam brjod las 'das pa/}
@@ -51243,7 +51238,7 @@ ho shod|{(sog) mong gol tsho bzhi'i ya gyal zhig o rod la ltos/}
 ho ho|{zil gyis gnon pa'i gad mo/}
 hong len|{(rgya) ser tshos te sngo sman gyi rigs shig ro kha/ zhu rjes bsil/ nus pas khrag ngan skem/ don snod kyi tsha ba dang/ 'khrugs tshad/ rgyu gzer bcas la phan/ ming gi rnam grangs la khra yi sder mo dang/ ga bur zil gnon/ bdud rtsi ka bhe ta/ spu tse shel/ bya rgan sug pa/ ma ma ka la/ 'tsho byed/ g.ya' rug pa/ shing skyes/ shing za ba bcas so/}
 hong len ser po|{myang rtsi spras kyi ming gi rnam grangs shig}
-hon|{nad thog mar phog skabs am cog thur du gug pa dang/ khog 'dar brgyab ste nyin shas nas lto chas ma 'ju bar khrag bshal te 'ci ba'i phyud nad cig}
+hon|{nad thog mar phog skabs am cog thur du gug pa dang/ khog 'dar brgyab ste nyin shas nas lto chas ma 'ju bar khrag bshal te 'ci ba'i phyugs nad cig}
 hon stor ba|{ga byed 'di byed med par gyur pa/ hon 'thor ba'ang zer/ rang la rkyen ngan byung bas hon stor ba/}
 hon 'thor ba|{zhed nas dran pa 'thor ba/ gtam rngam po che'am 'jigs skrag can glo bur thos pas re zhig hon 'thor song/}
 hon nad|{hon dang don gcig}
@@ -52019,8 +52014,8 @@ a phyug tshag pa|{(yul) 'bu cha ga pa/}
 a phrug|1) {bu phrug} 2) {rgyug khyi'am/dgos nges skabs bskul rgyu'i g.yog po/}
 a phrum|{(yul) phrum rus/}
 a phreng|{dbyangs yig a phreng ka phreng/}
-a ba|{(legs) a nas ba bar so sor bsdu ba'i yi ge ste legs sbyar skad kyi dbyangs dang sgra ldan spyi'i ming/ a ba a ba}
-a i au ri li e ee om oo ha ya wa ra la nya na na nga ma dzha dha dha gha bha dza da da ga ba a ba glang mgo|{gshin rje'i las mkhan/}
+a ba|{(legs) a nas ba bar so sor bsdu ba'i yi ge ste legs sbyar skad kyi dbyangs dang sgra ldan spyi'i ming/ a i au r-i l-i e ee o oo ha ya wa ra la nya Na na nga ma dzha Dha dha gha bha dza Da da ga ba}
+a ba glang mgo|{gshin rje'i las mkhan/}
 a ba dhU tI|{(legs)} 1) {len pa dang/ 'jigs pa/ ngo tsha ba/ spangs pa bcas la 'jug cing/ skabs 'dir kun spangs la go ba/} 2) {'chi ba sreg byed de/ lus kyi rlung khams kyi rten byed pa'i rtsa dbu ma'i ming gi rnam grangs shig}
 a ba bhram sha|{(legs) yul mi byings kyi skad las zur chag pa'am nyams pa'i skad de rgya gar gyi skad rigs chen po bzhi'i nang gses shig}
 a ba ri|{mthong chung gi snying re rje/ mi khyod 'dra'i rgod mdog a ba ri/}
@@ -52431,10 +52426,11 @@ ol cham|{rta drel ol cham gyi nad phog tshe glo rgyag mi thub par yun ring na na
 ol mdud|{mgrin pa'i mdun ngos kyi 'bur mdud/}
 ol ba|{ske'i mdun ngos/}
 ol 'dzum|{ma mchu'i 'og tu kha 'gul dus gnyer ma zhig 'byung bas de'i ming/}
-ayon|{au rgyan gyi 'bri tshul gzhan zhig}
-om|1) {sku rdo rje sogs mtshon don mang po/} 2) {sngags kyi mgo 'dren byed/}
-om ma ni padme hUom|{(legs) spyan ras gzigs kyi snying po gzungs sngags yi ge drug ma'o/}
-om mdzad ma|{sgrol ma'i ming gi rnam grangs/}
-om swasti|{(legs) bde legs su gyur cig ces dpe cha'i 'gor 'bri ba'i shis brjod kyi skad dod cig}
+a+yon|{au rgyan gyi 'bri tshul gzhan zhig}
+oM|1) {sku rdo rje sogs mtshon don mang po/} 2) {sngags kyi mgo 'dren byed/}
+oM ma Ni pad+me hUM|{(legs) spyan ras gzigs kyi snying po gzungs sngags yi ge drug ma'o/}
+oM mdzad ma|{sgrol ma'i ming gi rnam grangs/}
+oM swas+ti|{(legs) bde legs su gyur cig ces dpe cha'i 'gor 'bri ba'i shis brjod kyi skad dod cig}
 oo di yA na|{(legs) au rgyan yul/ au rgyan la ltos/}
 oodyA na|{oo di yA na'i 'bri tshul gzhan zhig}
+a+yoon|{au rgyan gyi 'bri tshul gzhan zhig}


### PR DESCRIPTION
This is the second helping of _tshig mdzod chen mo_ fixes.  This is mostly more of looking at the collation order anomalies, transliteration errors and chasing some leads found while looking at the first two.